### PR TITLE
Add regression guards for four Phase 3 hardening fixes

### DIFF
--- a/server/tests/redteam_broadcast_gc_resurrect.rs
+++ b/server/tests/redteam_broadcast_gc_resurrect.rs
@@ -1,0 +1,226 @@
+//! RED-TEAM regression guard (REAL handler): mark_all_read's broadcast_reads GC
+//! must bind the watermark it just installed, never a fresh clock read. The fix
+//! changed the GC bound from a re-evaluated clock to the returned `new_watermark`
+//! so it "can never delete an exception row above the watermark and resurrect an
+//! individually-read broadcast as unread" (commit 18ea409).
+//!
+//! The bug needs an exact interleaving: mark_all_read installs the watermark W
+//! (clock under the counters lock), and an above-W exception must be visible to
+//! the GC's DELETE. Within one transaction the GC runs microseconds after the
+//! UPDATE, and the counters lock serializes every production exception insert,
+//! so this state never arises by itself. We construct it deterministically:
+//!
+//!   1. Hold a table lock on `jobs` so the handler blocks at enqueue_timeline,
+//!      which runs AFTER the watermark UPDATE (W installed) but BEFORE the GC
+//!      DELETE.
+//!   2. While it is blocked, commit a broadcast read with broadcast_created_at
+//!      strictly after W. It commits before the (later) DELETE statement starts,
+//!      so READ COMMITTED puts it in the DELETE's snapshot.
+//!   3. Release the lock. The handler's DELETE now faces an above-watermark
+//!      exception.
+//!
+//! With the fix (bound = W) that exception is kept (created_at > W). With a fresh
+//! clock read (bound = clock at DELETE time, which is later than W) it is deleted
+//! and the broadcast resurrects as unread. The test asserts it survives.
+
+mod support;
+
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+const SUB: &str = "usr_gc_resurrect";
+
+async fn internal_id(app: &support::TestApp, external: &str) -> Uuid {
+    sqlx::query_scalar(
+        "SELECT id FROM subscribers WHERE environment_id = $1 AND subscriber_id = $2",
+    )
+    .bind(app.env.id)
+    .bind(external)
+    .fetch_one(&app.pool)
+    .await
+    .expect("subscriber internal id")
+}
+
+/// True once some other backend is blocked waiting on a lock while running the
+/// `enqueue_timeline` INSERT into `jobs` (the step between the watermark UPDATE
+/// and the broadcast_reads GC).
+async fn markall_blocked_at_enqueue_timeline(app: &support::TestApp) -> bool {
+    let n: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM pg_stat_activity
+          WHERE pid <> pg_backend_pid()
+            AND wait_event_type = 'Lock'
+            AND query ILIKE '%insert into jobs%'",
+    )
+    .fetch_one(&app.pool)
+    .await
+    .expect("pg_stat_activity probe");
+    n > 0
+}
+
+async fn broadcast_read_exists(app: &support::TestApp, sub: Uuid, broadcast: Uuid) -> bool {
+    let n: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM broadcast_reads
+          WHERE environment_id = $1 AND subscriber_id = $2 AND broadcast_id = $3",
+    )
+    .bind(app.env.id)
+    .bind(sub)
+    .bind(broadcast)
+    .fetch_one(&app.pool)
+    .await
+    .expect("broadcast_reads probe");
+    n > 0
+}
+
+#[tokio::test]
+async fn mark_all_read_gc_keeps_an_above_watermark_exception() {
+    let app = support::spawn().await;
+
+    // Create the subscriber (and its counters row, watermark = epoch).
+    let res = app
+        .client
+        .put(format!("{}/v1/subscribers/{SUB}", app.base))
+        .bearer_auth(&app.env.api_key)
+        .send()
+        .await
+        .expect("upsert subscriber");
+    assert_eq!(res.status(), 200);
+    let sub_id = internal_id(&app, SUB).await;
+
+    // A broadcast read individually BEFORE the move: this exception is below
+    // the watermark mark_all_read will install, so the GC must remove it. Its
+    // removal proves the DELETE actually ran (the test is not vacuous).
+    app.create_broadcast("below").await;
+    let below_id = app
+        .list_all_items(SUB, 10)
+        .await
+        .into_iter()
+        .find(|i| i["source"] == "broadcast")
+        .expect("broadcast in inbox")["id"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    let res = app
+        .post_inbox(SUB, &format!("/v1/inbox/broadcasts/{below_id}/read"))
+        .await;
+    assert_eq!(res.status(), 204);
+    let below_uuid = dronte::ids::parse_typeid(dronte::ids::BROADCAST, &below_id).unwrap();
+    assert!(broadcast_read_exists(&app, sub_id, below_uuid).await);
+
+    // Hold a SHARE lock on `jobs` so the handler's enqueue_timeline INSERT
+    // blocks AFTER it has installed the watermark but BEFORE the GC DELETE.
+    let mut hold = app.pool.begin().await.expect("begin lock-holder txn");
+    sqlx::query("LOCK TABLE jobs IN SHARE MODE")
+        .execute(&mut *hold)
+        .await
+        .expect("share-lock jobs");
+
+    // Fire the REAL mark_all_read; it installs the watermark, then blocks.
+    let base = app.base.clone();
+    let headers = app.subscriber_headers(SUB);
+    let client = app.client.clone();
+    let handle = tokio::spawn(async move {
+        client
+            .post(format!("{base}/v1/inbox/read-all"))
+            .headers(headers)
+            .send()
+            .await
+    });
+
+    let mut blocked = false;
+    for _ in 0..120 {
+        if markall_blocked_at_enqueue_timeline(&app).await {
+            blocked = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert!(
+        blocked,
+        "mark_all_read never blocked at enqueue_timeline (watermark already installed)"
+    );
+    // Margin so the new exception's broadcast_created_at is unambiguously after
+    // the watermark instant the handler captured.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    // An ABOVE-watermark broadcast read, committed while the handler is parked
+    // between its watermark UPDATE and its GC DELETE. broadcast_created_at =
+    // clock_timestamp() now, which is strictly after the watermark W. It commits
+    // before the DELETE statement starts, so it lands in the DELETE's snapshot.
+    let above_uuid = dronte::ids::new_uuid();
+    let above_created_at: DateTime<Utc> = sqlx::query_scalar(
+        "INSERT INTO broadcasts (environment_id, id, category, created_at)
+         VALUES ($1, $2, 'above', clock_timestamp())
+         RETURNING created_at",
+    )
+    .bind(app.env.id)
+    .bind(above_uuid)
+    .fetch_one(&app.pool)
+    .await
+    .expect("insert above-watermark broadcast");
+    sqlx::query(
+        "INSERT INTO broadcast_reads
+             (environment_id, subscriber_id, broadcast_id, broadcast_created_at, read_at)
+         VALUES ($1, $2, $3, $4, now())",
+    )
+    .bind(app.env.id)
+    .bind(sub_id)
+    .bind(above_uuid)
+    .bind(above_created_at)
+    .execute(&app.pool)
+    .await
+    .expect("insert above-watermark exception");
+
+    // Release the lock; the handler runs its GC DELETE and commits.
+    hold.commit().await.expect("release jobs lock");
+    let res = handle
+        .await
+        .expect("join mark-all")
+        .expect("mark-all response");
+    assert_eq!(res.status(), 200, "mark_all_read completed");
+
+    // The watermark must sit strictly below the above-watermark exception.
+    let watermark: DateTime<Utc> = sqlx::query_scalar(
+        "SELECT read_watermark FROM subscriber_counters
+          WHERE environment_id = $1 AND subscriber_id = $2",
+    )
+    .bind(app.env.id)
+    .bind(sub_id)
+    .fetch_one(&app.pool)
+    .await
+    .expect("read watermark");
+    assert!(
+        watermark < above_created_at,
+        "test precondition: watermark ({watermark}) must precede the above-watermark \
+         exception ({above_created_at})"
+    );
+
+    // The GC ran: the below-watermark exception is gone (redundant).
+    assert!(
+        !broadcast_read_exists(&app, sub_id, below_uuid).await,
+        "below-watermark exception should be GC'd"
+    );
+    // The fix: the ABOVE-watermark exception survives. A fresh-clock GC bound
+    // would delete it and resurrect the broadcast as unread.
+    assert!(
+        broadcast_read_exists(&app, sub_id, above_uuid).await,
+        "mark_all_read GC deleted an exception ABOVE the watermark, resurrecting an \
+         individually-read broadcast as unread: the GC must bind the installed watermark, \
+         not a fresh clock read"
+    );
+
+    // User-facing symptom: the above-watermark broadcast stays read in the list.
+    let above_typeid = dronte::ids::typeid(dronte::ids::BROADCAST, above_uuid);
+    let item_read = app
+        .list_all_items(SUB, 50)
+        .await
+        .into_iter()
+        .find(|i| i["id"] == above_typeid.as_str())
+        .map(|i| i["read"] == true);
+    assert_eq!(
+        item_read,
+        Some(true),
+        "the above-watermark broadcast must still be read in the inbox list"
+    );
+}

--- a/server/tests/redteam_broadcast_gc_resurrect.rs
+++ b/server/tests/redteam_broadcast_gc_resurrect.rs
@@ -43,19 +43,29 @@ async fn internal_id(app: &support::TestApp, external: &str) -> Uuid {
     .expect("subscriber internal id")
 }
 
-/// True once some other backend is blocked waiting on a lock while running the
-/// `enqueue_timeline` INSERT into `jobs` (the step between the watermark UPDATE
-/// and the broadcast_reads GC).
-async fn markall_blocked_at_enqueue_timeline(app: &support::TestApp) -> bool {
+/// True once some other backend is blocked waiting for a lock on the `jobs`
+/// relation. Probing pg_locks by relation (not pg_stat_activity by query text)
+/// keeps this correct if the enqueue SQL is ever rephrased.
+///
+/// REQUIRED INVARIANT this test depends on: the FIRST `jobs` write in
+/// mark_all_read (enqueue_timeline) runs AFTER the watermark UPDATE and BEFORE
+/// the broadcast_reads GC DELETE. The SHARE lock parks the handler at that
+/// write, which is the window we inject the above-watermark exception into. If
+/// the GC DELETE is ever moved ahead of enqueue_timeline, the handler would
+/// park at a `jobs` write that runs AFTER the DELETE: the injected exception
+/// would land too late for the DELETE's READ COMMITTED snapshot and survive
+/// regardless of the bound, turning this guard into a vacuous pass. Keep the GC
+/// DELETE after enqueue_timeline, or rewrite the pause point here.
+async fn markall_blocked_on_jobs_lock(app: &support::TestApp) -> bool {
     let n: i64 = sqlx::query_scalar(
-        "SELECT count(*) FROM pg_stat_activity
-          WHERE pid <> pg_backend_pid()
-            AND wait_event_type = 'Lock'
-            AND query ILIKE '%insert into jobs%'",
+        "SELECT count(*) FROM pg_locks
+          WHERE relation = 'jobs'::regclass
+            AND NOT granted
+            AND pid <> pg_backend_pid()",
     )
     .fetch_one(&app.pool)
     .await
-    .expect("pg_stat_activity probe");
+    .expect("pg_locks probe");
     n > 0
 }
 
@@ -116,7 +126,8 @@ async fn mark_all_read_gc_keeps_an_above_watermark_exception() {
         .await
         .expect("share-lock jobs");
 
-    // Fire the REAL mark_all_read; it installs the watermark, then blocks.
+    // Fire the REAL mark_all_read. It installs the watermark, then blocks at
+    // the enqueue_timeline write (see the invariant on the probe below).
     let base = app.base.clone();
     let headers = app.subscriber_headers(SUB);
     let client = app.client.clone();
@@ -130,7 +141,7 @@ async fn mark_all_read_gc_keeps_an_above_watermark_exception() {
 
     let mut blocked = false;
     for _ in 0..120 {
-        if markall_blocked_at_enqueue_timeline(&app).await {
+        if markall_blocked_on_jobs_lock(&app).await {
             blocked = true;
             break;
         }
@@ -172,7 +183,7 @@ async fn mark_all_read_gc_keeps_an_above_watermark_exception() {
     .await
     .expect("insert above-watermark exception");
 
-    // Release the lock; the handler runs its GC DELETE and commits.
+    // Release the lock. The handler runs its GC DELETE and commits.
     hold.commit().await.expect("release jobs lock");
     let res = handle
         .await

--- a/server/tests/redteam_dlq_env_scope.rs
+++ b/server/tests/redteam_dlq_env_scope.rs
@@ -1,0 +1,92 @@
+//! RED-TEAM regression guard: dead-letter replay is scoped to one environment.
+//! environment_id is part of every key (CLAUDE.md); the dead_letters primary
+//! key is (environment_id, id). The pre-fix replay predicate matched bare job
+//! ids ("$1 IS NULL OR id = $1"), so a replay reached across environments. The
+//! fix adds an environment scope to both replay_all and replay-by-id.
+//!
+//! Two environments each hold a parked job. Replaying ONLY environment A must
+//! leave environment B's dead_letters untouched. The unscoped pre-fix predicate
+//! replays B as well and these tests go red.
+
+mod support;
+
+use uuid::Uuid;
+
+async fn park_dead_letter_with_id(pool: &sqlx::PgPool, env: Uuid, id: Uuid) {
+    sqlx::query(
+        "INSERT INTO dead_letters
+             (environment_id, id, job_type, payload, attempts, max_attempts,
+              last_error, progress_cursor, created_at)
+         VALUES ($1, $2, 'counter_rebuild', '{\"subscriber_id\": \"x\"}'::jsonb,
+                 10, 10, 'simulated outage', NULL, now())",
+    )
+    .bind(env)
+    .bind(id)
+    .execute(pool)
+    .await
+    .expect("park dead letter");
+}
+
+async fn dead_letters_in(pool: &sqlx::PgPool, env: Uuid) -> i64 {
+    sqlx::query_scalar("SELECT count(*) FROM dead_letters WHERE environment_id = $1")
+        .bind(env)
+        .fetch_one(pool)
+        .await
+        .expect("count dead letters")
+}
+
+#[tokio::test]
+async fn replay_all_replays_only_the_scoped_environment() {
+    let app = support::spawn().await;
+    let env_b = app.create_environment(true).await;
+
+    park_dead_letter_with_id(&app.pool, app.env.id, dronte::ids::new_uuid()).await;
+    park_dead_letter_with_id(&app.pool, env_b.id, dronte::ids::new_uuid()).await;
+    assert_eq!(dead_letters_in(&app.pool, app.env.id).await, 1);
+    assert_eq!(dead_letters_in(&app.pool, env_b.id).await, 1);
+
+    let moved = dronte::dlq::replay_all(&app.pool, Some(app.env.id))
+        .await
+        .expect("replay env A");
+    assert_eq!(moved, 1, "only env A's parked job is replayed");
+
+    assert_eq!(
+        dead_letters_in(&app.pool, app.env.id).await,
+        0,
+        "env A's dead letter moved back to jobs"
+    );
+    assert_eq!(
+        dead_letters_in(&app.pool, env_b.id).await,
+        1,
+        "env B's dead letter must survive an env-A-scoped replay-all"
+    );
+}
+
+#[tokio::test]
+async fn replay_by_id_replays_only_the_scoped_environment() {
+    let app = support::spawn().await;
+    let env_b = app.create_environment(true).await;
+
+    // The SAME job id parked in BOTH environments. The dead_letters PK is
+    // (environment_id, id), so this is legal — and an id-only replay predicate
+    // would match (and replay) both copies.
+    let shared = dronte::ids::new_uuid();
+    park_dead_letter_with_id(&app.pool, app.env.id, shared).await;
+    park_dead_letter_with_id(&app.pool, env_b.id, shared).await;
+
+    let replayed = dronte::dlq::replay(&app.pool, shared, Some(app.env.id))
+        .await
+        .expect("replay env A's copy");
+    assert!(replayed, "env A's copy was replayed");
+
+    assert_eq!(
+        dead_letters_in(&app.pool, app.env.id).await,
+        0,
+        "env A's copy moved back to jobs"
+    );
+    assert_eq!(
+        dead_letters_in(&app.pool, env_b.id).await,
+        1,
+        "env B's same-id dead letter must survive an env-A-scoped replay"
+    );
+}

--- a/server/tests/redteam_dlq_env_scope.rs
+++ b/server/tests/redteam_dlq_env_scope.rs
@@ -1,5 +1,5 @@
 //! RED-TEAM regression guard: dead-letter replay is scoped to one environment.
-//! environment_id is part of every key (CLAUDE.md); the dead_letters primary
+//! environment_id is part of every key (CLAUDE.md). The dead_letters primary
 //! key is (environment_id, id). The pre-fix replay predicate matched bare job
 //! ids ("$1 IS NULL OR id = $1"), so a replay reached across environments. The
 //! fix adds an environment scope to both replay_all and replay-by-id.
@@ -68,7 +68,7 @@ async fn replay_by_id_replays_only_the_scoped_environment() {
     let env_b = app.create_environment(true).await;
 
     // The SAME job id parked in BOTH environments. The dead_letters PK is
-    // (environment_id, id), so this is legal — and an id-only replay predicate
+    // (environment_id, id), so this is legal. An id-only replay predicate
     // would match (and replay) both copies.
     let shared = dronte::ids::new_uuid();
     park_dead_letter_with_id(&app.pool, app.env.id, shared).await;

--- a/server/tests/redteam_failjob_backoff_atomicity.rs
+++ b/server/tests/redteam_failjob_backoff_atomicity.rs
@@ -1,0 +1,126 @@
+//! RED-TEAM regression guard (CONCURRENT): a job that just failed must not be
+//! re-claimable until its backoff is in place. fail_job bumps `attempts` and
+//! pushes `run_at` into the future in ONE atomic UPDATE, holding the row lock
+//! until the transaction commits. The pre-fix two-statement shape committed the
+//! attempts bump in its own auto-committed statement and pushed run_at in a
+//! second, leaving a window where the still-due row (run_at <= now() with
+//! attempts already incremented) could be claimed by another worker before its
+//! backoff landed.
+//!
+//! Why a sequential test is not enough: the existing
+//! failing_jobs_back_off_with_jitter_then_park test passes against BOTH shapes,
+//! because once fail_job RETURNS the row looks identical either way (attempts
+//! bumped, run_at future). The defect lives only in the committed intermediate
+//! state, visible only to a CONCURRENT claimer.
+//!
+//! This test runs that claimer: a non-consuming observer issues the production
+//! claim (FOR UPDATE SKIP LOCKED ... run_at <= now()) on a tight loop and rolls
+//! back. The backoff is configured large enough that a failed job's run_at can
+//! never become due again during the test, so a claimable row carrying
+//! attempts >= 1 can ONLY be the two-statement window. The atomic fix makes
+//! that state impossible to commit, so the observer must never see it. Green is
+//! deterministic (the forbidden state never exists under the fix); the
+//! repeated fail cycles give the observer ample chances to catch the window if
+//! the two-statement shape returns.
+
+mod support;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+use std::time::Duration;
+
+use dronte::worker;
+
+const ROUNDS: usize = 200;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_failed_job_is_never_reclaimable_before_its_backoff_lands() {
+    // Backoff large enough never to elapse during the test: every failed job's
+    // run_at lands ~15-30s out, so the ONLY way a claim can see a due row with
+    // attempts >= 1 is the two-statement window.
+    let app = support::spawn_configured(false, |cfg| {
+        cfg.retry_backoff_base = Duration::from_secs(30);
+        cfg.retry_backoff_cap = Duration::from_secs(60);
+    })
+    .await;
+    let env = app.env.id;
+
+    // One always-failing job: 'bogus' is an unknown job type, so process_one
+    // errors and routes through fail_job. max_attempts is high so it never
+    // parks; `attempts` only records how many times it was failed.
+    let job_id = dronte::ids::new_uuid();
+    sqlx::query(
+        "INSERT INTO jobs (environment_id, id, job_type, payload, run_at,
+                           attempts, max_attempts)
+         VALUES ($1, $2, 'bogus', '{}'::jsonb, now(), 0, 1000)",
+    )
+    .bind(env)
+    .bind(job_id)
+    .execute(&app.pool)
+    .await
+    .unwrap();
+
+    let stop = Arc::new(AtomicBool::new(false));
+    // The highest `attempts` the observer ever found on a CLAIMABLE row. It
+    // stays 0 iff no failed-but-still-due row was ever exposed.
+    let max_due_attempts = Arc::new(AtomicI32::new(0));
+
+    let observer = tokio::spawn({
+        let pool = app.pool.clone();
+        let stop = stop.clone();
+        let max_due_attempts = max_due_attempts.clone();
+        async move {
+            while !stop.load(Ordering::Relaxed) {
+                let Ok(mut tx) = pool.begin().await else {
+                    continue;
+                };
+                // The PRODUCTION claim predicate, but non-consuming: we read
+                // `attempts` and roll back so we never advance the job.
+                let claimed: Option<(i32,)> = sqlx::query_as(
+                    "SELECT attempts FROM jobs
+                      WHERE environment_id = $1 AND run_at <= now()
+                      ORDER BY run_at
+                      LIMIT 1
+                      FOR UPDATE SKIP LOCKED",
+                )
+                .bind(env)
+                .fetch_optional(&mut *tx)
+                .await
+                .unwrap_or(None);
+                if let Some((attempts,)) = claimed {
+                    max_due_attempts.fetch_max(attempts, Ordering::Relaxed);
+                }
+                let _ = tx.rollback().await;
+            }
+        }
+    });
+
+    // Drive the job through many fail cycles. Each round resets it to a fresh
+    // due, un-failed state, then fails it once via the real worker path.
+    for _ in 0..ROUNDS {
+        sqlx::query(
+            "UPDATE jobs SET attempts = 0, run_at = now(), last_error = NULL
+              WHERE environment_id = $1 AND id = $2",
+        )
+        .bind(env)
+        .bind(job_id)
+        .execute(&app.pool)
+        .await
+        .unwrap();
+        // Fails the job. Under the fix, attempts++ and run_at += backoff commit
+        // together; under the two-statement shape the bump commits first and
+        // leaves (attempts = 1, run_at = now()) re-claimable.
+        let _ = worker::process_one(&app.pool, app.pubsub.as_ref(), &app.cfg, env).await;
+    }
+
+    stop.store(true, Ordering::Relaxed);
+    observer.await.unwrap();
+
+    let seen = max_due_attempts.load(Ordering::Relaxed);
+    assert_eq!(
+        seen, 0,
+        "a concurrent claim observed a failed job (attempts = {seen}) still due \
+         (run_at <= now()) before its backoff was installed: fail_job must bump \
+         attempts and back off run_at in ONE atomic statement, never two"
+    );
+}

--- a/server/tests/redteam_failjob_backoff_atomicity.rs
+++ b/server/tests/redteam_failjob_backoff_atomicity.rs
@@ -19,9 +19,9 @@
 //! never become due again during the test, so a claimable row carrying
 //! attempts >= 1 can ONLY be the two-statement window. The atomic fix makes
 //! that state impossible to commit, so the observer must never see it. Green is
-//! deterministic (the forbidden state never exists under the fix); the
-//! repeated fail cycles give the observer ample chances to catch the window if
-//! the two-statement shape returns.
+//! deterministic (the forbidden state never exists under the fix). The repeated
+//! fail cycles give the observer ample chances to catch the window if the
+//! two-statement shape returns.
 
 mod support;
 
@@ -47,7 +47,7 @@ async fn a_failed_job_is_never_reclaimable_before_its_backoff_lands() {
 
     // One always-failing job: 'bogus' is an unknown job type, so process_one
     // errors and routes through fail_job. max_attempts is high so it never
-    // parks; `attempts` only records how many times it was failed.
+    // parks. `attempts` only records how many times it was failed.
     let job_id = dronte::ids::new_uuid();
     sqlx::query(
         "INSERT INTO jobs (environment_id, id, job_type, payload, run_at,
@@ -108,7 +108,7 @@ async fn a_failed_job_is_never_reclaimable_before_its_backoff_lands() {
         .await
         .unwrap();
         // Fails the job. Under the fix, attempts++ and run_at += backoff commit
-        // together; under the two-statement shape the bump commits first and
+        // together. Under the two-statement shape the bump commits first and
         // leaves (attempts = 1, run_at = now()) re-claimable.
         let _ = worker::process_one(&app.pool, app.pubsub.as_ref(), &app.cfg, env).await;
     }

--- a/server/tests/redteam_timeline_ratelimit.rs
+++ b/server/tests/redteam_timeline_ratelimit.rs
@@ -1,0 +1,58 @@
+//! RED-TEAM regression guard (REAL handler): GET
+//! /v1/notifications/{id}/timeline is a management-plane endpoint and must
+//! enforce the per-API-key token bucket like every other management call.
+//! get_notification_timeline was the only management endpoint that lacked the
+//! enforce_api_key_limit() call. Reverting that one line leaves the timeline
+//! read unmetered: the bucket never drains through it, the 429 below never
+//! arrives, and this test goes red.
+//!
+//! Contract: the 429 carries Retry-After and error.code = "rate_limited"
+//! (specs/openapi.yaml RateLimited).
+
+mod support;
+
+#[tokio::test]
+async fn timeline_reads_draw_down_the_api_key_bucket_and_429_past_the_burst() {
+    // burst = 2: the create below spends one token and the first timeline read
+    // spends the second, so the next timeline read finds the bucket empty. The
+    // near-zero refill rate means no wall-clock during the test can mint a
+    // replacement token.
+    let app = support::spawn_configured(false, |cfg| {
+        cfg.api_key_rate_per_sec = 0.01;
+        cfg.api_key_rate_burst = 2.0;
+    })
+    .await;
+
+    let body = app.create_notification("usr_tl", "x").await;
+    let id = body["notifications"][0]["id"]
+        .as_str()
+        .expect("notification id")
+        .to_owned();
+
+    // First read is served within the burst: proof the endpoint works and is
+    // metered by the same bucket the create just drew from.
+    let res = app.timeline_api(&id).await;
+    assert_eq!(res.status(), 200, "first timeline read is within the burst");
+
+    // Bucket now empty (create + one read = the burst of 2). The next read on
+    // the SAME api key must be refused.
+    let res = app.timeline_api(&id).await;
+    assert_eq!(
+        res.status(),
+        429,
+        "a timeline read past the api-key burst must be rate limited, \
+         not served unmetered"
+    );
+
+    let retry_after: u64 = res
+        .headers()
+        .get("retry-after")
+        .expect("429 carries Retry-After")
+        .to_str()
+        .unwrap()
+        .parse()
+        .expect("integral seconds");
+    assert!(retry_after >= 1);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["error"]["code"], "rate_limited");
+}


### PR DESCRIPTION
Each of these fixes shipped without a test that fails if the fix is reverted. One targeted guard per fix, each confirmed to go red against the pre-fix code shape and green now. All run against real Postgres via testcontainers (no storage mocks).

timeline rate limit: get_notification_timeline was the only management endpoint without enforce_api_key_limit. The guard drains the api-key bucket through a create plus one timeline read, then asserts the next timeline read is a 429 with Retry-After and error.code = rate_limited. Dropping the enforce call serves the read unmetered and the 429 never arrives.

fail_job backoff atomicity: the fix bumps attempts and pushes run_at in one atomic UPDATE, holding the row lock until commit; the two-statement shape committed the bump first, exposing a still-due row with attempts already incremented. The existing sequential test cannot see this (after fail_job returns both shapes look identical), so this guard is concurrent: a non-consuming observer runs the production claim (FOR UPDATE SKIP LOCKED ... run_at <= now()) on a tight loop while a driver fails the job repeatedly. With the backoff large enough never to elapse, a claimable row with attempts >= 1 can only be the two-statement window. Green is deterministic (the fix never commits that state); the two-statement shape exposes attempts = 1 on a due row.

env-scoped DLQ replay: the pre-fix replay predicate matched bare job ids across environments. Two environments each park a dead letter (and, in a second case, the same job id in both, legal under the (environment_id, id) primary key); replaying only environment A must leave B untouched. The unscoped predicate replays B as well.

broadcast_reads GC resurrect: mark_all_read's GC must bind the watermark it just installed, not a fresh clock read, or it deletes an exception above the watermark and resurrects an individually-read broadcast. The state is unreachable on its own (the counters lock serializes inserts, the watermark leads existing rows), so the guard builds it: a SHARE lock on jobs blocks the handler at enqueue_timeline, after the watermark UPDATE but before the GC DELETE; an above-watermark broadcast read is committed into that gap so it lands in the DELETE's READ COMMITTED snapshot; releasing the lock lets the GC run. Binding the watermark keeps the exception, a fresh clock read deletes it.