### PR TITLE
Phase 4: embedded admin dashboard and Dronte brand palette

### DIFF
--- a/.changeset/inbox-brand-palette.md
+++ b/.changeset/inbox-brand-palette.md
@@ -1,0 +1,10 @@
+---
+'@dronte/react': minor
+---
+
+Default `<Inbox />` theme now ships the Dronte brand palette: primary actions,
+links, the unread badge, the unread dot, and focus rings use the accent
+`#1264FF`; hover/section accents use the deep accent `#004F32`. Adds a
+`colorPrimaryHover` appearance variable and accent focus-visible outlines.
+All values remain overridable through the existing `--dronte-*` custom
+properties — no new styling dependency.

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,12 @@
-# Whitelist: the image build needs only the server crate.
-*
-!server/Cargo.toml
-!server/Cargo.lock
-!server/src/
-!server/.sqlx/
-!server/migrations/
+# The image build needs the server crate (Rust stages) and the admin SPA
+# source (Node stage). Exclude generated/heavy trees and secrets.
+.git
+**/node_modules
+**/dist
+/server/target
+**/.next
+docs/.source
+docs/next-env.d.ts
+**/.env
+**/.env.*
+.DS_Store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,19 @@ jobs:
           for path, method, code in sanctioned_responses:
               responses = doc['paths'][path][method]['responses']
               assert responses.pop(code, None) is not None, f'{method} {path} {code} missing'
+          # specs/phase-4-admin.md: the embedded admin dashboard's API is an
+          # additive post-freeze plane (own `admin` tag, /admin/api paths,
+          # Admin* schemas, the AdminToken Basic scheme). It is kept in the
+          # served/generated spec and stripped from the strict convergence
+          # diff, exactly like the phase-3 timeline above.
+          admin_paths = [p for p in list(doc['paths']) if p.startswith('/admin')]
+          assert admin_paths, 'admin plane missing from generated spec'
+          for path in admin_paths:
+              doc['paths'].pop(path)
+          doc['tags'] = [t for t in doc.get('tags', []) if t.get('name') != 'admin']
+          for schema in [s for s in list(doc['components']['schemas']) if s.startswith('Admin')]:
+              doc['components']['schemas'].pop(schema)
+          doc.get('components', {}).get('securitySchemes', {}).pop('AdminToken', None)
           yaml.safe_dump(doc, open('/tmp/openapi.gen.stripped.yaml', 'w'), sort_keys=False)
           EOF
       - uses: actions/setup-go@v5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,16 @@ plan.
 - Long literal text (OpenAPI descriptions and similar) uses raw strings
   (`r#"..."#`) with real newlines, never `\n` escapes.
 
+## Commit & PR style
+
+- Commit subjects and PR titles use Conventional Commits
+  (`type(scope): summary`, e.g. `feat(admin): embed the dashboard SPA`).
+  Common types: `feat`, `fix`, `refactor`, `docs`, `test`, `build`, `ci`,
+  `chore`.
+- Keep it concise. Commit summaries are short (target ≤ 50 chars); commit
+  bodies and PR descriptions state what changed and why in as few words as
+  possible. No verbose prose, no restating the diff.
+
 ## Stack decisions (settled — sessions do not relitigate)
 
 **Server:** Rust stable (2024 edition, pinned via rust-toolchain.toml), axum 0.8 on tokio, sqlx (compile-time-checked raw SQL; built-in migrator, run on boot under advisory lock), Postgres ≥15, `fred` Redis client (resilient pub/sub), Redis Lua token bucket for cross-replica rate limiting, RustCrypto hmac+sha2, thiserror/anyhow, tracing + OTLP, metrics + Prometheus exporter. Single crate until compile times force a split.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,27 @@
 # syntax=docker/dockerfile:1
-# cargo-chef multi-stage build: dependency layers are cached independently of
-# src/ changes. Builder rust version matches rust-toolchain.toml.
+# Multi-stage build. A Node stage builds the embedded admin SPA
+# (server/admin -> server/admin/dist); the cargo-chef Rust stages then embed
+# that bundle into the single binary via rust-embed. The image stays one file:
+# `docker run dronte` ships the dashboard with no extra artifact.
+
+# --- Admin SPA: server/admin -> server/admin/dist ---
+FROM node:24-slim AS admin
+RUN corepack enable && corepack prepare pnpm@11.5.2 --activate
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+WORKDIR /app
+# The whole workspace is needed so pnpm can resolve the committed lockfile;
+# the focused install pulls only the admin SPA's subtree.
+COPY . .
+RUN pnpm install --frozen-lockfile --filter dronte-admin...
+RUN pnpm --filter dronte-admin build
+
+# --- Rust build (cargo-chef: dependency layers cached independently of src) ---
 FROM lukemathwalker/cargo-chef:latest-rust-1.96.0 AS chef
 WORKDIR /app
 
 FROM chef AS planner
 COPY server/Cargo.toml server/Cargo.lock ./
+COPY server/build.rs ./build.rs
 COPY server/src ./src
 RUN cargo chef prepare --recipe-path recipe.json
 
@@ -13,11 +29,15 @@ FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 COPY server/Cargo.toml server/Cargo.lock ./
+COPY server/build.rs ./build.rs
 COPY server/src ./src
 # sqlx compile-time checks read the committed offline cache (no database in
 # the image build); migrations/ is embedded by sqlx::migrate! at compile time.
 COPY server/.sqlx ./.sqlx
 COPY server/migrations ./migrations
+# The built admin SPA, embedded by rust-embed (api::admin). build.rs leaves a
+# populated admin/dist untouched (it only writes a placeholder when missing).
+COPY --from=admin /app/server/admin/dist ./admin/dist
 ENV SQLX_OFFLINE=true
 RUN cargo build --release --bin dronte
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ docs/              Fumadocs site + project plan            (MIT)
 specs/             frozen v1 contracts (read-only)
 ```
 
+## Admin dashboard
+
+The server embeds an operator dashboard at `/admin` (status/timeline browser,
+broadcast composer, subscriber lookup, DLQ replay, environment + API key
+management, HMAC rotation). It ships inside the binary — `docker run dronte`
+serves it with no extra artifact.
+
+Set `DRONTE_ADMIN_TOKEN` to enable it. The dashboard and its API gate on that
+single static credential via HTTP Basic (any username, the token as the
+password); the browser prompts on first visit. Unset, the admin plane is
+disabled and every `/admin` route returns 401. The credential is read only
+from the env var and never logged.
+
+```bash
+DRONTE_ADMIN_TOKEN=$(openssl rand -hex 32) dronte serve
+```
+
 ## License FAQ
 
 **What is licensed how?** The server (`server/`) is

--- a/biome.json
+++ b/biome.json
@@ -13,7 +13,8 @@
       "!packages/client/src/generated",
       "!docs/openapi",
       "!docs/app/global.css",
-      "!conformance/.generated"
+      "!conformance/.generated",
+      "!server/admin"
     ]
   },
   "formatter": {

--- a/docs/openapi/dronte.yaml
+++ b/docs/openapi/dronte.yaml
@@ -41,6 +41,517 @@ info:
 servers:
 - url: https://dronte.example.com
 paths:
+  /admin/api/dlq:
+    get:
+      tags:
+      - admin
+      summary: List parked jobs across environments
+      operationId: adminListDeadLetters
+      responses:
+        '200':
+          description: Parked jobs.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AdminDeadLetter'
+        '401':
+          description: Admin authentication required.
+      security:
+      - AdminToken: []
+  /admin/api/dlq/replay-all:
+    post:
+      tags:
+      - admin
+      summary: Replay every parked job
+      operationId: adminReplayAllDeadLetters
+      responses:
+        '200':
+          description: Replayed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminReplayResult'
+        '401':
+          description: Admin authentication required.
+      security:
+      - AdminToken: []
+  /admin/api/dlq/{job_id}/replay:
+    post:
+      tags:
+      - admin
+      summary: Replay one parked job (re-enters the normal claim path)
+      description: Moves the parked row back into `jobs` with a fresh attempt budget; the normal worker loop (SKIP LOCKED, per-environment fairness, delete-on-completion) runs it. Never executed inline.
+      operationId: adminReplayDeadLetter
+      parameters:
+      - name: job_id
+        in: path
+        description: Job TypeID (job_…).
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Replayed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminReplayResult'
+        '401':
+          description: Admin authentication required.
+        '404':
+          description: No such parked job.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+      - AdminToken: []
+  /admin/api/environments:
+    get:
+      tags:
+      - admin
+      summary: List environments
+      operationId: adminListEnvironments
+      responses:
+        '200':
+          description: Environments.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AdminEnvironment'
+        '401':
+          description: Admin authentication required.
+      security:
+      - AdminToken: []
+    post:
+      tags:
+      - admin
+      summary: Create an environment
+      operationId: adminCreateEnvironment
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminCreateEnvironmentRequest'
+        required: true
+      responses:
+        '201':
+          description: Created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminEnvironmentDetail'
+        '400':
+          description: Validation error or slug already exists.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Admin authentication required.
+      security:
+      - AdminToken: []
+  /admin/api/environments/{env_id}:
+    get:
+      tags:
+      - admin
+      summary: Environment detail (includes the subscriber HMAC secret)
+      operationId: adminGetEnvironment
+      parameters:
+      - name: env_id
+        in: path
+        description: Environment TypeID (env_…).
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Environment.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminEnvironmentDetail'
+        '401':
+          description: Admin authentication required.
+        '404':
+          description: No such environment.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+      - AdminToken: []
+  /admin/api/environments/{env_id}/api-keys:
+    get:
+      tags:
+      - admin
+      summary: List API keys for an environment (prefix only, never the key)
+      operationId: adminListApiKeys
+      parameters:
+      - name: env_id
+        in: path
+        description: Environment TypeID (env_…).
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Keys.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AdminApiKey'
+        '401':
+          description: Admin authentication required.
+        '404':
+          description: No such environment.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+      - AdminToken: []
+    post:
+      tags:
+      - admin
+      summary: Create an API key (plaintext returned once)
+      operationId: adminCreateApiKey
+      parameters:
+      - name: env_id
+        in: path
+        description: Environment TypeID (env_…).
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminCreateApiKeyRequest'
+        required: true
+      responses:
+        '201':
+          description: Created; `key` is shown once.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminApiKeyCreated'
+        '400':
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Admin authentication required.
+        '404':
+          description: No such environment.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+      - AdminToken: []
+  /admin/api/environments/{env_id}/api-keys/{key_id}/revoke:
+    post:
+      tags:
+      - admin
+      summary: Revoke an API key (soft; row kept for audit)
+      operationId: adminRevokeApiKey
+      parameters:
+      - name: env_id
+        in: path
+        description: Environment TypeID (env_…).
+        required: true
+        schema:
+          type: string
+      - name: key_id
+        in: path
+        description: API key TypeID (key_…).
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: Revoked (now or already).
+        '401':
+          description: Admin authentication required.
+        '404':
+          description: No such API key.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+      - AdminToken: []
+  /admin/api/environments/{env_id}/broadcasts:
+    post:
+      tags:
+      - admin
+      summary: Compose a broadcast (one row, fan-out on read)
+      description: 'Composing is creating: the same idempotent management-plane write-path. One row per announcement, never materialized per subscriber.'
+      operationId: adminCreateBroadcast
+      parameters:
+      - name: env_id
+        in: path
+        description: Environment TypeID (env_…).
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminCreateBroadcastRequest'
+        required: true
+      responses:
+        '200':
+          description: Idempotent replay.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Broadcast'
+        '201':
+          description: Created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Broadcast'
+        '400':
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Admin authentication required.
+        '404':
+          description: No such environment.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+      - AdminToken: []
+  /admin/api/environments/{env_id}/hmac/rotate:
+    post:
+      tags:
+      - admin
+      summary: Begin a subscriber-HMAC rotation (current → previous)
+      description: |
+        Generates a new current secret and moves the existing one into the
+        previous slot. During the overlap BOTH secrets verify live `<Inbox />`
+        sessions (auth checks current then previous), so rotation is
+        zero-downtime. Complete the rotation to clear the previous slot once
+        every customer backend has switched.
+      operationId: adminRotateHmac
+      parameters:
+      - name: env_id
+        in: path
+        description: Environment TypeID (env_…).
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Rotated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminHmacRotation'
+        '401':
+          description: Admin authentication required.
+        '404':
+          description: No such environment.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+      - AdminToken: []
+  /admin/api/environments/{env_id}/hmac/rotate/complete:
+    post:
+      tags:
+      - admin
+      summary: Complete a rotation (clear the previous secret slot)
+      operationId: adminCompleteHmacRotation
+      parameters:
+      - name: env_id
+        in: path
+        description: Environment TypeID (env_…).
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: Previous secret cleared.
+        '401':
+          description: Admin authentication required.
+        '404':
+          description: No such environment.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+      - AdminToken: []
+  /admin/api/environments/{env_id}/notifications:
+    get:
+      tags:
+      - admin
+      summary: Browse direct notifications (filter by subscriber, category, time)
+      operationId: adminListNotifications
+      parameters:
+      - name: env_id
+        in: path
+        description: Environment TypeID (env_…).
+        required: true
+        schema:
+          type: string
+      - name: subscriber_id
+        in: path
+        description: Customer-provided subscriber id.
+        required: true
+        schema:
+          type: string
+          nullable: true
+      - name: category
+        in: path
+        required: true
+        schema:
+          type: string
+          nullable: true
+      - name: after
+        in: path
+        description: Lower bound on `visible_at` (inclusive), RFC 3339.
+        required: true
+        schema:
+          type: string
+          format: date-time
+          nullable: true
+      - name: before
+        in: path
+        description: Upper bound on `visible_at` (exclusive), RFC 3339.
+        required: true
+        schema:
+          type: string
+          format: date-time
+          nullable: true
+      - name: limit
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+          nullable: true
+      - name: cursor
+        in: path
+        description: Opaque keyset cursor from the previous page's `next_cursor`.
+        required: true
+        schema:
+          type: string
+          nullable: true
+      responses:
+        '200':
+          description: A page of notifications.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminNotificationPage'
+        '400':
+          description: Malformed cursor or out-of-range limit.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Admin authentication required.
+        '404':
+          description: No such environment.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+      - AdminToken: []
+  /admin/api/environments/{env_id}/notifications/{notif_id}/timeline:
+    get:
+      tags:
+      - admin
+      summary: Status timeline for one notification (the "did it send?" answer)
+      operationId: adminNotificationTimeline
+      parameters:
+      - name: env_id
+        in: path
+        description: Environment TypeID (env_…).
+        required: true
+        schema:
+          type: string
+      - name: notif_id
+        in: path
+        description: Notification TypeID (notif_…).
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: The timeline so far.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminNotificationTimeline'
+        '401':
+          description: Admin authentication required.
+        '404':
+          description: No such notification.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+      - AdminToken: []
+  /admin/api/environments/{env_id}/subscribers/{subscriber_id}:
+    get:
+      tags:
+      - admin
+      summary: 'Subscriber lookup: counters, watermarks, preferences, merged inbox'
+      operationId: adminGetSubscriber
+      parameters:
+      - name: env_id
+        in: path
+        description: Environment TypeID (env_…).
+        required: true
+        schema:
+          type: string
+      - name: subscriber_id
+        in: path
+        description: Customer-provided subscriber id.
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Subscriber view.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminSubscriberView'
+        '401':
+          description: Admin authentication required.
+        '404':
+          description: No such subscriber.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+      - AdminToken: []
   /v1/broadcasts:
     post:
       tags:
@@ -648,6 +1159,328 @@ paths:
       - ApiKeyBearer: []
 components:
   schemas:
+    AdminApiKey:
+      type: object
+      required:
+      - id
+      - name
+      - key_prefix
+      - created_at
+      properties:
+        created_at:
+          type: string
+        id:
+          type: string
+          description: TypeID, `key_…`.
+        key_prefix:
+          type: string
+          description: Display prefix for recognition; the full key is never retrievable.
+        last_used_at:
+          type: string
+          nullable: true
+        name:
+          type: string
+        revoked_at:
+          type: string
+          nullable: true
+    AdminApiKeyCreated:
+      type: object
+      required:
+      - id
+      - name
+      - key_prefix
+      - key
+      - created_at
+      properties:
+        created_at:
+          type: string
+        id:
+          type: string
+        key:
+          type: string
+          description: The plaintext key, shown EXACTLY once. Only the sha256 hash is stored.
+        key_prefix:
+          type: string
+        name:
+          type: string
+    AdminCounts:
+      type: object
+      required:
+      - unread
+      - unseen
+      properties:
+        unread:
+          type: integer
+          format: int32
+        unseen:
+          type: integer
+          format: int32
+    AdminCreateApiKeyRequest:
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          type: string
+    AdminCreateBroadcastRequest:
+      type: object
+      required:
+      - category
+      properties:
+        category:
+          type: string
+        idempotency_key:
+          type: string
+          nullable: true
+        payload: {}
+    AdminCreateEnvironmentRequest:
+      type: object
+      required:
+      - slug
+      - name
+      properties:
+        name:
+          type: string
+        require_subscriber_hash:
+          type: boolean
+          description: Production default true; set false for a dev/quickstart environment.
+        slug:
+          type: string
+    AdminDeadLetter:
+      type: object
+      required:
+      - id
+      - environment_slug
+      - job_type
+      - attempts
+      - last_error
+      - parked_at
+      properties:
+        attempts:
+          type: integer
+          format: int32
+        environment_slug:
+          type: string
+        id:
+          type: string
+          description: TypeID, `job_…` (stable across park/replay).
+        job_type:
+          type: string
+        last_error:
+          type: string
+        parked_at:
+          type: string
+    AdminEnvironment:
+      type: object
+      required:
+      - id
+      - slug
+      - name
+      - require_subscriber_hash
+      - created_at
+      properties:
+        created_at:
+          type: string
+        id:
+          type: string
+          description: TypeID, `env_…`.
+        name:
+          type: string
+        require_subscriber_hash:
+          type: boolean
+        slug:
+          type: string
+    AdminEnvironmentDetail:
+      type: object
+      required:
+      - id
+      - slug
+      - name
+      - require_subscriber_hash
+      - subscriber_hmac_secret
+      - has_previous_secret
+      - created_at
+      properties:
+        created_at:
+          type: string
+        has_previous_secret:
+          type: boolean
+          description: |-
+            True while a rotation overlap is open (the previous secret still
+            verifies live `<Inbox />` sessions).
+        id:
+          type: string
+        name:
+          type: string
+        require_subscriber_hash:
+          type: boolean
+        slug:
+          type: string
+        subscriber_hmac_rotated_at:
+          type: string
+          nullable: true
+        subscriber_hmac_secret:
+          type: string
+          description: |-
+            The dedicated subscriber HMAC secret. Plaintext by design (the
+            customer backend computes hashes with it) and operator-only.
+    AdminHmacRotation:
+      type: object
+      required:
+      - subscriber_hmac_secret
+      - has_previous_secret
+      properties:
+        has_previous_secret:
+          type: boolean
+        subscriber_hmac_rotated_at:
+          type: string
+          nullable: true
+        subscriber_hmac_secret:
+          type: string
+          description: |-
+            The new current secret. Update the customer backend with it; the
+            previous secret keeps verifying until the rotation is completed.
+    AdminInboxItem:
+      type: object
+      required:
+      - id
+      - source
+      - category
+      - payload
+      - occurred_at
+      - read
+      properties:
+        category:
+          type: string
+        id:
+          type: string
+        occurred_at:
+          type: string
+        payload: {}
+        read:
+          type: boolean
+        source:
+          type: string
+    AdminNotification:
+      type: object
+      required:
+      - id
+      - subscriber_id
+      - category
+      - payload
+      - created_at
+      - visible_at
+      properties:
+        category:
+          type: string
+        created_at:
+          type: string
+        deliver_at:
+          type: string
+          nullable: true
+        id:
+          type: string
+          description: TypeID, `notif_…`.
+        payload: {}
+        read_at:
+          type: string
+          nullable: true
+        subscriber_id:
+          type: string
+        visible_at:
+          type: string
+    AdminNotificationPage:
+      type: object
+      required:
+      - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdminNotification'
+        next_cursor:
+          type: string
+          nullable: true
+    AdminNotificationTimeline:
+      type: object
+      required:
+      - id
+      - subscriber_id
+      - timeline
+      properties:
+        id:
+          type: string
+        subscriber_id:
+          type: string
+        timeline:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdminTimelineEntry'
+    AdminPreference:
+      type: object
+      required:
+      - category
+      - channel
+      - enabled
+      properties:
+        category:
+          type: string
+        channel:
+          type: string
+        enabled:
+          type: boolean
+    AdminReplayResult:
+      type: object
+      required:
+      - replayed
+      properties:
+        replayed:
+          type: integer
+          format: int64
+          description: Number of parked jobs moved back into the claim path.
+    AdminSubscriberView:
+      type: object
+      required:
+      - subscriber_id
+      - created_at
+      - counters
+      - read_watermark
+      - seen_watermark
+      - preferences
+      - inbox
+      properties:
+        counters:
+          $ref: '#/components/schemas/AdminCounts'
+        created_at:
+          type: string
+          description: Governs broadcast visibility (`broadcast.created_at >= this`).
+        inbox:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdminInboxItem'
+          description: |-
+            The subscriber's recent merged inbox, from the SAME canonical query
+            the subscriber plane serves.
+        preferences:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdminPreference'
+        read_watermark:
+          type: string
+        seen_watermark:
+          type: string
+        subscriber_id:
+          type: string
+    AdminTimelineEntry:
+      type: object
+      required:
+      - status
+      - occurred_at
+      properties:
+        occurred_at:
+          type: string
+        status:
+          type: string
     Broadcast:
       type: object
       required:
@@ -957,6 +1790,10 @@ components:
           schema:
             $ref: '#/components/schemas/Error'
   securitySchemes:
+    AdminToken:
+      type: http
+      scheme: basic
+      description: Instance admin credential (DRONTE_ADMIN_TOKEN) as the HTTP Basic password.
     ApiKeyBearer:
       type: http
       scheme: bearer
@@ -1013,3 +1850,5 @@ tags:
   description: Backend-to-Dronte. Bearer API key.
 - name: subscriber
   description: Widget-to-Dronte. HMAC subscriber hash.
+- name: admin
+  description: Instance admin dashboard. HTTP Basic (static credential).

--- a/examples/nextjs/app/globals.css
+++ b/examples/nextjs/app/globals.css
@@ -21,6 +21,11 @@ body {
 .topbar h1 {
   margin: 0;
   font-size: 18px;
+  color: #004f32;
+}
+
+a {
+  color: #1264ff;
 }
 
 main {

--- a/packages/client/src/generated/api.d.ts
+++ b/packages/client/src/generated/api.d.ts
@@ -4,6 +4,242 @@
  */
 
 export interface paths {
+    "/admin/api/dlq": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List parked jobs across environments */
+        get: operations["adminListDeadLetters"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/api/dlq/replay-all": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Replay every parked job */
+        post: operations["adminReplayAllDeadLetters"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/api/dlq/{job_id}/replay": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Replay one parked job (re-enters the normal claim path)
+         * @description Moves the parked row back into `jobs` with a fresh attempt budget; the normal worker loop (SKIP LOCKED, per-environment fairness, delete-on-completion) runs it. Never executed inline.
+         */
+        post: operations["adminReplayDeadLetter"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/api/environments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List environments */
+        get: operations["adminListEnvironments"];
+        put?: never;
+        /** Create an environment */
+        post: operations["adminCreateEnvironment"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/api/environments/{env_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Environment detail (includes the subscriber HMAC secret) */
+        get: operations["adminGetEnvironment"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/api/environments/{env_id}/api-keys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List API keys for an environment (prefix only, never the key) */
+        get: operations["adminListApiKeys"];
+        put?: never;
+        /** Create an API key (plaintext returned once) */
+        post: operations["adminCreateApiKey"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/api/environments/{env_id}/api-keys/{key_id}/revoke": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Revoke an API key (soft; row kept for audit) */
+        post: operations["adminRevokeApiKey"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/api/environments/{env_id}/broadcasts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Compose a broadcast (one row, fan-out on read)
+         * @description Composing is creating: the same idempotent management-plane write-path. One row per announcement, never materialized per subscriber.
+         */
+        post: operations["adminCreateBroadcast"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/api/environments/{env_id}/hmac/rotate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Begin a subscriber-HMAC rotation (current → previous)
+         * @description Generates a new current secret and moves the existing one into the
+         *     previous slot. During the overlap BOTH secrets verify live `<Inbox />`
+         *     sessions (auth checks current then previous), so rotation is
+         *     zero-downtime. Complete the rotation to clear the previous slot once
+         *     every customer backend has switched.
+         */
+        post: operations["adminRotateHmac"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/api/environments/{env_id}/hmac/rotate/complete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Complete a rotation (clear the previous secret slot) */
+        post: operations["adminCompleteHmacRotation"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/api/environments/{env_id}/notifications": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Browse direct notifications (filter by subscriber, category, time) */
+        get: operations["adminListNotifications"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/api/environments/{env_id}/notifications/{notif_id}/timeline": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Status timeline for one notification (the "did it send?" answer) */
+        get: operations["adminNotificationTimeline"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/api/environments/{env_id}/subscribers/{subscriber_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Subscriber lookup: counters, watermarks, preferences, merged inbox */
+        get: operations["adminGetSubscriber"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/broadcasts": {
         parameters: {
             query?: never;
@@ -328,6 +564,147 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        AdminApiKey: {
+            created_at: string;
+            /** @description TypeID, `key_…`. */
+            id: string;
+            /** @description Display prefix for recognition; the full key is never retrievable. */
+            key_prefix: string;
+            last_used_at?: string | null;
+            name: string;
+            revoked_at?: string | null;
+        };
+        AdminApiKeyCreated: {
+            created_at: string;
+            id: string;
+            /** @description The plaintext key, shown EXACTLY once. Only the sha256 hash is stored. */
+            key: string;
+            key_prefix: string;
+            name: string;
+        };
+        AdminCounts: {
+            /** Format: int32 */
+            unread: number;
+            /** Format: int32 */
+            unseen: number;
+        };
+        AdminCreateApiKeyRequest: {
+            name: string;
+        };
+        AdminCreateBroadcastRequest: {
+            category: string;
+            idempotency_key?: string | null;
+            payload?: unknown;
+        };
+        AdminCreateEnvironmentRequest: {
+            name: string;
+            /** @description Production default true; set false for a dev/quickstart environment. */
+            require_subscriber_hash?: boolean;
+            slug: string;
+        };
+        AdminDeadLetter: {
+            /** Format: int32 */
+            attempts: number;
+            environment_slug: string;
+            /** @description TypeID, `job_…` (stable across park/replay). */
+            id: string;
+            job_type: string;
+            last_error: string;
+            parked_at: string;
+        };
+        AdminEnvironment: {
+            created_at: string;
+            /** @description TypeID, `env_…`. */
+            id: string;
+            name: string;
+            require_subscriber_hash: boolean;
+            slug: string;
+        };
+        AdminEnvironmentDetail: {
+            created_at: string;
+            /**
+             * @description True while a rotation overlap is open (the previous secret still
+             *     verifies live `<Inbox />` sessions).
+             */
+            has_previous_secret: boolean;
+            id: string;
+            name: string;
+            require_subscriber_hash: boolean;
+            slug: string;
+            subscriber_hmac_rotated_at?: string | null;
+            /**
+             * @description The dedicated subscriber HMAC secret. Plaintext by design (the
+             *     customer backend computes hashes with it) and operator-only.
+             */
+            subscriber_hmac_secret: string;
+        };
+        AdminHmacRotation: {
+            has_previous_secret: boolean;
+            subscriber_hmac_rotated_at?: string | null;
+            /**
+             * @description The new current secret. Update the customer backend with it; the
+             *     previous secret keeps verifying until the rotation is completed.
+             */
+            subscriber_hmac_secret: string;
+        };
+        AdminInboxItem: {
+            category: string;
+            id: string;
+            occurred_at: string;
+            payload: unknown;
+            read: boolean;
+            source: string;
+        };
+        AdminNotification: {
+            category: string;
+            created_at: string;
+            deliver_at?: string | null;
+            /** @description TypeID, `notif_…`. */
+            id: string;
+            payload: unknown;
+            read_at?: string | null;
+            subscriber_id: string;
+            visible_at: string;
+        };
+        AdminNotificationPage: {
+            items: components["schemas"]["AdminNotification"][];
+            next_cursor?: string | null;
+        };
+        AdminNotificationTimeline: {
+            id: string;
+            subscriber_id: string;
+            timeline: components["schemas"]["AdminTimelineEntry"][];
+        };
+        AdminPreference: {
+            category: string;
+            channel: string;
+            enabled: boolean;
+        };
+        AdminReplayResult: {
+            /**
+             * Format: int64
+             * @description Number of parked jobs moved back into the claim path.
+             */
+            replayed: number;
+        };
+        AdminSubscriberView: {
+            counters: components["schemas"]["AdminCounts"];
+            /** @description Governs broadcast visibility (`broadcast.created_at >= this`). */
+            created_at: string;
+            /**
+             * @description The subscriber's recent merged inbox, from the SAME canonical query
+             *     the subscriber plane serves.
+             */
+            inbox: components["schemas"]["AdminInboxItem"][];
+            preferences: components["schemas"]["AdminPreference"][];
+            read_watermark: string;
+            seen_watermark: string;
+            subscriber_id: string;
+        };
+        AdminTimelineEntry: {
+            occurred_at: string;
+            status: string;
+        };
         Broadcast: {
             category: string;
             /** Format: date-time */
@@ -529,6 +906,612 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    adminListDeadLetters: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Parked jobs. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminDeadLetter"][];
+                };
+            };
+            /** @description Admin authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    adminReplayAllDeadLetters: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Replayed. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminReplayResult"];
+                };
+            };
+            /** @description Admin authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    adminReplayDeadLetter: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Job TypeID (job_…). */
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Replayed. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminReplayResult"];
+                };
+            };
+            /** @description Admin authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description No such parked job. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    adminListEnvironments: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Environments. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminEnvironment"][];
+                };
+            };
+            /** @description Admin authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    adminCreateEnvironment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AdminCreateEnvironmentRequest"];
+            };
+        };
+        responses: {
+            /** @description Created. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminEnvironmentDetail"];
+                };
+            };
+            /** @description Validation error or slug already exists. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Admin authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    adminGetEnvironment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Environment TypeID (env_…). */
+                env_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Environment. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminEnvironmentDetail"];
+                };
+            };
+            /** @description Admin authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description No such environment. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    adminListApiKeys: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Environment TypeID (env_…). */
+                env_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Keys. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminApiKey"][];
+                };
+            };
+            /** @description Admin authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description No such environment. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    adminCreateApiKey: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Environment TypeID (env_…). */
+                env_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AdminCreateApiKeyRequest"];
+            };
+        };
+        responses: {
+            /** @description Created; `key` is shown once. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminApiKeyCreated"];
+                };
+            };
+            /** @description Validation error. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Admin authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description No such environment. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    adminRevokeApiKey: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Environment TypeID (env_…). */
+                env_id: string;
+                /** @description API key TypeID (key_…). */
+                key_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Revoked (now or already). */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Admin authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description No such API key. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    adminCreateBroadcast: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Environment TypeID (env_…). */
+                env_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AdminCreateBroadcastRequest"];
+            };
+        };
+        responses: {
+            /** @description Idempotent replay. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Broadcast"];
+                };
+            };
+            /** @description Created. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Broadcast"];
+                };
+            };
+            /** @description Validation error. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Admin authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description No such environment. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    adminRotateHmac: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Environment TypeID (env_…). */
+                env_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Rotated. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminHmacRotation"];
+                };
+            };
+            /** @description Admin authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description No such environment. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    adminCompleteHmacRotation: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Environment TypeID (env_…). */
+                env_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Previous secret cleared. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Admin authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description No such environment. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    adminListNotifications: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Environment TypeID (env_…). */
+                env_id: string;
+                /** @description Customer-provided subscriber id. */
+                subscriber_id: string | null;
+                category: string | null;
+                /** @description Lower bound on `visible_at` (inclusive), RFC 3339. */
+                after: string | null;
+                /** @description Upper bound on `visible_at` (exclusive), RFC 3339. */
+                before: string | null;
+                limit: number | null;
+                /** @description Opaque keyset cursor from the previous page's `next_cursor`. */
+                cursor: string | null;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description A page of notifications. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminNotificationPage"];
+                };
+            };
+            /** @description Malformed cursor or out-of-range limit. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Admin authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description No such environment. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    adminNotificationTimeline: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Environment TypeID (env_…). */
+                env_id: string;
+                /** @description Notification TypeID (notif_…). */
+                notif_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The timeline so far. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminNotificationTimeline"];
+                };
+            };
+            /** @description Admin authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description No such notification. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    adminGetSubscriber: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Environment TypeID (env_…). */
+                env_id: string;
+                /** @description Customer-provided subscriber id. */
+                subscriber_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Subscriber view. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminSubscriberView"];
+                };
+            };
+            /** @description Admin authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description No such subscriber. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
     createBroadcast: {
         parameters: {
             query?: never;

--- a/packages/react/src/Inbox.tsx
+++ b/packages/react/src/Inbox.tsx
@@ -31,10 +31,14 @@ export type InboxSlot =
  */
 export interface InboxAppearance {
   variables?: {
+    /** Primary actions, links, unread badge and dot, focus rings. Default #1264FF. */
     colorPrimary?: string;
+    /** Hover/section accent. Default #004F32. */
+    colorPrimaryHover?: string;
     colorBackground?: string;
     colorForeground?: string;
     colorMuted?: string;
+    /** Unread badge background. Default #1264FF. */
     colorBadge?: string;
     borderRadius?: string;
     fontFamily?: string;

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -36,7 +36,7 @@ export const INBOX_CSS = `
   height: 16px;
   padding: 0 4px;
   border-radius: 999px;
-  background: var(--dronte-colorBadge, #dc2626);
+  background: var(--dronte-colorBadge, #1264FF);
   color: #ffffff;
   font-size: 11px;
   font-weight: 600;
@@ -72,7 +72,7 @@ export const INBOX_CSS = `
 .dronte-header-action {
   border: none;
   background: transparent;
-  color: var(--dronte-colorPrimary, #2563eb);
+  color: var(--dronte-colorPrimary, #1264FF);
   font: inherit;
   cursor: pointer;
   padding: 2px 4px;
@@ -80,6 +80,13 @@ export const INBOX_CSS = `
 }
 .dronte-header-action:hover {
   background: var(--dronte-colorMuted, #f3f4f6);
+  color: var(--dronte-colorPrimaryHover, #004F32);
+}
+.dronte-bell:focus-visible,
+.dronte-header-action:focus-visible,
+.dronte-item:focus-visible {
+  outline: 2px solid var(--dronte-colorPrimary, #1264FF);
+  outline-offset: 2px;
 }
 .dronte-list {
   flex: 1;
@@ -140,7 +147,7 @@ export const INBOX_CSS = `
   margin-top: 6px;
   margin-left: auto;
   border-radius: 50%;
-  background: var(--dronte-colorPrimary, #2563eb);
+  background: var(--dronte-colorPrimary, #1264FF);
   flex: none;
 }
 .dronte-empty {
@@ -173,7 +180,7 @@ export const INBOX_CSS = `
   padding: 10px 14px;
 }
 .dronte-preference input {
-  accent-color: var(--dronte-colorPrimary, #2563eb);
+  accent-color: var(--dronte-colorPrimary, #1264FF);
 }
 `;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,16 +31,16 @@ importers:
     dependencies:
       fumadocs-core:
         specifier: ^16.9.3
-        version: 16.9.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 16.9.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       fumadocs-mdx:
         specifier: ^15.0.11
-        version: 15.0.11(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(rolldown@1.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0))
+        version: 15.0.11(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(rolldown@1.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0))
       fumadocs-openapi:
         specifier: ^10.10.3
-        version: 10.10.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(fumadocs-ui@16.9.3(@tailwindcss/oxide@4.3.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 10.10.3(b79c6de4651aee2fb7a5b83c209f67d1)
       fumadocs-ui:
         specifier: ^16.9.3
-        version: 16.9.3(@tailwindcss/oxide@4.3.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)
+        version: 16.9.3(@tailwindcss/oxide@4.3.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)
       next:
         specifier: 16.2.8
         version: 16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -156,6 +156,79 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.2)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0))
 
+  server/admin:
+    dependencies:
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.6
+        version: 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-label':
+        specifier: ^2.1.2
+        version: 2.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-separator':
+        specifier: ^1.1.2
+        version: 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot':
+        specifier: ^1.1.2
+        version: 1.2.5(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.3
+        version: 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/react-query':
+        specifier: ^5.66.0
+        version: 5.101.0(react@19.2.7)
+      '@tanstack/react-router':
+        specifier: ^1.99.0
+        version: 1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: ^0.474.0
+        version: 0.474.0(react@19.2.7)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      recharts:
+        specifier: ^2.15.1
+        version: 2.15.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      sonner:
+        specifier: ^1.7.4
+        version: 1.7.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      tailwind-merge:
+        specifier: ^3.0.2
+        version: 3.6.0
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.0.6
+        version: 4.3.1(vite@6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@types/node':
+        specifier: ^22.13.1
+        version: 22.19.21
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0))
+      tailwindcss:
+        specifier: ^4.0.6
+        version: 4.3.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^6.1.0
+        version: 6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)
+
 packages:
 
   '@alloc/quick-lru@5.2.0':
@@ -181,12 +254,87 @@ packages:
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@biomejs/biome@2.4.16':
@@ -350,6 +498,12 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
@@ -362,6 +516,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
@@ -372,6 +532,12 @@ packages:
     resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.7':
@@ -386,6 +552,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
@@ -398,6 +570,12 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
@@ -408,6 +586,12 @@ packages:
     resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.7':
@@ -422,6 +606,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.7':
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
@@ -432,6 +622,12 @@ packages:
     resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -446,6 +642,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
@@ -456,6 +658,12 @@ packages:
     resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.7':
@@ -470,6 +678,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.7':
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
@@ -480,6 +694,12 @@ packages:
     resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.7':
@@ -494,6 +714,12 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.7':
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
@@ -504,6 +730,12 @@ packages:
     resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -518,6 +750,12 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.7':
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
@@ -528,6 +766,12 @@ packages:
     resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.7':
@@ -542,6 +786,12 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.7':
     resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
@@ -554,6 +804,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
@@ -564,6 +820,12 @@ packages:
     resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.7':
@@ -578,6 +840,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
@@ -588,6 +856,12 @@ packages:
     resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -602,6 +876,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
@@ -613,6 +893,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.7':
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
@@ -626,6 +912,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
@@ -638,6 +930,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.7':
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
@@ -648,6 +946,12 @@ packages:
     resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.7':
@@ -1125,6 +1429,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-label@2.1.9':
+    resolution: {integrity: sha512-rDoTeMbCwRVcnmo7NGT9IlPo1yXmEI+xc1URP3oeewwZEV4mdTp1dYUhYbQdo4D1q2SjKVvv4N1gNY77QAQtjA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-navigation-menu@1.2.15':
     resolution: {integrity: sha512-/fS8hKCcRt4DwCGa5QIB3juRXmfYSOk4a2AEe/BDIyy7Hm+eje2Y13oUx5zejl+wFt1owrM7E8NWlbaEl5EGpg==}
     peerDependencies:
@@ -1231,6 +1548,19 @@ packages:
 
   '@radix-ui/react-select@2.3.0':
     resolution: {integrity: sha512-mENc7WpJvJcW8hlMpzfFcHcEhTvYS5JMBmi9HVC1Q00uhBwML086MHYUV8QQdQv6lcu0Wg8dzd1RB8AFADcG/g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-separator@1.1.9':
+    resolution: {integrity: sha512-gvgW+JV/Mbjj6darztTetnmElpQEzZrXpJvfj+dOxNAxiyHEAyUvEjjl4zxblvmjmKmi3jfPoy7ZdxzCuUBJSA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1457,6 +1787,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
@@ -1638,8 +1971,17 @@ packages:
   '@tailwindcss/node@4.3.0':
     resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
 
+  '@tailwindcss/node@4.3.1':
+    resolution: {integrity: sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==}
+
   '@tailwindcss/oxide-android-arm64@4.3.0':
     resolution: {integrity: sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-android-arm64@4.3.1':
+    resolution: {integrity: sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [android]
@@ -1650,8 +1992,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@tailwindcss/oxide-darwin-arm64@4.3.1':
+    resolution: {integrity: sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@tailwindcss/oxide-darwin-x64@4.3.0':
     resolution: {integrity: sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.1':
+    resolution: {integrity: sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
@@ -1662,14 +2016,33 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@tailwindcss/oxide-freebsd-x64@4.3.1':
+    resolution: {integrity: sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
     resolution: {integrity: sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==}
     engines: {node: '>= 20'}
     cpu: [arm]
     os: [linux]
 
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.1':
+    resolution: {integrity: sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
   '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
     resolution: {integrity: sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.1':
+    resolution: {integrity: sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
@@ -1682,6 +2055,13 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
+    resolution: {integrity: sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
@@ -1689,8 +2069,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
+    resolution: {integrity: sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.1':
+    resolution: {integrity: sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
@@ -1708,8 +2102,26 @@ packages:
       - '@emnapi/wasi-threads'
       - tslib
 
+  '@tailwindcss/oxide-wasm32-wasi@4.3.1':
+    resolution: {integrity: sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
   '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
     resolution: {integrity: sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.1':
+    resolution: {integrity: sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [win32]
@@ -1720,12 +2132,59 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.1':
+    resolution: {integrity: sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
   '@tailwindcss/oxide@4.3.0':
     resolution: {integrity: sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==}
     engines: {node: '>= 20'}
 
+  '@tailwindcss/oxide@4.3.1':
+    resolution: {integrity: sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==}
+    engines: {node: '>= 20'}
+
   '@tailwindcss/postcss@4.3.0':
     resolution: {integrity: sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==}
+
+  '@tailwindcss/vite@4.3.1':
+    resolution: {integrity: sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tanstack/history@1.162.0':
+    resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/query-core@5.101.0':
+    resolution: {integrity: sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==}
+
+  '@tanstack/react-query@5.101.0':
+    resolution: {integrity: sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==}
+    peerDependencies:
+      react: ^18 || ^19
+
+  '@tanstack/react-router@1.170.15':
+    resolution: {integrity: sha512-GawYz7HEjj8rTUUDoT/SemDEVm63pZUO+2mOcXHY9Jl3EwMS5gFBnPu/2UvcrwRm1jN1k79fokc0d4aFmrLatg==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-store@0.9.3':
+    resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/router-core@1.171.13':
+    resolution: {integrity: sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/store@0.9.3':
+    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -1752,8 +2211,47 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
@@ -1782,6 +2280,9 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
+  '@types/node@22.19.21':
+    resolution: {integrity: sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==}
+
   '@types/node@25.9.2':
     resolution: {integrity: sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==}
 
@@ -1801,6 +2302,12 @@ packages:
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitest/expect@4.1.8':
     resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
@@ -1910,6 +2417,11 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1992,6 +2504,9 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -2002,6 +2517,50 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -2015,6 +2574,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -2047,6 +2609,16 @@ packages:
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+
+  electron-to-chromium@1.5.372:
+    resolution: {integrity: sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==}
+
+  enhanced-resolve@5.21.6:
+    resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
+    engines: {node: '>=10.13.0'}
+
   enhanced-resolve@5.23.0:
     resolution: {integrity: sha512-yJN/BOOLxcOW2aQgeif9mSnaUB8KtvmMMp56oA1kx1CRfBKbhZm2pJ+NBY+3eOboHxix8lfjWpHE0Ei5U8RbSA==}
     engines: {node: '>=10.13.0'}
@@ -2072,6 +2644,11 @@ packages:
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
@@ -2081,6 +2658,10 @@ packages:
     resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
@@ -2123,6 +2704,9 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -2135,6 +2719,10 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@5.4.0:
+    resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
+    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -2318,6 +2906,10 @@ packages:
       next:
         optional: true
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
@@ -2393,6 +2985,10 @@ packages:
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
 
@@ -2431,6 +3027,10 @@ packages:
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
+
+  isbot@5.1.42:
+    resolution: {integrity: sha512-/SXsVh7KpPRISrD4ffrGSxnTLlUBzEQUfWIusaJPrpJ93FW1P0YEZri5vAUkFsA0m2HRUhQRQadk2wJ+EeKowQ==}
+    engines: {node: '>=18'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -2471,8 +3071,18 @@ packages:
       canvas:
         optional: true
 
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -2569,12 +3179,27 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
 
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
     engines: {node: 20 || >=22}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@0.474.0:
+    resolution: {integrity: sha512-CmghgHkh0OJNmxGKWc0qfPJCYHASPMVSyGY8fj3xgk4v84ItqDg64JNKFZn5hC6E0vHi6gxnbCgwhyVB09wQtA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lucide-react@1.17.0:
     resolution: {integrity: sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==}
@@ -2828,6 +3453,10 @@ packages:
       sass:
         optional: true
 
+  node-releases@2.0.47:
+    resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
+    engines: {node: '>=18'}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -2963,6 +3592,9 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
@@ -2981,8 +3613,18 @@ packages:
     peerDependencies:
       react: ^19.2.7
 
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -3004,6 +3646,12 @@ packages:
       '@types/react':
         optional: true
 
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -3013,6 +3661,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
 
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
@@ -3029,6 +3683,17 @@ packages:
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
+
+  recharts-scale@0.4.5:
+    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+
+  recharts@2.15.4:
+    resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
+    engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   recma-build-jsx@1.0.0:
     resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
@@ -3115,10 +3780,24 @@ packages:
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
   semver@7.8.3:
     resolution: {integrity: sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==}
     engines: {node: '>=10'}
     hasBin: true
+
+  seroval-plugins@1.5.4:
+    resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.5.4:
+    resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
+    engines: {node: '>=10'}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -3146,6 +3825,12 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  sonner@1.7.4:
+    resolution: {integrity: sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -3218,6 +3903,9 @@ packages:
   tailwindcss@4.3.0:
     resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
 
+  tailwindcss@4.3.1:
+    resolution: {integrity: sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==}
+
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
@@ -3232,6 +3920,9 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -3317,6 +4008,9 @@ packages:
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
@@ -3352,6 +4046,12 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   uri-js-replace@1.0.1:
     resolution: {integrity: sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==}
 
@@ -3375,6 +4075,11 @@ packages:
       '@types/react':
         optional: true
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
 
@@ -3383,6 +4088,49 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  victory-vendor@36.9.2:
+    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
+
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
@@ -3504,6 +4252,9 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yaml-ast-parser@0.0.43:
     resolution: {integrity: sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==}
 
@@ -3547,9 +4298,113 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3(supports-color@10.2.2)
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.29.7': {}
 
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
   '@babel/runtime@7.29.7': {}
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@biomejs/biome@2.4.16':
     optionalDependencies:
@@ -3773,10 +4628,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
   '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
@@ -3785,10 +4646,16 @@ snapshots:
   '@esbuild/android-arm64@0.28.0':
     optional: true
 
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.27.7':
     optional: true
 
   '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
@@ -3797,10 +4664,16 @@ snapshots:
   '@esbuild/android-x64@0.28.0':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
   '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
@@ -3809,10 +4682,16 @@ snapshots:
   '@esbuild/darwin-x64@0.28.0':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -3821,10 +4700,16 @@ snapshots:
   '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
@@ -3833,10 +4718,16 @@ snapshots:
   '@esbuild/linux-arm@0.28.0':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
   '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
@@ -3845,10 +4736,16 @@ snapshots:
   '@esbuild/linux-loong64@0.28.0':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
   '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -3857,10 +4754,16 @@ snapshots:
   '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
   '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
@@ -3869,10 +4772,16 @@ snapshots:
   '@esbuild/linux-s390x@0.28.0':
     optional: true
 
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
@@ -3881,10 +4790,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
@@ -3893,10 +4808,16 @@ snapshots:
   '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
@@ -3905,10 +4826,16 @@ snapshots:
   '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
   '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
@@ -3917,10 +4844,16 @@ snapshots:
   '@esbuild/win32-arm64@0.28.0':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
   '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
@@ -4319,6 +5252,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  '@radix-ui/react-label@2.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-navigation-menu@1.2.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
@@ -4470,6 +5412,15 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-separator@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -4634,6 +5585,8 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.3':
     optional: true
 
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
   '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/rollup-android-arm-eabi@4.61.1':
@@ -4767,40 +5720,86 @@ snapshots:
       source-map-js: 1.2.1
       tailwindcss: 4.3.0
 
+  '@tailwindcss/node@4.3.1':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.21.6
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.1
+
   '@tailwindcss/oxide-android-arm64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-android-arm64@4.3.1':
     optional: true
 
   '@tailwindcss/oxide-darwin-arm64@4.3.0':
     optional: true
 
+  '@tailwindcss/oxide-darwin-arm64@4.3.1':
+    optional: true
+
   '@tailwindcss/oxide-darwin-x64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.1':
     optional: true
 
   '@tailwindcss/oxide-freebsd-x64@4.3.0':
     optional: true
 
+  '@tailwindcss/oxide-freebsd-x64@4.3.1':
+    optional: true
+
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.1':
     optional: true
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
     optional: true
 
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.1':
+    optional: true
+
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
     optional: true
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     optional: true
 
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
+    optional: true
+
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.1':
     optional: true
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     optional: true
 
+  '@tailwindcss/oxide-wasm32-wasi@4.3.1':
+    optional: true
+
   '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
     optional: true
 
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.1':
+    optional: true
+
   '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.1':
     optional: true
 
   '@tailwindcss/oxide@4.3.0':
@@ -4818,6 +5817,21 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
 
+  '@tailwindcss/oxide@4.3.1':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.1
+      '@tailwindcss/oxide-darwin-arm64': 4.3.1
+      '@tailwindcss/oxide-darwin-x64': 4.3.1
+      '@tailwindcss/oxide-freebsd-x64': 4.3.1
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.1
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.1
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.1
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.1
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.1
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.1
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
+
   '@tailwindcss/postcss@4.3.0':
     dependencies:
       '@alloc/quick-lru': 5.2.0
@@ -4825,6 +5839,47 @@ snapshots:
       '@tailwindcss/oxide': 4.3.0
       postcss: 8.5.15
       tailwindcss: 4.3.0
+
+  '@tailwindcss/vite@4.3.1(vite@6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.1
+      '@tailwindcss/oxide': 4.3.1
+      tailwindcss: 4.3.1
+      vite: 6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)
+
+  '@tanstack/history@1.162.0': {}
+
+  '@tanstack/query-core@5.101.0': {}
+
+  '@tanstack/react-query@5.101.0(react@19.2.7)':
+    dependencies:
+      '@tanstack/query-core': 5.101.0
+      react: 19.2.7
+
+  '@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      '@tanstack/react-store': 0.9.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/router-core': 1.171.13
+      isbot: 5.1.42
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@tanstack/react-store@0.9.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/store': 0.9.3
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
+
+  '@tanstack/router-core@1.171.13':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      cookie-es: 3.1.1
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
+
+  '@tanstack/store@0.9.3': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -4854,10 +5909,55 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
 
   '@types/debug@4.1.13':
     dependencies:
@@ -4885,6 +5985,10 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
+  '@types/node@22.19.21':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@25.9.2':
     dependencies:
       undici-types: 7.24.6
@@ -4902,6 +6006,18 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.1': {}
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -5010,6 +6126,14 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.34
+      caniuse-lite: 1.0.30001797
+      electron-to-chromium: 1.5.372
+      node-releases: 2.0.47
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
   bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
       esbuild: 0.27.7
@@ -5067,6 +6191,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie-es@3.1.1: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -5080,6 +6206,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   data-urls@7.0.0:
     dependencies:
       whatwg-mimetype: 5.0.0
@@ -5092,6 +6256,8 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 10.2.2
+
+  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -5116,6 +6282,18 @@ snapshots:
       path-type: 4.0.0
 
   dom-accessibility-api@0.5.16: {}
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      csstype: 3.2.3
+
+  electron-to-chromium@1.5.372: {}
+
+  enhanced-resolve@5.21.6:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
 
   enhanced-resolve@5.23.0:
     dependencies:
@@ -5146,6 +6324,35 @@ snapshots:
       acorn: 8.16.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -5205,6 +6412,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.0
       '@esbuild/win32-x64': 0.28.0
 
+  escalade@3.2.0: {}
+
   escape-string-regexp@5.0.0: {}
 
   esprima@4.0.1: {}
@@ -5250,6 +6459,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
+  eventemitter3@4.0.7: {}
+
   expect-type@1.3.0: {}
 
   extend@3.0.2: {}
@@ -5257,6 +6468,8 @@ snapshots:
   extendable-error@0.1.7: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-equals@5.4.0: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -5313,7 +6526,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
+  fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
     dependencies:
       '@orama/orama': 3.1.18
       estree-util-value-to-estree: 3.5.0
@@ -5334,6 +6547,7 @@ snapshots:
       vfile: 6.0.3
     optionalDependencies:
       '@mdx-js/mdx': 3.1.1
+      '@tanstack/react-router': 1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -5346,14 +6560,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@15.0.11(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(rolldown@1.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)):
+  fumadocs-mdx@15.0.11(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(rolldown@1.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.28.0
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.9.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      fumadocs-core: 16.9.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       js-yaml: 4.2.0
       mdast-util-mdx: 3.0.0
       picocolors: 1.1.1
@@ -5376,7 +6590,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-openapi@10.10.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(fumadocs-ui@16.9.3(@tailwindcss/oxide@4.3.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  fumadocs-openapi@10.10.3(b79c6de4651aee2fb7a5b83c209f67d1):
     dependencies:
       '@fumari/json-schema-ts': 0.0.2
       '@fumari/stf': 1.0.5(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -5385,8 +6599,8 @@ snapshots:
       '@radix-ui/react-select': 2.3.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       chokidar: 5.0.0
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.9.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
-      fumadocs-ui: 16.9.3(@tailwindcss/oxide@4.3.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)
+      fumadocs-core: 16.9.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      fumadocs-ui: 16.9.3(@tailwindcss/oxide@4.3.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)
       github-slugger: 2.0.0
       hast-util-to-jsx-runtime: 2.3.6
       js-yaml: 4.2.0
@@ -5404,7 +6618,7 @@ snapshots:
       - '@typescript-eslint/types'
       - supports-color
 
-  fumadocs-ui@16.9.3(@tailwindcss/oxide@4.3.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0):
+  fumadocs-ui@16.9.3(@tailwindcss/oxide@4.3.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0):
     dependencies:
       '@fumadocs/tailwind': 0.0.5(@tailwindcss/oxide@4.3.0)(tailwindcss@4.3.0)
       '@radix-ui/react-accordion': 1.2.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -5418,7 +6632,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.5(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-tabs': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.9.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      fumadocs-core: 16.9.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       lucide-react: 1.17.0(react@19.2.7)
       motion: 12.40.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-themes: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -5439,6 +6653,8 @@ snapshots:
       - '@tailwindcss/oxide'
       - '@types/react-dom'
       - tailwindcss
+
+  gensync@1.0.0-beta.2: {}
 
   get-nonce@1.0.1: {}
 
@@ -5594,6 +6810,8 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
+  internmap@2.0.3: {}
+
   is-alphabetical@2.0.1: {}
 
   is-alphanumerical@2.0.1:
@@ -5622,6 +6840,8 @@ snapshots:
       better-path-resolve: 1.0.0
 
   is-windows@1.0.2: {}
+
+  isbot@5.1.42: {}
 
   isexe@2.0.0: {}
 
@@ -5672,7 +6892,11 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  jsesc@3.1.0: {}
+
   json-schema-traverse@1.0.0: {}
+
+  json5@2.2.3: {}
 
   jsonfile@4.0.0:
     optionalDependencies:
@@ -5739,9 +6963,23 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
+  lodash@4.18.1: {}
+
   longest-streak@3.1.0: {}
 
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   lru-cache@11.5.1: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  lucide-react@0.474.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
 
   lucide-react@1.17.0(react@19.2.7):
     dependencies:
@@ -6259,6 +7497,8 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-releases@2.0.47: {}
+
   object-assign@4.1.1: {}
 
   obug@2.1.2: {}
@@ -6380,6 +7620,12 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   property-information@7.2.0: {}
 
   punycode@2.3.1: {}
@@ -6393,7 +7639,13 @@ snapshots:
       react: 19.2.7
       scheduler: 0.27.0
 
+  react-is@16.13.1: {}
+
   react-is@17.0.2: {}
+
+  react-is@18.3.1: {}
+
+  react-refresh@0.17.0: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.7):
     dependencies:
@@ -6414,6 +7666,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  react-smooth@4.0.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      fast-equals: 5.4.0
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-transition-group: 4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+
   react-style-singleton@2.2.3(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       get-nonce: 1.0.1
@@ -6421,6 +7681,15 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.17
+
+  react-transition-group@4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   react@19.2.7: {}
 
@@ -6434,6 +7703,23 @@ snapshots:
   readdirp@4.1.2: {}
 
   readdirp@5.0.0: {}
+
+  recharts-scale@0.4.5:
+    dependencies:
+      decimal.js-light: 2.5.1
+
+  recharts@2.15.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
+      lodash: 4.18.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      recharts-scale: 0.4.5
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
 
   recma-build-jsx@1.0.0:
     dependencies:
@@ -6612,7 +7898,15 @@ snapshots:
     dependencies:
       compute-scroll-into-view: 3.1.1
 
+  semver@6.3.1: {}
+
   semver@7.8.3: {}
+
+  seroval-plugins@1.5.4(seroval@1.5.4):
+    dependencies:
+      seroval: 1.5.4
+
+  seroval@1.5.4: {}
 
   sharp@0.34.5:
     dependencies:
@@ -6668,6 +7962,11 @@ snapshots:
   signal-exit@4.1.0: {}
 
   slash@3.0.0: {}
+
+  sonner@1.7.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   source-map-js@1.2.1: {}
 
@@ -6728,6 +8027,8 @@ snapshots:
 
   tailwindcss@4.3.0: {}
 
+  tailwindcss@4.3.1: {}
+
   tapable@2.3.3: {}
 
   term-size@2.2.1: {}
@@ -6739,6 +8040,8 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
 
@@ -6815,6 +8118,8 @@ snapshots:
 
   ufo@1.6.4: {}
 
+  undici-types@6.21.0: {}
+
   undici-types@7.24.6: {}
 
   undici@7.27.2: {}
@@ -6863,6 +8168,12 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   uri-js-replace@1.0.1: {}
 
   use-callback-ref@1.3.3(@types/react@19.2.17)(react@19.2.7):
@@ -6880,6 +8191,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  use-sync-external-store@1.6.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
   vfile-location@5.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -6894,6 +8209,37 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  victory-vendor@36.9.2:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
+
+  vite@6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.61.1
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.19.21
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
 
   vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0):
     dependencies:
@@ -7007,6 +8353,8 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  yallist@3.1.1: {}
 
   yaml-ast-parser@0.0.43: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - packages/*
   - docs
   - examples/*
+  - server/admin
 allowBuilds:
   esbuild: true
   sharp: true

--- a/server/.sqlx/query-02b7a8edc635d2854f95e2c3fcd362e42f594f551db01404522edf2d59afbf08.json
+++ b/server/.sqlx/query-02b7a8edc635d2854f95e2c3fcd362e42f594f551db01404522edf2d59afbf08.json
@@ -1,0 +1,112 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, slug, name, require_subscriber_hash, subscriber_hmac_secret,\n                  subscriber_hmac_secret_previous, subscriber_hmac_rotated_at, created_at\n             FROM environments WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "environments",
+            "name": "id"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "slug",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "environments",
+            "name": "slug"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "environments",
+            "name": "name"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "require_subscriber_hash",
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "environments",
+            "name": "require_subscriber_hash"
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "subscriber_hmac_secret",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "environments",
+            "name": "subscriber_hmac_secret"
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "subscriber_hmac_secret_previous",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "environments",
+            "name": "subscriber_hmac_secret_previous"
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "subscriber_hmac_rotated_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "environments",
+            "name": "subscriber_hmac_rotated_at"
+          }
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "created_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "environments",
+            "name": "created_at"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "02b7a8edc635d2854f95e2c3fcd362e42f594f551db01404522edf2d59afbf08"
+}

--- a/server/.sqlx/query-0f2a8e6354f459d85970d62d1687e74411b1de6dda14067745fbd3b6883a0d5b.json
+++ b/server/.sqlx/query-0f2a8e6354f459d85970d62d1687e74411b1de6dda14067745fbd3b6883a0d5b.json
@@ -1,0 +1,88 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, name, key_prefix, created_at, last_used_at, revoked_at\n             FROM api_keys WHERE environment_id = $1 ORDER BY created_at",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "api_keys",
+            "name": "id"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "api_keys",
+            "name": "name"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "key_prefix",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "api_keys",
+            "name": "key_prefix"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "api_keys",
+            "name": "created_at"
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "last_used_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "api_keys",
+            "name": "last_used_at"
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "revoked_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "api_keys",
+            "name": "revoked_at"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "0f2a8e6354f459d85970d62d1687e74411b1de6dda14067745fbd3b6883a0d5b"
+}

--- a/server/.sqlx/query-2fe95712dae85ce39bc6637175ebe247a42d5408c57339aef039dfdba466874b.json
+++ b/server/.sqlx/query-2fe95712dae85ce39bc6637175ebe247a42d5408c57339aef039dfdba466874b.json
@@ -1,0 +1,53 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE environments SET\n               subscriber_hmac_secret = $2,\n               subscriber_hmac_secret_previous = subscriber_hmac_secret,\n               subscriber_hmac_rotated_at = now(),\n               updated_at = now()\n           WHERE id = $1\n           RETURNING subscriber_hmac_secret, subscriber_hmac_secret_previous,\n                     subscriber_hmac_rotated_at",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "subscriber_hmac_secret",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "environments",
+            "name": "subscriber_hmac_secret"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "subscriber_hmac_secret_previous",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "environments",
+            "name": "subscriber_hmac_secret_previous"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "subscriber_hmac_rotated_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "environments",
+            "name": "subscriber_hmac_rotated_at"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "2fe95712dae85ce39bc6637175ebe247a42d5408c57339aef039dfdba466874b"
+}

--- a/server/.sqlx/query-3e7bd3c19f3fb722e7bacb5a08ba6d8510c7b6ceeebbb405383bc755bffdbdf6.json
+++ b/server/.sqlx/query-3e7bd3c19f3fb722e7bacb5a08ba6d8510c7b6ceeebbb405383bc755bffdbdf6.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT EXISTS(SELECT 1 FROM environments WHERE id = $1) AS \"exists!\"",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists!",
+        "type_info": "Bool",
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "3e7bd3c19f3fb722e7bacb5a08ba6d8510c7b6ceeebbb405383bc755bffdbdf6"
+}

--- a/server/.sqlx/query-49ed8e2fa9e09aa6056d115b4aae2313cf158a87f9d1f5d81ced32dbaf4117d2.json
+++ b/server/.sqlx/query-49ed8e2fa9e09aa6056d115b4aae2313cf158a87f9d1f5d81ced32dbaf4117d2.json
@@ -1,0 +1,65 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT s.id, s.created_at,\n                  c.read_watermark AS \"read_watermark!\",\n                  c.seen_watermark AS \"seen_watermark!\"\n             FROM subscribers s\n             JOIN subscriber_counters c\n               ON c.environment_id = s.environment_id AND c.subscriber_id = s.id\n            WHERE s.environment_id = $1 AND s.subscriber_id = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "subscribers",
+            "name": "id"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "created_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "subscribers",
+            "name": "created_at"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "read_watermark!",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "subscriber_counters",
+            "name": "read_watermark"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "seen_watermark!",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "subscriber_counters",
+            "name": "seen_watermark"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "49ed8e2fa9e09aa6056d115b4aae2313cf158a87f9d1f5d81ced32dbaf4117d2"
+}

--- a/server/.sqlx/query-7bf610e70e43cccaf6a431f96b48549f6de05615c4f40fd7cdfc102cc23ab28a.json
+++ b/server/.sqlx/query-7bf610e70e43cccaf6a431f96b48549f6de05615c4f40fd7cdfc102cc23ab28a.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO api_keys (environment_id, id, name, key_hash, key_prefix)\n           VALUES ($1, $2, $3, $4, $5)\n           RETURNING created_at",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "created_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "api_keys",
+            "name": "created_at"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text",
+        "Bytea",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "7bf610e70e43cccaf6a431f96b48549f6de05615c4f40fd7cdfc102cc23ab28a"
+}

--- a/server/.sqlx/query-878f52a0c78c70cf313950bd3568059b3a67d8d809cbe4281e7e33a399feaa66.json
+++ b/server/.sqlx/query-878f52a0c78c70cf313950bd3568059b3a67d8d809cbe4281e7e33a399feaa66.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE api_keys SET revoked_at = COALESCE(revoked_at, now())\n           WHERE environment_id = $1 AND id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "878f52a0c78c70cf313950bd3568059b3a67d8d809cbe4281e7e33a399feaa66"
+}

--- a/server/.sqlx/query-9bfbf8473a93a43bdd6f9f2d4a6ccb3c97c3412b79bb71771cfa9679eb0929c0.json
+++ b/server/.sqlx/query-9bfbf8473a93a43bdd6f9f2d4a6ccb3c97c3412b79bb71771cfa9679eb0929c0.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO environments\n               (id, slug, name, subscriber_hmac_secret, require_subscriber_hash)\n           VALUES ($1, $2, $3, $4, $5)\n           ON CONFLICT (slug) DO NOTHING\n           RETURNING created_at",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "created_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "environments",
+            "name": "created_at"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Text",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "9bfbf8473a93a43bdd6f9f2d4a6ccb3c97c3412b79bb71771cfa9679eb0929c0"
+}

--- a/server/.sqlx/query-db6b540e402824ca0f8e7a7d9bbd01d6cbead3d0596eee546c6f101132687623.json
+++ b/server/.sqlx/query-db6b540e402824ca0f8e7a7d9bbd01d6cbead3d0596eee546c6f101132687623.json
@@ -1,0 +1,74 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, slug, name, require_subscriber_hash, created_at\n             FROM environments ORDER BY created_at",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "environments",
+            "name": "id"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "slug",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "environments",
+            "name": "slug"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "environments",
+            "name": "name"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "require_subscriber_hash",
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "environments",
+            "name": "require_subscriber_hash"
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "environments",
+            "name": "created_at"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "db6b540e402824ca0f8e7a7d9bbd01d6cbead3d0596eee546c6f101132687623"
+}

--- a/server/.sqlx/query-ed1a051a2c9cee814bb28d3cdea295b92a6de98372046ed9b9f49048e8af4f7b.json
+++ b/server/.sqlx/query-ed1a051a2c9cee814bb28d3cdea295b92a6de98372046ed9b9f49048e8af4f7b.json
@@ -1,0 +1,36 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT status, min(occurred_at) AS \"occurred_at!\"\n             FROM notification_status_log\n            WHERE environment_id = $1 AND notification_id = $2\n            GROUP BY status ORDER BY 2, 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "status",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "notification_status_log",
+            "name": "status"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "occurred_at!",
+        "type_info": "Timestamptz",
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      null
+    ]
+  },
+  "hash": "ed1a051a2c9cee814bb28d3cdea295b92a6de98372046ed9b9f49048e8af4f7b"
+}

--- a/server/.sqlx/query-f4c69cc09fa0e8a9c8b82ecbb9e065eecc8b835754bf8a937b78c5acf5711d52.json
+++ b/server/.sqlx/query-f4c69cc09fa0e8a9c8b82ecbb9e065eecc8b835754bf8a937b78c5acf5711d52.json
@@ -1,0 +1,119 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT n.id, s.subscriber_id AS \"subscriber_id!\", n.category, n.payload,\n                  n.created_at, n.deliver_at, n.visible_at, n.read_at\n             FROM notifications n\n             JOIN subscribers s ON s.environment_id = n.environment_id\n                               AND s.id = n.subscriber_id\n            WHERE n.environment_id = $1\n              AND ($2::text IS NULL OR s.subscriber_id = $2)\n              AND ($3::text IS NULL OR n.category = $3)\n              AND ($4::timestamptz IS NULL OR n.visible_at >= $4)\n              AND ($5::timestamptz IS NULL OR n.visible_at < $5)\n              AND (n.visible_at, n.id) < ($6, $7)\n            ORDER BY n.visible_at DESC, n.id DESC\n            LIMIT $8",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "notifications",
+            "name": "id"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "subscriber_id!",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "subscribers",
+            "name": "subscriber_id"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "category",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "notifications",
+            "name": "category"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "payload",
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "notifications",
+            "name": "payload"
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "notifications",
+            "name": "created_at"
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "deliver_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "notifications",
+            "name": "deliver_at"
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "visible_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "notifications",
+            "name": "visible_at"
+          }
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "read_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "notifications",
+            "name": "read_at"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Timestamptz",
+        "Timestamptz",
+        "Timestamptz",
+        "Uuid",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true
+    ]
+  },
+  "hash": "f4c69cc09fa0e8a9c8b82ecbb9e065eecc8b835754bf8a937b78c5acf5711d52"
+}

--- a/server/.sqlx/query-f829eaa16f131ff4dabb6dc11a1833af50a083559d6adf076eca0716394ea6de.json
+++ b/server/.sqlx/query-f829eaa16f131ff4dabb6dc11a1833af50a083559d6adf076eca0716394ea6de.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE environments SET subscriber_hmac_secret_previous = NULL, updated_at = now()\n           WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "f829eaa16f131ff4dabb6dc11a1833af50a083559d6adf076eca0716394ea6de"
+}

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -645,6 +645,7 @@ dependencies = [
  "proptest",
  "rand 0.9.4",
  "reqwest 0.12.28",
+ "rust-embed",
  "serde",
  "serde_json",
  "serde_norway",
@@ -1670,6 +1671,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2433,6 +2444,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "mime_guess",
+ "sha2 0.10.9",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2524,6 +2570,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -3513,6 +3568,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3689,6 +3750,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -3876,6 +3947,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2024"
 license = "FSL-1.1-MIT"
 description = "In-app notification inbox infrastructure: one binary + Postgres + Redis."
+# Ensures admin/dist exists (placeholder when the SPA is unbuilt) so the
+# rust-embed derive and `cargo nextest`/`cargo run -- openapi` work without a
+# Node build. The Docker/CI release build populates admin/dist first.
+build = "build.rs"
 
 [lib]
 name = "dronte"
@@ -31,6 +35,11 @@ opentelemetry = "0.32.0"
 opentelemetry-otlp = { version = "0.32.0", features = ["grpc-tonic"] }
 opentelemetry_sdk = { version = "0.32.1", features = ["rt-tokio"] }
 rand = "0.9.2"
+# Embeds the admin SPA (server/admin/dist) into the binary — the single-file
+# deploy story (specs/phase-4-admin.md). debug-embed: embed in every profile
+# so tests serve the same bytes the release binary ships, no runtime disk
+# dependency. mime-guess: content types for the served assets.
+rust-embed = { version = "8.5.0", features = ["mime-guess", "debug-embed"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 # Already in the tree via utoipa's yaml feature. Direct use: the 3.0.3

--- a/server/admin/index.html
+++ b/server/admin/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <title>Dronte admin</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/server/admin/package.json
+++ b/server/admin/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "dronte-admin",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Dronte embedded admin dashboard (served at /admin by the dronte binary).",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.6",
+    "@radix-ui/react-label": "^2.1.2",
+    "@radix-ui/react-separator": "^1.1.2",
+    "@radix-ui/react-slot": "^1.1.2",
+    "@radix-ui/react-tabs": "^1.1.3",
+    "@tanstack/react-query": "^5.66.0",
+    "@tanstack/react-router": "^1.99.0",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.474.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "recharts": "^2.15.1",
+    "sonner": "^1.7.4",
+    "tailwind-merge": "^3.0.2"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.0.6",
+    "@types/node": "^22.13.1",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^4.3.4",
+    "tailwindcss": "^4.0.6",
+    "typescript": "^6.0.3",
+    "vite": "^6.1.0"
+  }
+}

--- a/server/admin/src/components/copy-field.tsx
+++ b/server/admin/src/components/copy-field.tsx
@@ -1,0 +1,46 @@
+import { Check, Copy, Eye, EyeOff } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+export function CopyField({
+  value,
+  maskable = false,
+}: {
+  value: string;
+  maskable?: boolean;
+}) {
+  const [copied, setCopied] = useState(false);
+  const [revealed, setRevealed] = useState(!maskable);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      toast.success('Copied to clipboard');
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      toast.error('Could not copy');
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <Input
+        readOnly
+        value={revealed ? value : '•'.repeat(Math.min(value.length, 32))}
+        className="font-mono"
+        onFocus={(e) => e.currentTarget.select()}
+      />
+      {maskable && (
+        <Button variant="outline" size="icon" onClick={() => setRevealed((r) => !r)} type="button">
+          {revealed ? <EyeOff /> : <Eye />}
+        </Button>
+      )}
+      <Button variant="outline" size="icon" onClick={copy} type="button">
+        {copied ? <Check className="text-success" /> : <Copy />}
+      </Button>
+    </div>
+  );
+}

--- a/server/admin/src/components/env-nav.tsx
+++ b/server/admin/src/components/env-nav.tsx
@@ -1,0 +1,30 @@
+import { Link } from '@tanstack/react-router';
+import { cn } from '@/lib/utils';
+
+const TABS = [
+  { to: '/environments/$envId', label: 'Overview', exact: true },
+  { to: '/environments/$envId/notifications', label: 'Notifications', exact: false },
+  { to: '/environments/$envId/broadcasts', label: 'Broadcast', exact: false },
+  { to: '/environments/$envId/subscribers', label: 'Subscriber lookup', exact: false },
+] as const;
+
+export function EnvNav({ envId }: { envId: string }) {
+  return (
+    <nav className="flex flex-wrap gap-1 border-b border-border pb-2">
+      {TABS.map((t) => (
+        <Link
+          key={t.to}
+          to={t.to}
+          params={{ envId }}
+          activeOptions={{ exact: t.exact }}
+          className="rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          activeProps={{
+            className: cn('rounded-md px-3 py-1.5 text-sm font-medium', 'bg-primary/10 text-primary'),
+          }}
+        >
+          {t.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/server/admin/src/components/layout.tsx
+++ b/server/admin/src/components/layout.tsx
@@ -1,0 +1,101 @@
+import { Link, Outlet } from '@tanstack/react-router';
+import { AlertTriangle, Boxes, LayoutDashboard, Monitor, Moon, Sun } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Select } from '@/components/ui/select';
+import { useTheme } from '@/lib/theme';
+import { cn } from '@/lib/utils';
+
+const NAV = [
+  { to: '/', label: 'Dashboard', icon: LayoutDashboard, exact: true },
+  { to: '/environments', label: 'Environments', icon: Boxes, exact: false },
+  { to: '/dlq', label: 'Dead-letter queue', icon: AlertTriangle, exact: true },
+] as const;
+
+function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const icon =
+    theme === 'dark' ? <Moon className="size-4" /> : theme === 'light' ? <Sun className="size-4" /> : <Monitor className="size-4" />;
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-muted-foreground">{icon}</span>
+      <Select
+        aria-label="Theme"
+        value={theme}
+        onChange={(e) => setTheme(e.target.value as 'light' | 'dark' | 'system')}
+        className="h-8 w-28"
+      >
+        <option value="system">System</option>
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+      </Select>
+    </div>
+  );
+}
+
+function Unauthorized() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-6 text-center">
+      <h1 className="text-xl font-semibold">Session expired</h1>
+      <p className="max-w-sm text-muted-foreground">
+        Your admin credential is no longer valid. Reload the page to re-authenticate.
+      </p>
+      <Button onClick={() => window.location.reload()}>Reload</Button>
+    </div>
+  );
+}
+
+export function Layout() {
+  const [unauthorized, setUnauthorized] = useState(false);
+
+  useEffect(() => {
+    const handler = () => setUnauthorized(true);
+    window.addEventListener('dronte-admin-unauthorized', handler);
+    return () => window.removeEventListener('dronte-admin-unauthorized', handler);
+  }, []);
+
+  if (unauthorized) return <Unauthorized />;
+
+  return (
+    <div className="grid min-h-screen grid-cols-[15rem_1fr] max-md:grid-cols-1">
+      <aside className="flex flex-col border-r border-border bg-card max-md:hidden">
+        <div className="flex h-14 items-center gap-2 px-5">
+          <span className="inline-block size-2.5 rounded-full bg-primary" />
+          <span className="text-lg font-semibold tracking-tight">Dronte</span>
+          <span className="text-xs text-muted-foreground">admin</span>
+        </div>
+        <nav className="flex flex-1 flex-col gap-1 p-3">
+          {NAV.map(({ to, label, icon: Icon, exact }) => (
+            <Link
+              key={to}
+              to={to}
+              activeOptions={{ exact }}
+              className="flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              activeProps={{
+                className: cn(
+                  'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                  'bg-primary/10 text-primary',
+                ),
+              }}
+            >
+              <Icon className="size-4" />
+              {label}
+            </Link>
+          ))}
+        </nav>
+        <div className="border-t border-border p-3">
+          <ThemeToggle />
+        </div>
+      </aside>
+      <main className="min-w-0 overflow-x-hidden">
+        <header className="flex h-14 items-center justify-between gap-4 border-b border-border px-6 md:hidden">
+          <span className="font-semibold">Dronte admin</span>
+          <ThemeToggle />
+        </header>
+        <div className="mx-auto max-w-6xl p-6">
+          <Outlet />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/server/admin/src/components/states.tsx
+++ b/server/admin/src/components/states.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from 'react';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function EmptyState({ title, hint }: { title: string; hint?: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-1 rounded-lg border border-dashed border-border py-12 text-center">
+      <p className="font-medium">{title}</p>
+      {hint && <p className="text-sm text-muted-foreground">{hint}</p>}
+    </div>
+  );
+}
+
+export function ErrorState({ message }: { message: string }) {
+  return (
+    <div className="rounded-lg border border-danger/40 bg-danger/10 p-4 text-sm text-danger">
+      {message}
+    </div>
+  );
+}
+
+export function TableSkeleton({ rows = 5, cols = 4 }: { rows?: number; cols?: number }) {
+  return (
+    <div className="flex flex-col gap-2">
+      {Array.from({ length: rows }).map((_, r) => (
+        <div key={r} className="flex gap-3">
+          {Array.from({ length: cols }).map((_, c) => (
+            <Skeleton key={c} className="h-8 flex-1" />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function Async<T>({
+  query,
+  children,
+  emptyTitle,
+}: {
+  query: { isLoading: boolean; isError: boolean; error: unknown; data: T | undefined };
+  children: (data: T) => ReactNode;
+  emptyTitle?: string;
+}) {
+  if (query.isLoading) return <TableSkeleton />;
+  if (query.isError) {
+    const message = query.error instanceof Error ? query.error.message : 'Request failed';
+    return <ErrorState message={message} />;
+  }
+  if (query.data === undefined) return <EmptyState title={emptyTitle ?? 'No data'} />;
+  return <>{children(query.data)}</>;
+}

--- a/server/admin/src/components/status-badge.tsx
+++ b/server/admin/src/components/status-badge.tsx
@@ -1,0 +1,37 @@
+import { Badge } from '@/components/ui/badge';
+
+// Maps notification/job states to the semantic palette. State is the ONLY
+// thing color encodes here.
+const STATUS_VARIANT: Record<
+  string,
+  'neutral' | 'default' | 'success' | 'warning' | 'warningHi' | 'danger'
+> = {
+  created: 'neutral',
+  delivered_hint: 'default',
+  seen: 'default',
+  read: 'success',
+  retrying: 'warning',
+  near_dlq: 'warningHi',
+  failed: 'danger',
+  parked: 'danger',
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  created: 'created',
+  delivered_hint: 'delivered',
+  seen: 'seen',
+  read: 'read',
+};
+
+export function StatusBadge({ status }: { status: string }) {
+  const variant = STATUS_VARIANT[status] ?? 'neutral';
+  return <Badge variant={variant}>{STATUS_LABEL[status] ?? status}</Badge>;
+}
+
+export function ReadBadge({ read }: { read: boolean }) {
+  return read ? (
+    <Badge variant="success">read</Badge>
+  ) : (
+    <Badge variant="default">unread</Badge>
+  );
+}

--- a/server/admin/src/components/ui/badge.tsx
+++ b/server/admin/src/components/ui/badge.tsx
@@ -1,0 +1,33 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import type { HTMLAttributes } from 'react';
+import { cn } from '@/lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium whitespace-nowrap',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary/10 text-primary',
+        neutral: 'border-border bg-muted text-muted-foreground',
+        outline: 'border-border text-foreground',
+        // Semantic state badges — tinted background, state-colored text.
+        success: 'border-transparent bg-success/15 text-success-foreground dark:text-success',
+        warning: 'border-transparent bg-warning/20 text-warning-foreground dark:text-warning',
+        warningHi:
+          'border-transparent bg-warning-hi/15 text-warning-hi-foreground dark:text-warning-hi',
+        danger: 'border-transparent bg-danger/15 text-danger',
+      },
+    },
+    defaultVariants: { variant: 'default' },
+  },
+);
+
+export interface BadgeProps
+  extends HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof badgeVariants> {}
+
+export function Badge({ className, variant, ...props }: BadgeProps) {
+  return <span className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { badgeVariants };

--- a/server/admin/src/components/ui/button.tsx
+++ b/server/admin/src/components/ui/button.tsx
@@ -1,0 +1,41 @@
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import type { ButtonHTMLAttributes } from 'react';
+import { cn } from '@/lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-2 focus-visible:outline-ring focus-visible:outline-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0 cursor-pointer',
+  {
+    variants: {
+      variant: {
+        // Brand: accent default, deep-accent on hover (section/hover accent).
+        default: 'bg-primary text-primary-foreground hover:bg-primary-deep',
+        destructive: 'bg-destructive text-destructive-foreground hover:opacity-90',
+        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-accent',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline hover:text-primary-deep',
+      },
+      size: {
+        default: 'h-9 px-4 py-2',
+        sm: 'h-8 rounded-md px-3 text-xs',
+        lg: 'h-10 rounded-md px-6',
+        icon: 'size-9',
+      },
+    },
+    defaultVariants: { variant: 'default', size: 'default' },
+  },
+);
+
+export interface ButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+export function Button({ className, variant, size, asChild = false, ...props }: ButtonProps) {
+  const Comp = asChild ? Slot : 'button';
+  return <Comp className={cn(buttonVariants({ variant, size, className }))} {...props} />;
+}
+
+export { buttonVariants };

--- a/server/admin/src/components/ui/card.tsx
+++ b/server/admin/src/components/ui/card.tsx
@@ -1,0 +1,31 @@
+import type { HTMLAttributes } from 'react';
+import { cn } from '@/lib/utils';
+
+export function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('rounded-xl border border-border bg-card text-card-foreground shadow-sm', className)}
+      {...props}
+    />
+  );
+}
+
+export function CardHeader({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('flex flex-col gap-1.5 p-6', className)} {...props} />;
+}
+
+export function CardTitle({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('font-semibold leading-none tracking-tight', className)} {...props} />;
+}
+
+export function CardDescription({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('text-sm text-muted-foreground', className)} {...props} />;
+}
+
+export function CardContent({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('p-6 pt-0', className)} {...props} />;
+}
+
+export function CardFooter({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('flex items-center p-6 pt-0', className)} {...props} />;
+}

--- a/server/admin/src/components/ui/dialog.tsx
+++ b/server/admin/src/components/ui/dialog.tsx
@@ -1,0 +1,64 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import type { ComponentProps } from 'react';
+import { cn } from '@/lib/utils';
+
+export const Dialog = DialogPrimitive.Root;
+export const DialogTrigger = DialogPrimitive.Trigger;
+export const DialogClose = DialogPrimitive.Close;
+
+export function DialogContent({
+  className,
+  children,
+  ...props
+}: ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPrimitive.Portal>
+      <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=open]:fade-in-0" />
+      <DialogPrimitive.Content
+        className={cn(
+          'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl border border-border bg-card p-6 shadow-lg',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus-visible:outline-2 focus-visible:outline-ring">
+          <X className="size-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPrimitive.Portal>
+  );
+}
+
+export function DialogHeader({ className, ...props }: ComponentProps<'div'>) {
+  return <div className={cn('flex flex-col gap-1.5', className)} {...props} />;
+}
+
+export function DialogFooter({ className, ...props }: ComponentProps<'div'>) {
+  return (
+    <div className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)} {...props} />
+  );
+}
+
+export function DialogTitle({ className, ...props }: ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+      {...props}
+    />
+  );
+}
+
+export function DialogDescription({
+  className,
+  ...props
+}: ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}

--- a/server/admin/src/components/ui/input.tsx
+++ b/server/admin/src/components/ui/input.tsx
@@ -1,0 +1,15 @@
+import type { InputHTMLAttributes } from 'react';
+import { cn } from '@/lib/utils';
+
+export function Input({ className, type, ...props }: InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      type={type}
+      className={cn(
+        'flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-2 focus-visible:outline-ring focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/server/admin/src/components/ui/label.tsx
+++ b/server/admin/src/components/ui/label.tsx
@@ -1,0 +1,12 @@
+import * as LabelPrimitive from '@radix-ui/react-label';
+import type { ComponentProps } from 'react';
+import { cn } from '@/lib/utils';
+
+export function Label({ className, ...props }: ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      className={cn('text-sm font-medium leading-none', className)}
+      {...props}
+    />
+  );
+}

--- a/server/admin/src/components/ui/select.tsx
+++ b/server/admin/src/components/ui/select.tsx
@@ -1,0 +1,15 @@
+import type { SelectHTMLAttributes } from 'react';
+import { cn } from '@/lib/utils';
+
+// Native select, styled to match the input. Avoids a Radix Select dependency.
+export function Select({ className, ...props }: SelectHTMLAttributes<HTMLSelectElement>) {
+  return (
+    <select
+      className={cn(
+        'flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-2 focus-visible:outline-ring focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/server/admin/src/components/ui/separator.tsx
+++ b/server/admin/src/components/ui/separator.tsx
@@ -1,0 +1,23 @@
+import * as SeparatorPrimitive from '@radix-ui/react-separator';
+import type { ComponentProps } from 'react';
+import { cn } from '@/lib/utils';
+
+export function Separator({
+  className,
+  orientation = 'horizontal',
+  decorative = true,
+  ...props
+}: ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        'shrink-0 bg-border',
+        orientation === 'horizontal' ? 'h-px w-full' : 'h-full w-px',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/server/admin/src/components/ui/skeleton.tsx
+++ b/server/admin/src/components/ui/skeleton.tsx
@@ -1,0 +1,6 @@
+import type { HTMLAttributes } from 'react';
+import { cn } from '@/lib/utils';
+
+export function Skeleton({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('animate-pulse rounded-md bg-muted', className)} {...props} />;
+}

--- a/server/admin/src/components/ui/table.tsx
+++ b/server/admin/src/components/ui/table.tsx
@@ -1,0 +1,43 @@
+import type { HTMLAttributes, TdHTMLAttributes, ThHTMLAttributes } from 'react';
+import { cn } from '@/lib/utils';
+
+export function Table({ className, ...props }: HTMLAttributes<HTMLTableElement>) {
+  return (
+    <div className="relative w-full overflow-x-auto">
+      <table className={cn('w-full caption-bottom text-sm', className)} {...props} />
+    </div>
+  );
+}
+
+export function TableHeader({ className, ...props }: HTMLAttributes<HTMLTableSectionElement>) {
+  return <thead className={cn('[&_tr]:border-b', className)} {...props} />;
+}
+
+export function TableBody({ className, ...props }: HTMLAttributes<HTMLTableSectionElement>) {
+  return <tbody className={cn('[&_tr:last-child]:border-0', className)} {...props} />;
+}
+
+export function TableRow({ className, ...props }: HTMLAttributes<HTMLTableRowElement>) {
+  return (
+    <tr
+      className={cn('border-b border-border transition-colors hover:bg-muted/50', className)}
+      {...props}
+    />
+  );
+}
+
+export function TableHead({ className, ...props }: ThHTMLAttributes<HTMLTableCellElement>) {
+  return (
+    <th
+      className={cn(
+        'h-10 px-3 text-left align-middle text-xs font-medium text-muted-foreground uppercase tracking-wide',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function TableCell({ className, ...props }: TdHTMLAttributes<HTMLTableCellElement>) {
+  return <td className={cn('px-3 py-2.5 align-middle', className)} {...props} />;
+}

--- a/server/admin/src/components/ui/tabs.tsx
+++ b/server/admin/src/components/ui/tabs.tsx
@@ -1,0 +1,33 @@
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+import type { ComponentProps } from 'react';
+import { cn } from '@/lib/utils';
+
+export const Tabs = TabsPrimitive.Root;
+
+export function TabsList({ className, ...props }: ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      className={cn(
+        'inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function TabsTrigger({ className, ...props }: ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      className={cn(
+        'inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-all focus-visible:outline-2 focus-visible:outline-ring data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm cursor-pointer',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function TabsContent({ className, ...props }: ComponentProps<typeof TabsPrimitive.Content>) {
+  return <TabsPrimitive.Content className={cn('mt-4 focus-visible:outline-none', className)} {...props} />;
+}

--- a/server/admin/src/components/ui/textarea.tsx
+++ b/server/admin/src/components/ui/textarea.tsx
@@ -1,0 +1,14 @@
+import type { TextareaHTMLAttributes } from 'react';
+import { cn } from '@/lib/utils';
+
+export function Textarea({ className, ...props }: TextareaHTMLAttributes<HTMLTextAreaElement>) {
+  return (
+    <textarea
+      className={cn(
+        'flex min-h-20 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-2 focus-visible:outline-ring focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 font-mono',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/server/admin/src/index.css
+++ b/server/admin/src/index.css
@@ -1,0 +1,169 @@
+@import 'tailwindcss';
+
+/* Manual dark mode: toggled by a `.dark` class on <html> (see theme.tsx),
+   not prefers-color-scheme, so the in-app toggle wins. */
+@custom-variant dark (&:where(.dark, .dark *));
+
+/*
+  Dronte / Dodo brand palette.
+  --primary       #1264FF  accent: primary actions, links, focus, active nav
+  --primary-deep  #004F32  deep accent: hover/section accents
+  base dark       #0D0D0D  dark-mode foundation (inverted for light)
+  Semantic (state ONLY, never decoration):
+  --success #00D87D  --warning #FFD84B  --warning-hi #FF8B37  --danger #E83439
+  The lime green #C6FE1E is deliberately excluded.
+*/
+:root {
+  --radius: 0.625rem;
+
+  --background: #ffffff;
+  --foreground: #0d0d0d;
+  --card: #ffffff;
+  --card-foreground: #0d0d0d;
+  --popover: #ffffff;
+  --popover-foreground: #0d0d0d;
+
+  --primary: #1264ff;
+  --primary-foreground: #ffffff;
+  --primary-deep: #004f32;
+
+  --secondary: #f4f5f7;
+  --secondary-foreground: #0d0d0d;
+  --muted: #f4f5f7;
+  --muted-foreground: #5b6573;
+  --accent: #eef1f5;
+  --accent-foreground: #0d0d0d;
+
+  --destructive: #e83439;
+  --destructive-foreground: #ffffff;
+
+  --border: #e3e6ea;
+  --input: #e3e6ea;
+  --ring: #1264ff;
+
+  /* Semantic state colors. */
+  --success: #00d87d;
+  --success-foreground: #00351f;
+  --warning: #ffd84b;
+  --warning-foreground: #3d2f00;
+  --warning-hi: #ff8b37;
+  --warning-hi-foreground: #3a1c00;
+  --danger: #e83439;
+  --danger-foreground: #ffffff;
+
+  /* Charts read as success / accent / warning / warning-hi / danger so a
+     glance at a chart conveys state, not arbitrary hues. */
+  --chart-1: #00d87d;
+  --chart-2: #1264ff;
+  --chart-3: #ffd84b;
+  --chart-4: #ff8b37;
+  --chart-5: #e83439;
+}
+
+.dark {
+  --background: #0d0d0d;
+  --foreground: #f5f6f7;
+  --card: #141414;
+  --card-foreground: #f5f6f7;
+  --popover: #141414;
+  --popover-foreground: #f5f6f7;
+
+  --primary: #1264ff;
+  --primary-foreground: #ffffff;
+  --primary-deep: #1f8a5a;
+
+  --secondary: #1b1b1b;
+  --secondary-foreground: #f5f6f7;
+  --muted: #1b1b1b;
+  --muted-foreground: #a1a8b3;
+  --accent: #1f1f1f;
+  --accent-foreground: #f5f6f7;
+
+  --destructive: #e83439;
+  --destructive-foreground: #ffffff;
+
+  --border: #262626;
+  --input: #262626;
+  --ring: #1264ff;
+
+  --success: #00d87d;
+  --success-foreground: #d5fff0;
+  --warning: #ffd84b;
+  --warning-foreground: #fff6d6;
+  --warning-hi: #ff8b37;
+  --warning-hi-foreground: #ffe6d4;
+  --danger: #e83439;
+  --danger-foreground: #ffffff;
+
+  --chart-1: #00d87d;
+  --chart-2: #4d8bff;
+  --chart-3: #ffd84b;
+  --chart-4: #ff8b37;
+  --chart-5: #ff5a5f;
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-primary-deep: var(--primary-deep);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
+  --color-warning-hi: var(--warning-hi);
+  --color-warning-hi-foreground: var(--warning-hi-foreground);
+  --color-danger: var(--danger);
+  --color-danger-foreground: var(--danger-foreground);
+
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+}
+
+* {
+  border-color: var(--color-border);
+}
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--color-background);
+  color: var(--color-foreground);
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+:focus-visible {
+  outline: 2px solid var(--color-ring);
+  outline-offset: 2px;
+}

--- a/server/admin/src/lib/api.ts
+++ b/server/admin/src/lib/api.ts
@@ -1,0 +1,234 @@
+// Admin API client. Every endpoint is same-origin under /admin/api/* and
+// gated by HTTP Basic auth; the browser holds the credential (it prompted on
+// the first /admin load) and attaches it to same-origin fetches automatically.
+
+export interface ApiError {
+  status: number;
+  code: string;
+  message: string;
+}
+
+export class ApiRequestError extends Error {
+  status: number;
+  code: string;
+  constructor(err: ApiError) {
+    super(err.message);
+    this.status = err.status;
+    this.code = err.code;
+  }
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`/admin/api${path}`, {
+    ...init,
+    credentials: 'same-origin',
+    headers: {
+      ...(init?.body ? { 'Content-Type': 'application/json' } : {}),
+      ...init?.headers,
+    },
+  });
+
+  if (res.status === 401) {
+    window.dispatchEvent(new CustomEvent('dronte-admin-unauthorized'));
+    throw new ApiRequestError({ status: 401, code: 'unauthorized', message: 'Session expired' });
+  }
+
+  if (!res.ok) {
+    let code = 'error';
+    let message = `Request failed (${res.status})`;
+    try {
+      const body = (await res.json()) as { error?: { code?: string; message?: string } };
+      if (body.error) {
+        code = body.error.code ?? code;
+        message = body.error.message ?? message;
+      }
+    } catch {
+      /* non-JSON error body */
+    }
+    throw new ApiRequestError({ status: res.status, code, message });
+  }
+
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+const get = <T,>(path: string) => request<T>(path);
+const post = <T,>(path: string, body?: unknown) =>
+  request<T>(path, { method: 'POST', body: body === undefined ? undefined : JSON.stringify(body) });
+
+// ----- Types (mirror server/src/api/admin.rs) -------------------------------
+
+export interface AdminEnvironment {
+  id: string;
+  slug: string;
+  name: string;
+  require_subscriber_hash: boolean;
+  created_at: string;
+}
+
+export interface AdminEnvironmentDetail extends AdminEnvironment {
+  subscriber_hmac_secret: string;
+  has_previous_secret: boolean;
+  subscriber_hmac_rotated_at: string | null;
+}
+
+export interface AdminHmacRotation {
+  subscriber_hmac_secret: string;
+  has_previous_secret: boolean;
+  subscriber_hmac_rotated_at: string | null;
+}
+
+export interface AdminApiKey {
+  id: string;
+  name: string;
+  key_prefix: string;
+  created_at: string;
+  last_used_at: string | null;
+  revoked_at: string | null;
+}
+
+export interface AdminApiKeyCreated {
+  id: string;
+  name: string;
+  key_prefix: string;
+  key: string;
+  created_at: string;
+}
+
+export interface AdminNotification {
+  id: string;
+  subscriber_id: string;
+  category: string;
+  payload: Record<string, unknown>;
+  created_at: string;
+  deliver_at: string | null;
+  visible_at: string;
+  read_at: string | null;
+}
+
+export interface AdminNotificationPage {
+  items: AdminNotification[];
+  next_cursor: string | null;
+}
+
+export interface AdminTimelineEntry {
+  status: string;
+  occurred_at: string;
+}
+
+export interface AdminNotificationTimeline {
+  id: string;
+  subscriber_id: string;
+  timeline: AdminTimelineEntry[];
+}
+
+export interface AdminPreference {
+  category: string;
+  channel: string;
+  enabled: boolean;
+}
+
+export interface AdminInboxItem {
+  id: string;
+  source: string;
+  category: string;
+  payload: Record<string, unknown>;
+  occurred_at: string;
+  read: boolean;
+}
+
+export interface AdminCounts {
+  unread: number;
+  unseen: number;
+}
+
+export interface AdminSubscriberView {
+  subscriber_id: string;
+  created_at: string;
+  counters: AdminCounts;
+  read_watermark: string;
+  seen_watermark: string;
+  preferences: AdminPreference[];
+  inbox: AdminInboxItem[];
+}
+
+export interface AdminDeadLetter {
+  id: string;
+  environment_slug: string;
+  job_type: string;
+  attempts: number;
+  last_error: string;
+  parked_at: string;
+}
+
+export interface AdminReplayResult {
+  replayed: number;
+}
+
+export interface Broadcast {
+  id: string;
+  category: string;
+  payload: Record<string, unknown>;
+  created_at: string;
+  idempotency_key: string;
+}
+
+// ----- Endpoints ------------------------------------------------------------
+
+const enc = encodeURIComponent;
+
+export interface NotificationFilter {
+  subscriber_id?: string;
+  category?: string;
+  after?: string;
+  before?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export const api = {
+  listEnvironments: () => get<AdminEnvironment[]>('/environments'),
+  createEnvironment: (body: { slug: string; name: string; require_subscriber_hash: boolean }) =>
+    post<AdminEnvironmentDetail>('/environments', body),
+  getEnvironment: (envId: string) => get<AdminEnvironmentDetail>(`/environments/${enc(envId)}`),
+  rotateHmac: (envId: string) =>
+    post<AdminHmacRotation>(`/environments/${enc(envId)}/hmac/rotate`),
+  completeHmacRotation: (envId: string) =>
+    post<void>(`/environments/${enc(envId)}/hmac/rotate/complete`),
+
+  listApiKeys: (envId: string) => get<AdminApiKey[]>(`/environments/${enc(envId)}/api-keys`),
+  createApiKey: (envId: string, name: string) =>
+    post<AdminApiKeyCreated>(`/environments/${enc(envId)}/api-keys`, { name }),
+  revokeApiKey: (envId: string, keyId: string) =>
+    post<void>(`/environments/${enc(envId)}/api-keys/${enc(keyId)}/revoke`),
+
+  listNotifications: (envId: string, filter: NotificationFilter) => {
+    const q = new URLSearchParams();
+    if (filter.subscriber_id) q.set('subscriber_id', filter.subscriber_id);
+    if (filter.category) q.set('category', filter.category);
+    if (filter.after) q.set('after', filter.after);
+    if (filter.before) q.set('before', filter.before);
+    if (filter.limit != null) q.set('limit', String(filter.limit));
+    if (filter.cursor) q.set('cursor', filter.cursor);
+    const qs = q.toString();
+    return get<AdminNotificationPage>(
+      `/environments/${enc(envId)}/notifications${qs ? `?${qs}` : ''}`,
+    );
+  },
+  notificationTimeline: (envId: string, notifId: string) =>
+    get<AdminNotificationTimeline>(
+      `/environments/${enc(envId)}/notifications/${enc(notifId)}/timeline`,
+    ),
+
+  createBroadcast: (
+    envId: string,
+    body: { category: string; payload?: Record<string, unknown>; idempotency_key?: string },
+  ) => post<Broadcast>(`/environments/${enc(envId)}/broadcasts`, body),
+
+  getSubscriber: (envId: string, subscriberId: string) =>
+    get<AdminSubscriberView>(`/environments/${enc(envId)}/subscribers/${enc(subscriberId)}`),
+
+  listDlq: () => get<AdminDeadLetter[]>('/dlq'),
+  replayDeadLetter: (jobId: string) => post<AdminReplayResult>(`/dlq/${enc(jobId)}/replay`),
+  replayAllDeadLetters: () => post<AdminReplayResult>('/dlq/replay-all'),
+};

--- a/server/admin/src/lib/theme.tsx
+++ b/server/admin/src/lib/theme.tsx
@@ -1,0 +1,62 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+
+type Theme = 'light' | 'dark' | 'system';
+
+interface ThemeContextValue {
+  theme: Theme;
+  resolved: 'light' | 'dark';
+  setTheme: (t: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+const STORAGE_KEY = 'dronte-admin-theme';
+
+function systemPrefersDark(): boolean {
+  return typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches;
+}
+
+function resolve(theme: Theme): 'light' | 'dark' {
+  if (theme === 'system') return systemPrefersDark() ? 'dark' : 'light';
+  return theme;
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored === 'light' || stored === 'dark' || stored === 'system' ? stored : 'system';
+  });
+  const [resolved, setResolved] = useState<'light' | 'dark'>(() => resolve(theme));
+
+  useEffect(() => {
+    const r = resolve(theme);
+    setResolved(r);
+    document.documentElement.classList.toggle('dark', r === 'dark');
+  }, [theme]);
+
+  useEffect(() => {
+    if (theme !== 'system') return;
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const onChange = () => {
+      const r = systemPrefersDark() ? 'dark' : 'light';
+      setResolved(r);
+      document.documentElement.classList.toggle('dark', r === 'dark');
+    };
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
+  }, [theme]);
+
+  const setTheme = (t: Theme) => {
+    localStorage.setItem(STORAGE_KEY, t);
+    setThemeState(t);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, resolved, setTheme }}>{children}</ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+  return ctx;
+}

--- a/server/admin/src/lib/utils.ts
+++ b/server/admin/src/lib/utils.ts
@@ -1,0 +1,20 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+export function formatTs(ts: string | null | undefined): string {
+  if (!ts) return '—';
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return ts;
+  return d.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}

--- a/server/admin/src/main.tsx
+++ b/server/admin/src/main.tsx
@@ -1,0 +1,33 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { RouterProvider } from '@tanstack/react-router';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { Toaster } from 'sonner';
+import { ThemeProvider, useTheme } from '@/lib/theme';
+import { router } from '@/router';
+import './index.css';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { staleTime: 10_000, retry: 1, refetchOnWindowFocus: false },
+  },
+});
+
+function ThemedToaster() {
+  const { resolved } = useTheme();
+  return <Toaster theme={resolved} richColors position="top-right" />;
+}
+
+const rootEl = document.getElementById('root');
+if (!rootEl) throw new Error('#root not found');
+
+createRoot(rootEl).render(
+  <StrictMode>
+    <ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+        <ThemedToaster />
+      </QueryClientProvider>
+    </ThemeProvider>
+  </StrictMode>,
+);

--- a/server/admin/src/router.tsx
+++ b/server/admin/src/router.tsx
@@ -1,0 +1,75 @@
+import { createRootRoute, createRoute, createRouter } from '@tanstack/react-router';
+import { Layout } from '@/components/layout';
+import { BroadcastsRoute } from '@/routes/broadcasts';
+import { DashboardRoute } from '@/routes/dashboard';
+import { DlqRoute } from '@/routes/dlq';
+import { EnvironmentDetailRoute } from '@/routes/environment-detail';
+import { EnvironmentsRoute } from '@/routes/environments';
+import { NotificationsRoute } from '@/routes/notifications';
+import { SubscribersRoute } from '@/routes/subscribers';
+
+const rootRoute = createRootRoute({ component: Layout });
+
+const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/',
+  component: DashboardRoute,
+});
+
+const environmentsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: 'environments',
+  component: EnvironmentsRoute,
+});
+
+const environmentDetailRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: 'environments/$envId',
+  component: EnvironmentDetailRoute,
+});
+
+const notificationsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: 'environments/$envId/notifications',
+  component: NotificationsRoute,
+});
+
+const broadcastsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: 'environments/$envId/broadcasts',
+  component: BroadcastsRoute,
+});
+
+const subscribersRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: 'environments/$envId/subscribers',
+  component: SubscribersRoute,
+});
+
+const dlqRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: 'dlq',
+  component: DlqRoute,
+});
+
+const routeTree = rootRoute.addChildren([
+  indexRoute,
+  environmentsRoute,
+  environmentDetailRoute,
+  notificationsRoute,
+  broadcastsRoute,
+  subscribersRoute,
+  dlqRoute,
+]);
+
+export const router = createRouter({
+  routeTree,
+  basepath: '/admin',
+  defaultPreload: 'intent',
+});
+
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router;
+  }
+}

--- a/server/admin/src/routes/broadcasts.tsx
+++ b/server/admin/src/routes/broadcasts.tsx
@@ -1,0 +1,140 @@
+import { useMutation } from '@tanstack/react-query';
+import { useParams } from '@tanstack/react-router';
+import { Radio } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { EnvNav } from '@/components/env-nav';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { api, ApiRequestError } from '@/lib/api';
+
+export function BroadcastsRoute() {
+  const { envId } = useParams({ strict: false }) as { envId: string };
+  const [category, setCategory] = useState('');
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [actionUrl, setActionUrl] = useState('');
+  const [iconUrl, setIconUrl] = useState('');
+  const [extraJson, setExtraJson] = useState('');
+  const [idemKey, setIdemKey] = useState('');
+  const [lastId, setLastId] = useState<string | null>(null);
+
+  const compose = useMutation({
+    mutationFn: () => {
+      const payload: Record<string, unknown> = {};
+      if (title) payload.title = title;
+      if (body) payload.body = body;
+      if (actionUrl) payload.action_url = actionUrl;
+      if (iconUrl) payload.icon_url = iconUrl;
+      if (extraJson.trim()) {
+        const extra = JSON.parse(extraJson) as Record<string, unknown>;
+        Object.assign(payload, extra);
+      }
+      return api.createBroadcast(envId, {
+        category,
+        payload,
+        idempotency_key: idemKey || undefined,
+      });
+    },
+    onSuccess: (b) => {
+      setLastId(b.id);
+      toast.success(`Broadcast ${b.id} composed`);
+    },
+    onError: (e) => {
+      if (e instanceof SyntaxError) toast.error('Extra JSON is not valid JSON');
+      else toast.error(e instanceof ApiRequestError ? e.message : 'Failed to compose');
+    },
+  });
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Compose broadcast</h1>
+        <p className="text-sm text-muted-foreground">
+          One row per announcement, fanned out on read — never materialized per subscriber.
+        </p>
+      </div>
+      <EnvNav envId={envId} />
+
+      <Card className="max-w-2xl">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Radio className="size-4 text-primary" /> New broadcast
+          </CardTitle>
+          <CardDescription>
+            Subscribers see it only if it was created at or after their own creation time.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form
+            className="flex flex-col gap-4"
+            onSubmit={(e) => {
+              e.preventDefault();
+              compose.mutate();
+            }}
+          >
+            <Field label="Category" required>
+              <Input value={category} onChange={(e) => setCategory(e.target.value)} placeholder="product.update" required />
+            </Field>
+            <div className="rounded-md border border-border p-4">
+              <p className="mb-3 text-sm font-medium">Well-known payload fields</p>
+              <div className="flex flex-col gap-4">
+                <Field label="Title">
+                  <Input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="We shipped X" />
+                </Field>
+                <Field label="Body">
+                  <Textarea value={body} onChange={(e) => setBody(e.target.value)} className="font-sans" placeholder="Plain text, never HTML." />
+                </Field>
+                <Field label="Action URL">
+                  <Input value={actionUrl} onChange={(e) => setActionUrl(e.target.value)} placeholder="https://example.com/changelog" />
+                </Field>
+                <Field label="Icon URL">
+                  <Input value={iconUrl} onChange={(e) => setIconUrl(e.target.value)} placeholder="https://example.com/icon.png" />
+                </Field>
+              </div>
+            </div>
+            <Field label="Extra payload (JSON, merged into the well-known fields)">
+              <Textarea
+                value={extraJson}
+                onChange={(e) => setExtraJson(e.target.value)}
+                placeholder={'{\n  "feature_flag": "beta"\n}'}
+              />
+            </Field>
+            <Field label="Idempotency key (optional)">
+              <Input value={idemKey} onChange={(e) => setIdemKey(e.target.value)} placeholder="auto-generated if blank" />
+            </Field>
+            <div className="flex items-center gap-3">
+              <Button type="submit" disabled={compose.isPending}>
+                {compose.isPending ? 'Composing…' : 'Compose broadcast'}
+              </Button>
+              {lastId && <span className="font-mono text-sm text-success-foreground dark:text-success">{lastId}</span>}
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  required,
+  children,
+}: {
+  label: string;
+  required?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label>
+        {label}
+        {required && <span className="text-danger"> *</span>}
+      </Label>
+      {children}
+    </div>
+  );
+}

--- a/server/admin/src/routes/dashboard.tsx
+++ b/server/admin/src/routes/dashboard.tsx
@@ -1,0 +1,118 @@
+import { useQuery } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
+import { AlertTriangle, Boxes } from 'lucide-react';
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { Async } from '@/components/states';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { api, type AdminDeadLetter } from '@/lib/api';
+
+export function DashboardRoute() {
+  const envs = useQuery({ queryKey: ['environments'], queryFn: api.listEnvironments });
+  const dlq = useQuery({ queryKey: ['dlq'], queryFn: api.listDlq });
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Overview</h1>
+        <p className="text-sm text-muted-foreground">Operational status across the instance.</p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <StatCard
+          icon={<Boxes className="size-4 text-primary" />}
+          label="Environments"
+          value={envs.data?.length}
+          to="/environments"
+        />
+        <ParkedCard data={dlq.data} />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Parked jobs by environment</CardTitle>
+          <CardDescription>Dead-letter backlog awaiting replay.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Async query={dlq} emptyTitle="No parked jobs">
+            {(letters) => <DlqChart letters={letters} />}
+          </Async>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function StatCard({
+  icon,
+  label,
+  value,
+  to,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: number | undefined;
+  to: string;
+}) {
+  return (
+    <Link to={to} className="block">
+      <Card className="transition-colors hover:border-primary/50">
+        <CardContent className="flex items-center justify-between p-6">
+          <div>
+            <p className="text-sm text-muted-foreground">{label}</p>
+            <p className="text-3xl font-semibold tabular-nums">{value ?? '—'}</p>
+          </div>
+          {icon}
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}
+
+function ParkedCard({ data }: { data: AdminDeadLetter[] | undefined }) {
+  const count = data?.length ?? 0;
+  const danger = count > 0;
+  return (
+    <Link to="/dlq" className="block">
+      <Card className="transition-colors hover:border-primary/50">
+        <CardContent className="flex items-center justify-between p-6">
+          <div>
+            <p className="text-sm text-muted-foreground">Parked jobs</p>
+            <p className={`text-3xl font-semibold tabular-nums ${danger ? 'text-danger' : ''}`}>
+              {data ? count : '—'}
+            </p>
+          </div>
+          <AlertTriangle className={`size-4 ${danger ? 'text-danger' : 'text-muted-foreground'}`} />
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}
+
+function DlqChart({ letters }: { letters: AdminDeadLetter[] }) {
+  if (letters.length === 0) {
+    return <p className="py-8 text-center text-sm text-muted-foreground">No parked jobs — the queue is clear.</p>;
+  }
+  const byEnv = new Map<string, number>();
+  for (const l of letters) byEnv.set(l.environment_slug, (byEnv.get(l.environment_slug) ?? 0) + 1);
+  const data = [...byEnv.entries()].map(([slug, count]) => ({ slug, count }));
+
+  return (
+    <ResponsiveContainer width="100%" height={260}>
+      <BarChart data={data}>
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" vertical={false} />
+        <XAxis dataKey="slug" tick={{ fill: 'var(--color-muted-foreground)', fontSize: 12 }} />
+        <YAxis allowDecimals={false} tick={{ fill: 'var(--color-muted-foreground)', fontSize: 12 }} />
+        <Tooltip
+          contentStyle={{
+            background: 'var(--color-popover)',
+            border: '1px solid var(--color-border)',
+            borderRadius: 8,
+            color: 'var(--color-popover-foreground)',
+          }}
+        />
+        {/* Parked jobs are a failure state → danger. */}
+        <Bar dataKey="count" fill="var(--color-chart-5)" radius={[4, 4, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/server/admin/src/routes/dlq.tsx
+++ b/server/admin/src/routes/dlq.tsx
@@ -1,0 +1,118 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { Async } from '@/components/states';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { api, type AdminDeadLetter, ApiRequestError } from '@/lib/api';
+import { formatTs } from '@/lib/utils';
+
+export function DlqRoute() {
+  const qc = useQueryClient();
+  const dlq = useQuery({ queryKey: ['dlq'], queryFn: api.listDlq });
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ['dlq'] });
+  };
+
+  const replayOne = useMutation({
+    mutationFn: (jobId: string) => api.replayDeadLetter(jobId),
+    onSuccess: () => {
+      toast.success('Replayed — re-entered the normal claim path');
+      invalidate();
+    },
+    onError: (e) => toast.error(e instanceof ApiRequestError ? e.message : 'Replay failed'),
+  });
+
+  const replayAll = useMutation({
+    mutationFn: () => api.replayAllDeadLetters(),
+    onSuccess: (r) => {
+      toast.success(`Replayed ${r.replayed} job${r.replayed === 1 ? '' : 's'}`);
+      invalidate();
+    },
+    onError: (e) => toast.error(e instanceof ApiRequestError ? e.message : 'Replay failed'),
+  });
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Dead-letter queue</h1>
+          <p className="text-sm text-muted-foreground">
+            Jobs that exhausted their retries, across all environments. Replay re-enqueues through
+            the normal worker loop.
+          </p>
+        </div>
+        <Button
+          variant="destructive"
+          disabled={replayAll.isPending || (dlq.data?.length ?? 0) === 0}
+          onClick={() => replayAll.mutate()}
+        >
+          Replay all
+        </Button>
+      </div>
+
+      <Async query={dlq} emptyTitle="Dead-letter queue is empty">
+        {(letters: AdminDeadLetter[]) =>
+          letters.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No parked jobs. The queue is clear.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Job</TableHead>
+                  <TableHead>Environment</TableHead>
+                  <TableHead>Type</TableHead>
+                  <TableHead>Attempts</TableHead>
+                  <TableHead>Parked</TableHead>
+                  <TableHead>Error</TableHead>
+                  <TableHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {letters.map((l) => (
+                  <TableRow key={l.id}>
+                    <TableCell className="font-mono text-xs">{l.id}</TableCell>
+                    <TableCell className="font-mono">{l.environment_slug}</TableCell>
+                    <TableCell>{l.job_type}</TableCell>
+                    <TableCell>
+                      <Badge variant="warningHi">{l.attempts}</Badge>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">{formatTs(l.parked_at)}</TableCell>
+                    <TableCell className="max-w-xs">
+                      <button
+                        type="button"
+                        className="truncate text-left text-danger hover:underline"
+                        title="Click to expand"
+                        onClick={() => setExpanded(expanded === l.id ? null : l.id)}
+                      >
+                        {expanded === l.id ? l.last_error : truncate(l.last_error)}
+                      </button>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={replayOne.isPending}
+                        onClick={() => replayOne.mutate(l.id)}
+                      >
+                        Replay
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )
+        }
+      </Async>
+    </div>
+  );
+}
+
+function truncate(s: string, n = 60): string {
+  const firstLine = s.split('\n')[0] ?? s;
+  return firstLine.length > n ? `${firstLine.slice(0, n)}…` : firstLine;
+}

--- a/server/admin/src/routes/environment-detail.tsx
+++ b/server/admin/src/routes/environment-detail.tsx
@@ -1,0 +1,307 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useParams } from '@tanstack/react-router';
+import { KeyRound, Plus, RefreshCw } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { CopyField } from '@/components/copy-field';
+import { EnvNav } from '@/components/env-nav';
+import { Async } from '@/components/states';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Separator } from '@/components/ui/separator';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { api, type AdminApiKeyCreated, ApiRequestError } from '@/lib/api';
+import { formatTs } from '@/lib/utils';
+
+export function EnvironmentDetailRoute() {
+  const { envId } = useParams({ strict: false }) as { envId: string };
+  const env = useQuery({ queryKey: ['environment', envId], queryFn: () => api.getEnvironment(envId) });
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          {env.data?.name ?? 'Environment'}
+        </h1>
+        <p className="font-mono text-sm text-muted-foreground">{env.data?.slug ?? envId}</p>
+      </div>
+      <EnvNav envId={envId} />
+
+      <Tabs defaultValue="keys">
+        <TabsList>
+          <TabsTrigger value="keys">API keys</TabsTrigger>
+          <TabsTrigger value="hmac">Subscriber HMAC</TabsTrigger>
+        </TabsList>
+        <TabsContent value="keys">
+          <ApiKeysTab envId={envId} />
+        </TabsContent>
+        <TabsContent value="hmac">
+          <HmacTab envId={envId} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function ApiKeysTab({ envId }: { envId: string }) {
+  const keys = useQuery({ queryKey: ['api-keys', envId], queryFn: () => api.listApiKeys(envId) });
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex justify-end">
+        <CreateApiKeyDialog envId={envId} />
+      </div>
+      <Async query={keys} emptyTitle="No API keys">
+        {(rows) =>
+          rows.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No API keys yet.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Prefix</TableHead>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Created</TableHead>
+                  <TableHead>Last used</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((k) => (
+                  <TableRow key={k.id}>
+                    <TableCell className="font-mono">{k.key_prefix}…</TableCell>
+                    <TableCell>{k.name}</TableCell>
+                    <TableCell className="text-muted-foreground">{formatTs(k.created_at)}</TableCell>
+                    <TableCell className="text-muted-foreground">{formatTs(k.last_used_at)}</TableCell>
+                    <TableCell>
+                      {k.revoked_at ? (
+                        <Badge variant="danger">revoked</Badge>
+                      ) : (
+                        <Badge variant="success">active</Badge>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {!k.revoked_at && <RevokeKeyButton envId={envId} keyId={k.id} name={k.name} />}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )
+        }
+      </Async>
+    </div>
+  );
+}
+
+function CreateApiKeyDialog({ envId }: { envId: string }) {
+  const qc = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [created, setCreated] = useState<AdminApiKeyCreated | null>(null);
+
+  const create = useMutation({
+    mutationFn: () => api.createApiKey(envId, name),
+    onSuccess: (key) => {
+      setCreated(key);
+      setName('');
+      toast.success('API key created — copy it now');
+      qc.invalidateQueries({ queryKey: ['api-keys', envId] });
+    },
+    onError: (e) => toast.error(e instanceof ApiRequestError ? e.message : 'Failed'),
+  });
+
+  const close = (o: boolean) => {
+    setOpen(o);
+    if (!o) setCreated(null);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={close}>
+      <DialogTrigger asChild>
+        <Button>
+          <Plus /> Create key
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create API key</DialogTitle>
+          <DialogDescription>
+            The full key is shown once and never again. Only its hash is stored.
+          </DialogDescription>
+        </DialogHeader>
+        {created ? (
+          <div className="flex flex-col gap-3">
+            <div className="rounded-md border border-warning-hi/40 bg-warning-hi/10 p-3 text-sm">
+              Store this key now. You will not be able to see it again.
+            </div>
+            <CopyField value={created.key} />
+            <DialogFooter>
+              <Button onClick={() => close(false)}>Done</Button>
+            </DialogFooter>
+          </div>
+        ) : (
+          <form
+            className="flex flex-col gap-4"
+            onSubmit={(e) => {
+              e.preventDefault();
+              create.mutate();
+            }}
+          >
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="key-name">Name</Label>
+              <Input
+                id="key-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="ci, backend, …"
+                required
+              />
+            </div>
+            <DialogFooter>
+              <Button type="submit" disabled={create.isPending}>
+                {create.isPending ? 'Creating…' : 'Create key'}
+              </Button>
+            </DialogFooter>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function RevokeKeyButton({ envId, keyId, name }: { envId: string; keyId: string; name: string }) {
+  const qc = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const revoke = useMutation({
+    mutationFn: () => api.revokeApiKey(envId, keyId),
+    onSuccess: () => {
+      toast.success('Key revoked');
+      qc.invalidateQueries({ queryKey: ['api-keys', envId] });
+      setOpen(false);
+    },
+    onError: (e) => toast.error(e instanceof ApiRequestError ? e.message : 'Failed'),
+  });
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="sm" className="text-danger hover:text-danger">
+          Revoke
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Revoke “{name}”?</DialogTitle>
+          <DialogDescription>
+            The key stops authenticating immediately. The row is kept for audit.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={() => revoke.mutate()} disabled={revoke.isPending}>
+            Revoke key
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function HmacTab({ envId }: { envId: string }) {
+  const qc = useQueryClient();
+  const env = useQuery({ queryKey: ['environment', envId], queryFn: () => api.getEnvironment(envId) });
+  const [rotatedSecret, setRotatedSecret] = useState<string | null>(null);
+
+  const rotate = useMutation({
+    mutationFn: () => api.rotateHmac(envId),
+    onSuccess: (r) => {
+      setRotatedSecret(r.subscriber_hmac_secret);
+      toast.success('Rotated — both secrets verify during the overlap');
+      qc.invalidateQueries({ queryKey: ['environment', envId] });
+    },
+    onError: (e) => toast.error(e instanceof ApiRequestError ? e.message : 'Failed'),
+  });
+
+  const complete = useMutation({
+    mutationFn: () => api.completeHmacRotation(envId),
+    onSuccess: () => {
+      setRotatedSecret(null);
+      toast.success('Rotation completed — previous secret cleared');
+      qc.invalidateQueries({ queryKey: ['environment', envId] });
+    },
+    onError: (e) => toast.error(e instanceof ApiRequestError ? e.message : 'Failed'),
+  });
+
+  return (
+    <Async query={env} emptyTitle="Environment not found">
+      {(detail) => (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <KeyRound className="size-4 text-primary" /> Subscriber HMAC secret
+            </CardTitle>
+            <CardDescription>
+              The customer backend computes <code>HMAC-SHA256(secret, subscriber_id)</code> with
+              this. Rotation uses two slots so live widget sessions never break.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-5">
+            <div className="flex flex-col gap-1.5">
+              <Label>Current secret</Label>
+              <CopyField value={detail.subscriber_hmac_secret} maskable />
+            </div>
+
+            {detail.has_previous_secret && (
+              <div className="rounded-md border border-warning/40 bg-warning/10 p-3 text-sm">
+                Rotation in progress — the previous secret still verifies. Update every backend,
+                then complete the rotation.
+                {detail.subscriber_hmac_rotated_at && (
+                  <span className="block text-muted-foreground">
+                    Rotated {formatTs(detail.subscriber_hmac_rotated_at)}
+                  </span>
+                )}
+              </div>
+            )}
+
+            {rotatedSecret && (
+              <div className="flex flex-col gap-2 rounded-md border border-warning-hi/40 bg-warning-hi/10 p-3">
+                <p className="text-sm font-medium">New secret — copy it into your backend now.</p>
+                <CopyField value={rotatedSecret} />
+              </div>
+            )}
+
+            <Separator />
+
+            <div className="flex flex-wrap gap-2">
+              <Button onClick={() => rotate.mutate()} disabled={rotate.isPending}>
+                <RefreshCw className={rotate.isPending ? 'animate-spin' : ''} /> Rotate secret
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => complete.mutate()}
+                disabled={!detail.has_previous_secret || complete.isPending}
+              >
+                Complete rotation
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </Async>
+  );
+}

--- a/server/admin/src/routes/environments.tsx
+++ b/server/admin/src/routes/environments.tsx
@@ -1,0 +1,161 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { Plus } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { Async } from '@/components/states';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { api, ApiRequestError } from '@/lib/api';
+import { formatTs } from '@/lib/utils';
+
+export function EnvironmentsRoute() {
+  const envs = useQuery({ queryKey: ['environments'], queryFn: api.listEnvironments });
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Environments</h1>
+          <p className="text-sm text-muted-foreground">
+            The isolation unit. Each has its own API keys and subscriber HMAC secret.
+          </p>
+        </div>
+        <NewEnvironmentDialog />
+      </div>
+
+      <Async query={envs} emptyTitle="No environments yet">
+        {(rows) =>
+          rows.length === 0 ? (
+            <p className="text-sm text-muted-foreground">Create your first environment to begin.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Slug</TableHead>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Subscriber hash</TableHead>
+                  <TableHead>Created</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((env) => (
+                  <TableRow
+                    key={env.id}
+                    className="cursor-pointer"
+                    onClick={() => navigate({ to: '/environments/$envId', params: { envId: env.id } })}
+                  >
+                    <TableCell className="font-mono">{env.slug}</TableCell>
+                    <TableCell>{env.name}</TableCell>
+                    <TableCell>
+                      {env.require_subscriber_hash ? (
+                        <Badge variant="default">required</Badge>
+                      ) : (
+                        <Badge variant="neutral">optional (dev)</Badge>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">{formatTs(env.created_at)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )
+        }
+      </Async>
+    </div>
+  );
+}
+
+function NewEnvironmentDialog() {
+  const qc = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [slug, setSlug] = useState('');
+  const [name, setName] = useState('');
+  const [requireHash, setRequireHash] = useState(true);
+
+  const create = useMutation({
+    mutationFn: () => api.createEnvironment({ slug, name, require_subscriber_hash: requireHash }),
+    onSuccess: (env) => {
+      toast.success(`Environment ${env.slug} created`);
+      qc.invalidateQueries({ queryKey: ['environments'] });
+      setOpen(false);
+      setSlug('');
+      setName('');
+      setRequireHash(true);
+    },
+    onError: (e) => toast.error(e instanceof ApiRequestError ? e.message : 'Failed to create'),
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>
+          <Plus /> New environment
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New environment</DialogTitle>
+          <DialogDescription>
+            Slugs are URL-safe handles the widget sends to scope the subscriber plane.
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          className="flex flex-col gap-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            create.mutate();
+          }}
+        >
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="slug">Slug</Label>
+            <Input
+              id="slug"
+              value={slug}
+              onChange={(e) => setSlug(e.target.value)}
+              placeholder="dashboard-prod"
+              required
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="name">Name</Label>
+            <Input
+              id="name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Dashboard (production)"
+              required
+            />
+          </div>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={requireHash}
+              onChange={(e) => setRequireHash(e.target.checked)}
+              className="accent-primary"
+            />
+            Require subscriber HMAC hash (recommended for production)
+          </label>
+          <DialogFooter>
+            <Button type="submit" disabled={create.isPending}>
+              {create.isPending ? 'Creating…' : 'Create environment'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/server/admin/src/routes/notifications.tsx
+++ b/server/admin/src/routes/notifications.tsx
@@ -1,0 +1,221 @@
+import { useQuery } from '@tanstack/react-query';
+import { useParams } from '@tanstack/react-router';
+import { useState } from 'react';
+import { EnvNav } from '@/components/env-nav';
+import { ReadBadge, StatusBadge } from '@/components/status-badge';
+import { Async } from '@/components/states';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { api, type AdminNotification, type NotificationFilter } from '@/lib/api';
+import { formatTs } from '@/lib/utils';
+
+export function NotificationsRoute() {
+  const { envId } = useParams({ strict: false }) as { envId: string };
+  const [draft, setDraft] = useState<NotificationFilter>({ limit: 50 });
+  const [applied, setApplied] = useState<NotificationFilter>({ limit: 50 });
+  const [open, setOpen] = useState<AdminNotification | null>(null);
+
+  const page = useQuery({
+    queryKey: ['notifications', envId, applied],
+    queryFn: () => api.listNotifications(envId, applied),
+  });
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Notifications</h1>
+        <p className="text-sm text-muted-foreground">
+          Browse direct notifications and inspect the “did it send?” timeline.
+        </p>
+      </div>
+      <EnvNav envId={envId} />
+
+      <form
+        className="grid items-end gap-3 sm:grid-cols-2 lg:grid-cols-4"
+        onSubmit={(e) => {
+          e.preventDefault();
+          setApplied(draft);
+        }}
+      >
+        <Field label="Subscriber id">
+          <Input
+            value={draft.subscriber_id ?? ''}
+            onChange={(e) => setDraft((d) => ({ ...d, subscriber_id: e.target.value || undefined }))}
+            placeholder="usr_42"
+          />
+        </Field>
+        <Field label="Category">
+          <Input
+            value={draft.category ?? ''}
+            onChange={(e) => setDraft((d) => ({ ...d, category: e.target.value || undefined }))}
+            placeholder="payment.failed"
+          />
+        </Field>
+        <Field label="After">
+          <Input
+            type="datetime-local"
+            value={draft.after ? toLocalInput(draft.after) : ''}
+            onChange={(e) => setDraft((d) => ({ ...d, after: fromLocalInput(e.target.value) }))}
+          />
+        </Field>
+        <Field label="Before">
+          <Input
+            type="datetime-local"
+            value={draft.before ? toLocalInput(draft.before) : ''}
+            onChange={(e) => setDraft((d) => ({ ...d, before: fromLocalInput(e.target.value) }))}
+          />
+        </Field>
+        <div className="flex gap-2">
+          <Button type="submit">Apply filters</Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              setDraft({ limit: 50 });
+              setApplied({ limit: 50 });
+            }}
+          >
+            Reset
+          </Button>
+        </div>
+      </form>
+
+      <Async query={page} emptyTitle="No notifications">
+        {(data) =>
+          data.items.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No notifications match these filters.</p>
+          ) : (
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Subscriber</TableHead>
+                    <TableHead>Category</TableHead>
+                    <TableHead>Visible at</TableHead>
+                    <TableHead>Read</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {data.items.map((n) => (
+                    <TableRow key={n.id} className="cursor-pointer" onClick={() => setOpen(n)}>
+                      <TableCell className="font-mono">{n.subscriber_id}</TableCell>
+                      <TableCell>{n.category}</TableCell>
+                      <TableCell className="text-muted-foreground">{formatTs(n.visible_at)}</TableCell>
+                      <TableCell>
+                        <ReadBadge read={n.read_at != null} />
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              {data.next_cursor && (
+                <div>
+                  <Button
+                    variant="outline"
+                    onClick={() => setApplied((a) => ({ ...a, cursor: data.next_cursor ?? undefined }))}
+                  >
+                    Load more
+                  </Button>
+                </div>
+              )}
+            </>
+          )
+        }
+      </Async>
+
+      {open && (
+        <TimelineDialog envId={envId} notif={open} onClose={() => setOpen(null)} />
+      )}
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label>{label}</Label>
+      {children}
+    </div>
+  );
+}
+
+function TimelineDialog({
+  envId,
+  notif,
+  onClose,
+}: {
+  envId: string;
+  notif: AdminNotification;
+  onClose: () => void;
+}) {
+  const timeline = useQuery({
+    queryKey: ['timeline', envId, notif.id],
+    queryFn: () => api.notificationTimeline(envId, notif.id),
+  });
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Status timeline</DialogTitle>
+          <DialogDescription className="font-mono break-all">{notif.id}</DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3">
+          <div className="grid grid-cols-2 gap-2 text-sm">
+            <Meta label="Subscriber" value={notif.subscriber_id} />
+            <Meta label="Category" value={notif.category} />
+            <Meta label="Created" value={formatTs(notif.created_at)} />
+            <Meta label="Visible" value={formatTs(notif.visible_at)} />
+          </div>
+          <Async query={timeline} emptyTitle="No timeline">
+            {(t) => (
+              <ol className="flex flex-col gap-3 border-l border-border pl-4">
+                {t.timeline.map((entry) => (
+                  <li key={entry.status} className="relative">
+                    <span className="absolute -left-[1.32rem] top-1 size-2.5 rounded-full bg-primary" />
+                    <div className="flex items-center gap-2">
+                      <StatusBadge status={entry.status} />
+                      <span className="text-sm text-muted-foreground">
+                        {formatTs(entry.occurred_at)}
+                      </span>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            )}
+          </Async>
+          {Object.keys(notif.payload).length > 0 && (
+            <pre className="max-h-48 overflow-auto rounded-md bg-muted p-3 text-xs">
+              {JSON.stringify(notif.payload, null, 2)}
+            </pre>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Meta({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="font-mono">{value}</p>
+    </div>
+  );
+}
+
+function toLocalInput(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function fromLocalInput(value: string): string | undefined {
+  if (!value) return undefined;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? undefined : d.toISOString();
+}

--- a/server/admin/src/routes/subscribers.tsx
+++ b/server/admin/src/routes/subscribers.tsx
@@ -1,0 +1,177 @@
+import { useQuery } from '@tanstack/react-query';
+import { useParams } from '@tanstack/react-router';
+import { Search } from 'lucide-react';
+import { useState } from 'react';
+import { EnvNav } from '@/components/env-nav';
+import { ReadBadge } from '@/components/status-badge';
+import { ErrorState } from '@/components/states';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { ApiRequestError, api } from '@/lib/api';
+import { formatTs } from '@/lib/utils';
+
+export function SubscribersRoute() {
+  const { envId } = useParams({ strict: false }) as { envId: string };
+  const [input, setInput] = useState('');
+  const [query, setQuery] = useState('');
+
+  const view = useQuery({
+    queryKey: ['subscriber', envId, query],
+    queryFn: () => api.getSubscriber(envId, query),
+    enabled: query.length > 0,
+    retry: false,
+  });
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Subscriber lookup</h1>
+        <p className="text-sm text-muted-foreground">
+          Counters, watermarks, preferences, and the merged inbox exactly as the subscriber sees it.
+        </p>
+      </div>
+      <EnvNav envId={envId} />
+
+      <form
+        className="flex max-w-md gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          setQuery(input.trim());
+        }}
+      >
+        <Input value={input} onChange={(e) => setInput(e.target.value)} placeholder="Customer subscriber id (usr_42)" />
+        <Button type="submit">
+          <Search /> Look up
+        </Button>
+      </form>
+
+      {query && view.isLoading && <Skeleton className="h-40 w-full" />}
+      {query && view.isError && (
+        <ErrorState
+          message={
+            view.error instanceof ApiRequestError && view.error.status === 404
+              ? `No subscriber “${query}” in this environment.`
+              : 'Lookup failed.'
+          }
+        />
+      )}
+      {view.data && (
+        <div className="flex flex-col gap-6">
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <Stat label="Unread" value={view.data.counters.unread} accent />
+            <Stat label="Unseen" value={view.data.counters.unseen} />
+            <Stat label="Read watermark" text={formatTs(view.data.read_watermark)} />
+            <Stat label="Seen watermark" text={formatTs(view.data.seen_watermark)} />
+          </div>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Identity</CardTitle>
+              <CardDescription>
+                Broadcast visibility window: sees broadcasts created at or after{' '}
+                <span className="font-mono">{formatTs(view.data.created_at)}</span>.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+
+          <section className="flex flex-col gap-2">
+            <h2 className="text-sm font-semibold">Preferences</h2>
+            {view.data.preferences.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No explicit preferences — every category is enabled by default.
+              </p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Category</TableHead>
+                    <TableHead>Channel</TableHead>
+                    <TableHead>State</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {view.data.preferences.map((p) => (
+                    <TableRow key={`${p.category}:${p.channel}`}>
+                      <TableCell>{p.category}</TableCell>
+                      <TableCell className="font-mono">{p.channel}</TableCell>
+                      <TableCell>
+                        {p.enabled ? (
+                          <Badge variant="success">enabled</Badge>
+                        ) : (
+                          <Badge variant="neutral">muted</Badge>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </section>
+
+          <section className="flex flex-col gap-2">
+            <h2 className="text-sm font-semibold">Recent inbox (merged)</h2>
+            {view.data.inbox.length === 0 ? (
+              <p className="text-sm text-muted-foreground">Empty inbox.</p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Source</TableHead>
+                    <TableHead>Category</TableHead>
+                    <TableHead>Occurred</TableHead>
+                    <TableHead>Read</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {view.data.inbox.map((item) => (
+                    <TableRow key={item.id}>
+                      <TableCell>
+                        <Badge variant={item.source === 'broadcast' ? 'default' : 'neutral'}>
+                          {item.source}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>{item.category}</TableCell>
+                      <TableCell className="text-muted-foreground">{formatTs(item.occurred_at)}</TableCell>
+                      <TableCell>
+                        <ReadBadge read={item.read} />
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </section>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  text,
+  accent,
+}: {
+  label: string;
+  value?: number;
+  text?: string;
+  accent?: boolean;
+}) {
+  return (
+    <Card>
+      <CardContent className="p-5">
+        <p className="text-sm text-muted-foreground">{label}</p>
+        {text ? (
+          <p className="mt-1 font-mono text-sm">{text}</p>
+        ) : (
+          <p className={`text-3xl font-semibold tabular-nums ${accent ? 'text-primary' : ''}`}>{value}</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/server/admin/src/vite-env.d.ts
+++ b/server/admin/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/server/admin/tsconfig.json
+++ b/server/admin/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/server/admin/vite.config.ts
+++ b/server/admin/vite.config.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath, URL } from 'node:url';
+import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+// Served by the dronte binary at /admin (rust-embed). The base path makes
+// every emitted asset URL absolute under /admin/.
+export default defineConfig({
+  base: '/admin/',
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    chunkSizeWarningLimit: 2000,
+  },
+});

--- a/server/build.rs
+++ b/server/build.rs
@@ -1,0 +1,41 @@
+//! Guarantees `admin/dist` exists at compile time so the rust-embed derive in
+//! `api::admin` always has a folder to embed. The real admin SPA build
+//! (`pnpm --filter dronte-admin build`, run by CI and the Dockerfile) writes
+//! the production bundle there before `cargo build`. When it has not run — a
+//! bare `cargo nextest`, `cargo run -- openapi`, or `cargo sqlx prepare` — a
+//! minimal placeholder shell is written so the binary still compiles and
+//! serves a valid `/admin` page. The placeholder is overwritten by the real
+//! build and never committed (server/admin/dist is gitignored).
+
+use std::fs;
+use std::path::Path;
+
+const PLACEHOLDER: &str = r#"<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Dronte admin</title>
+  </head>
+  <body>
+    <main style="font-family: system-ui, sans-serif; max-width: 32rem; margin: 4rem auto; padding: 0 1rem;">
+      <h1>Dronte admin</h1>
+      <p>The admin dashboard bundle has not been built. Run
+      <code>pnpm --filter dronte-admin build</code> and rebuild the server.</p>
+    </main>
+  </body>
+</html>
+"#;
+
+fn main() {
+    let dist = Path::new("admin/dist");
+    let index = dist.join("index.html");
+    if !index.exists() {
+        fs::create_dir_all(dist).expect("create admin/dist");
+        fs::write(&index, PLACEHOLDER).expect("write placeholder admin/dist/index.html");
+    }
+    // Re-embed when the SPA bundle changes (so a fresh `pnpm build` is picked
+    // up) and when this script changes.
+    println!("cargo:rerun-if-changed=admin/dist");
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/server/src/api/admin.rs
+++ b/server/src/api/admin.rs
@@ -210,7 +210,7 @@ pub async fn create_environment(
     }
 
     let id = ids::new_uuid();
-    let hmac_secret = format!("whsec_{}", ids::new_uuid().as_simple());
+    let hmac_secret = format!("shmac_{}", ids::new_uuid().as_simple());
     let created = sqlx::query!(
         r#"INSERT INTO environments
                (id, slug, name, subscriber_hmac_secret, require_subscriber_hash)
@@ -325,7 +325,7 @@ pub async fn rotate_hmac(
     Path(env_id): Path<String>,
 ) -> Result<Json<AdminHmacRotation>, ApiError> {
     let env = parse_env_id(&env_id)?;
-    let new_secret = format!("whsec_{}", ids::new_uuid().as_simple());
+    let new_secret = format!("shmac_{}", ids::new_uuid().as_simple());
     let row = sqlx::query!(
         r#"UPDATE environments SET
                subscriber_hmac_secret = $2,

--- a/server/src/api/admin.rs
+++ b/server/src/api/admin.rs
@@ -54,7 +54,10 @@ struct AdminAssets;
 /// API request on this origin. Unknown non-file paths fall back to
 /// `index.html` so client-side routing (TanStack Router) works on refresh.
 pub async fn serve_spa(_auth: AdminAuth, uri: Uri) -> Response {
-    let path = uri.path().trim_start_matches("/admin").trim_start_matches('/');
+    let path = uri
+        .path()
+        .trim_start_matches("/admin")
+        .trim_start_matches('/');
     let path = if path.is_empty() { "index.html" } else { path };
 
     if let Some(file) = AdminAssets::get(path) {

--- a/server/src/api/admin.rs
+++ b/server/src/api/admin.rs
@@ -1,0 +1,1070 @@
+//! Admin plane: the embedded `/admin` dashboard's API (specs/phase-4-admin.md).
+//!
+//! Single-org by construction: no organizations, no admin users, no roles.
+//! One static credential gates the whole plane (see `auth::AdminAuth`).
+//! Every query is either scoped to one `environment_id` or is an explicit,
+//! documented cross-environment admin path (the DLQ browser) — the schema's
+//! shard-readiness invariant #3 exception.
+//!
+//! Admin reads REUSE the canonical queries (`inbox::list_items_for`,
+//! `inbox::fetch_counts_for`) and admin writes REUSE the canonical write-path
+//! (`management::create_broadcast_idempotent`, `dlq::replay`). A second
+//! implementation of the two-source merge or the broadcast write would be a
+//! bug by definition — two implementations WILL disagree.
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::header::{CACHE_CONTROL, CONTENT_TYPE};
+use axum::http::{StatusCode, Uri};
+use axum::response::{IntoResponse, Response};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use utoipa::{IntoParams, ToSchema};
+use uuid::Uuid;
+
+use crate::api::format_ts;
+use crate::api::inbox::{self, InboxCounts};
+use crate::api::management;
+use crate::auth::AdminAuth;
+use crate::error::ApiError;
+use crate::extract::{ApiJson, ApiQuery};
+use crate::state::AppState;
+use crate::{dlq, ids};
+
+const ADMIN_NOTIFICATION_PAGE: i64 = 50;
+const ADMIN_NOTIFICATION_MAX_PAGE: i64 = 200;
+const ADMIN_INBOX_PREVIEW: i64 = 20;
+/// Vite emits content-hashed asset filenames, so the bundle is immutable.
+const ASSET_CACHE_CONTROL: &str = "public, max-age=31536000, immutable";
+
+// =============================================================================
+// Embedded SPA (rust-embed). The single-binary deploy story: `docker run`
+// ships the dashboard, no CDN and no separate static host.
+// =============================================================================
+
+#[derive(rust_embed::RustEmbed)]
+#[folder = "admin/dist"]
+struct AdminAssets;
+
+/// Serve the embedded SPA. Gated by `AdminAuth` like every admin route, so a
+/// bare `/admin` navigation 401s with `WWW-Authenticate: Basic` and the
+/// browser prompts; thereafter it attaches the credential to every asset and
+/// API request on this origin. Unknown non-file paths fall back to
+/// `index.html` so client-side routing (TanStack Router) works on refresh.
+pub async fn serve_spa(_auth: AdminAuth, uri: Uri) -> Response {
+    let path = uri.path().trim_start_matches("/admin").trim_start_matches('/');
+    let path = if path.is_empty() { "index.html" } else { path };
+
+    if let Some(file) = AdminAssets::get(path) {
+        let cache = if path.starts_with("assets/") {
+            ASSET_CACHE_CONTROL
+        } else {
+            "no-cache"
+        };
+        return (
+            [
+                (CONTENT_TYPE, file.metadata.mimetype()),
+                (CACHE_CONTROL, cache),
+            ],
+            file.data.into_owned(),
+        )
+            .into_response();
+    }
+
+    // A path that looks like a file but is missing is a real 404; anything
+    // else is a client-side route and gets the SPA shell.
+    if path.contains('.') {
+        return (StatusCode::NOT_FOUND, "not found").into_response();
+    }
+    match AdminAssets::get("index.html") {
+        Some(index) => (
+            [
+                (CONTENT_TYPE, "text/html; charset=utf-8"),
+                (CACHE_CONTROL, "no-cache"),
+            ],
+            index.data.into_owned(),
+        )
+            .into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            "admin UI not built (run `pnpm --filter dronte-admin build`)",
+        )
+            .into_response(),
+    }
+}
+
+// =============================================================================
+// Environments
+// =============================================================================
+
+#[derive(Serialize, ToSchema)]
+pub struct AdminEnvironment {
+    /// TypeID, `env_…`.
+    pub id: String,
+    pub slug: String,
+    pub name: String,
+    pub require_subscriber_hash: bool,
+    pub created_at: String,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct AdminEnvironmentDetail {
+    pub id: String,
+    pub slug: String,
+    pub name: String,
+    pub require_subscriber_hash: bool,
+    /// The dedicated subscriber HMAC secret. Plaintext by design (the
+    /// customer backend computes hashes with it) and operator-only.
+    pub subscriber_hmac_secret: String,
+    /// True while a rotation overlap is open (the previous secret still
+    /// verifies live `<Inbox />` sessions).
+    pub has_previous_secret: bool,
+    pub subscriber_hmac_rotated_at: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct AdminCreateEnvironmentRequest {
+    pub slug: String,
+    pub name: String,
+    /// Production default true; set false for a dev/quickstart environment.
+    #[serde(default = "default_true")]
+    pub require_subscriber_hash: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[utoipa::path(
+    get,
+    path = "/admin/api/environments",
+    tag = "admin",
+    operation_id = "adminListEnvironments",
+    summary = "List environments",
+    responses((status = 200, description = "Environments.", body = Vec<AdminEnvironment>),
+              (status = 401, description = "Admin authentication required.")),
+    security(("AdminToken" = []))
+)]
+pub async fn list_environments(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+) -> Result<Json<Vec<AdminEnvironment>>, ApiError> {
+    let rows = sqlx::query!(
+        r#"SELECT id, slug, name, require_subscriber_hash, created_at
+             FROM environments ORDER BY created_at"#,
+    )
+    .fetch_all(&state.pool)
+    .await
+    .map_err(ApiError::from)?;
+    Ok(Json(
+        rows.into_iter()
+            .map(|r| AdminEnvironment {
+                id: ids::typeid(ids::ENVIRONMENT, r.id),
+                slug: r.slug,
+                name: r.name,
+                require_subscriber_hash: r.require_subscriber_hash,
+                created_at: format_ts(r.created_at),
+            })
+            .collect(),
+    ))
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/api/environments",
+    tag = "admin",
+    operation_id = "adminCreateEnvironment",
+    summary = "Create an environment",
+    request_body = AdminCreateEnvironmentRequest,
+    responses((status = 201, description = "Created.", body = AdminEnvironmentDetail),
+              (status = 400, description = "Validation error or slug already exists.", body = crate::api::contract::Error),
+              (status = 401, description = "Admin authentication required.")),
+    security(("AdminToken" = []))
+)]
+pub async fn create_environment(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    ApiJson(req): ApiJson<AdminCreateEnvironmentRequest>,
+) -> Result<Response, ApiError> {
+    let slug = req.slug.trim();
+    if slug.is_empty() || slug.len() > 255 {
+        return Err(ApiError::bad_request("slug must be 1-255 characters"));
+    }
+    if !slug
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(ApiError::bad_request(
+            "slug may contain only letters, digits, '-' and '_'",
+        ));
+    }
+    let name = req.name.trim();
+    if name.is_empty() || name.len() > 255 {
+        return Err(ApiError::bad_request("name must be 1-255 characters"));
+    }
+
+    let id = ids::new_uuid();
+    let hmac_secret = format!("whsec_{}", ids::new_uuid().as_simple());
+    let created = sqlx::query!(
+        r#"INSERT INTO environments
+               (id, slug, name, subscriber_hmac_secret, require_subscriber_hash)
+           VALUES ($1, $2, $3, $4, $5)
+           ON CONFLICT (slug) DO NOTHING
+           RETURNING created_at"#,
+        id,
+        slug,
+        name,
+        hmac_secret,
+        req.require_subscriber_hash,
+    )
+    .fetch_optional(&state.pool)
+    .await
+    .map_err(ApiError::from)?;
+
+    let Some(created) = created else {
+        return Err(ApiError::bad_request("environment slug already exists"));
+    };
+
+    Ok((
+        StatusCode::CREATED,
+        Json(AdminEnvironmentDetail {
+            id: ids::typeid(ids::ENVIRONMENT, id),
+            slug: slug.to_owned(),
+            name: name.to_owned(),
+            require_subscriber_hash: req.require_subscriber_hash,
+            subscriber_hmac_secret: hmac_secret,
+            has_previous_secret: false,
+            subscriber_hmac_rotated_at: None,
+            created_at: format_ts(created.created_at),
+        }),
+    )
+        .into_response())
+}
+
+#[utoipa::path(
+    get,
+    path = "/admin/api/environments/{env_id}",
+    tag = "admin",
+    operation_id = "adminGetEnvironment",
+    summary = "Environment detail (includes the subscriber HMAC secret)",
+    params(("env_id" = String, Path, description = "Environment TypeID (env_…).")),
+    responses((status = 200, description = "Environment.", body = AdminEnvironmentDetail),
+              (status = 401, description = "Admin authentication required."),
+              (status = 404, description = "No such environment.", body = crate::api::contract::Error)),
+    security(("AdminToken" = []))
+)]
+pub async fn get_environment(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Path(env_id): Path<String>,
+) -> Result<Json<AdminEnvironmentDetail>, ApiError> {
+    let env = parse_env_id(&env_id)?;
+    let row = sqlx::query!(
+        r#"SELECT id, slug, name, require_subscriber_hash, subscriber_hmac_secret,
+                  subscriber_hmac_secret_previous, subscriber_hmac_rotated_at, created_at
+             FROM environments WHERE id = $1"#,
+        env,
+    )
+    .fetch_optional(&state.pool)
+    .await
+    .map_err(ApiError::from)?
+    .ok_or_else(|| ApiError::not_found("no such environment"))?;
+
+    Ok(Json(AdminEnvironmentDetail {
+        id: ids::typeid(ids::ENVIRONMENT, row.id),
+        slug: row.slug,
+        name: row.name,
+        require_subscriber_hash: row.require_subscriber_hash,
+        subscriber_hmac_secret: row.subscriber_hmac_secret,
+        has_previous_secret: row.subscriber_hmac_secret_previous.is_some(),
+        subscriber_hmac_rotated_at: row.subscriber_hmac_rotated_at.map(format_ts),
+        created_at: format_ts(row.created_at),
+    }))
+}
+
+// =============================================================================
+// Subscriber HMAC rotation (two-slot overlap)
+// =============================================================================
+
+#[derive(Serialize, ToSchema)]
+pub struct AdminHmacRotation {
+    /// The new current secret. Update the customer backend with it; the
+    /// previous secret keeps verifying until the rotation is completed.
+    pub subscriber_hmac_secret: String,
+    pub has_previous_secret: bool,
+    pub subscriber_hmac_rotated_at: Option<String>,
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/api/environments/{env_id}/hmac/rotate",
+    tag = "admin",
+    operation_id = "adminRotateHmac",
+    summary = "Begin a subscriber-HMAC rotation (current → previous)",
+    description = r#"Generates a new current secret and moves the existing one into the
+previous slot. During the overlap BOTH secrets verify live `<Inbox />`
+sessions (auth checks current then previous), so rotation is
+zero-downtime. Complete the rotation to clear the previous slot once
+every customer backend has switched.
+"#,
+    params(("env_id" = String, Path, description = "Environment TypeID (env_…).")),
+    responses((status = 200, description = "Rotated.", body = AdminHmacRotation),
+              (status = 401, description = "Admin authentication required."),
+              (status = 404, description = "No such environment.", body = crate::api::contract::Error)),
+    security(("AdminToken" = []))
+)]
+pub async fn rotate_hmac(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Path(env_id): Path<String>,
+) -> Result<Json<AdminHmacRotation>, ApiError> {
+    let env = parse_env_id(&env_id)?;
+    let new_secret = format!("whsec_{}", ids::new_uuid().as_simple());
+    let row = sqlx::query!(
+        r#"UPDATE environments SET
+               subscriber_hmac_secret = $2,
+               subscriber_hmac_secret_previous = subscriber_hmac_secret,
+               subscriber_hmac_rotated_at = now(),
+               updated_at = now()
+           WHERE id = $1
+           RETURNING subscriber_hmac_secret, subscriber_hmac_secret_previous,
+                     subscriber_hmac_rotated_at"#,
+        env,
+        new_secret,
+    )
+    .fetch_optional(&state.pool)
+    .await
+    .map_err(ApiError::from)?
+    .ok_or_else(|| ApiError::not_found("no such environment"))?;
+
+    Ok(Json(AdminHmacRotation {
+        subscriber_hmac_secret: row.subscriber_hmac_secret,
+        has_previous_secret: row.subscriber_hmac_secret_previous.is_some(),
+        subscriber_hmac_rotated_at: row.subscriber_hmac_rotated_at.map(format_ts),
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/api/environments/{env_id}/hmac/rotate/complete",
+    tag = "admin",
+    operation_id = "adminCompleteHmacRotation",
+    summary = "Complete a rotation (clear the previous secret slot)",
+    params(("env_id" = String, Path, description = "Environment TypeID (env_…).")),
+    responses((status = 204, description = "Previous secret cleared."),
+              (status = 401, description = "Admin authentication required."),
+              (status = 404, description = "No such environment.", body = crate::api::contract::Error)),
+    security(("AdminToken" = []))
+)]
+pub async fn complete_hmac_rotation(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Path(env_id): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    let env = parse_env_id(&env_id)?;
+    let affected = sqlx::query!(
+        r#"UPDATE environments SET subscriber_hmac_secret_previous = NULL, updated_at = now()
+           WHERE id = $1"#,
+        env,
+    )
+    .execute(&state.pool)
+    .await
+    .map_err(ApiError::from)?
+    .rows_affected();
+    if affected == 0 {
+        return Err(ApiError::not_found("no such environment"));
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// =============================================================================
+// API keys
+// =============================================================================
+
+#[derive(Serialize, ToSchema)]
+pub struct AdminApiKey {
+    /// TypeID, `key_…`.
+    pub id: String,
+    pub name: String,
+    /// Display prefix for recognition; the full key is never retrievable.
+    pub key_prefix: String,
+    pub created_at: String,
+    pub last_used_at: Option<String>,
+    pub revoked_at: Option<String>,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct AdminApiKeyCreated {
+    pub id: String,
+    pub name: String,
+    pub key_prefix: String,
+    /// The plaintext key, shown EXACTLY once. Only the sha256 hash is stored.
+    pub key: String,
+    pub created_at: String,
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct AdminCreateApiKeyRequest {
+    pub name: String,
+}
+
+#[utoipa::path(
+    get,
+    path = "/admin/api/environments/{env_id}/api-keys",
+    tag = "admin",
+    operation_id = "adminListApiKeys",
+    summary = "List API keys for an environment (prefix only, never the key)",
+    params(("env_id" = String, Path, description = "Environment TypeID (env_…).")),
+    responses((status = 200, description = "Keys.", body = Vec<AdminApiKey>),
+              (status = 401, description = "Admin authentication required."),
+              (status = 404, description = "No such environment.", body = crate::api::contract::Error)),
+    security(("AdminToken" = []))
+)]
+pub async fn list_api_keys(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Path(env_id): Path<String>,
+) -> Result<Json<Vec<AdminApiKey>>, ApiError> {
+    let env = parse_env_id(&env_id)?;
+    ensure_environment(&state, env).await?;
+    let rows = sqlx::query!(
+        r#"SELECT id, name, key_prefix, created_at, last_used_at, revoked_at
+             FROM api_keys WHERE environment_id = $1 ORDER BY created_at"#,
+        env,
+    )
+    .fetch_all(&state.pool)
+    .await
+    .map_err(ApiError::from)?;
+    Ok(Json(
+        rows.into_iter()
+            .map(|r| AdminApiKey {
+                id: ids::typeid(ids::API_KEY, r.id),
+                name: r.name,
+                key_prefix: r.key_prefix,
+                created_at: format_ts(r.created_at),
+                last_used_at: r.last_used_at.map(format_ts),
+                revoked_at: r.revoked_at.map(format_ts),
+            })
+            .collect(),
+    ))
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/api/environments/{env_id}/api-keys",
+    tag = "admin",
+    operation_id = "adminCreateApiKey",
+    summary = "Create an API key (plaintext returned once)",
+    params(("env_id" = String, Path, description = "Environment TypeID (env_…).")),
+    request_body = AdminCreateApiKeyRequest,
+    responses((status = 201, description = "Created; `key` is shown once.", body = AdminApiKeyCreated),
+              (status = 400, description = "Validation error.", body = crate::api::contract::Error),
+              (status = 401, description = "Admin authentication required."),
+              (status = 404, description = "No such environment.", body = crate::api::contract::Error)),
+    security(("AdminToken" = []))
+)]
+pub async fn create_api_key(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Path(env_id): Path<String>,
+    ApiJson(req): ApiJson<AdminCreateApiKeyRequest>,
+) -> Result<Response, ApiError> {
+    let env = parse_env_id(&env_id)?;
+    ensure_environment(&state, env).await?;
+    let name = req.name.trim();
+    if name.is_empty() || name.len() > 255 {
+        return Err(ApiError::bad_request("name must be 1-255 characters"));
+    }
+
+    let id = ids::new_uuid();
+    // 256 bits of randomness in the key body; the prefix is for display only.
+    let key = format!("drnt_live_{}", ids::new_uuid().as_simple());
+    let key_hash: Vec<u8> = Sha256::digest(key.as_bytes()).to_vec();
+    let key_prefix = &key[..key.floor_char_boundary(14)];
+
+    let created = sqlx::query!(
+        r#"INSERT INTO api_keys (environment_id, id, name, key_hash, key_prefix)
+           VALUES ($1, $2, $3, $4, $5)
+           RETURNING created_at"#,
+        env,
+        id,
+        name,
+        key_hash,
+        key_prefix,
+    )
+    .fetch_one(&state.pool)
+    .await
+    .map_err(ApiError::from)?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(AdminApiKeyCreated {
+            id: ids::typeid(ids::API_KEY, id),
+            name: name.to_owned(),
+            key_prefix: key_prefix.to_owned(),
+            key,
+            created_at: format_ts(created.created_at),
+        }),
+    )
+        .into_response())
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/api/environments/{env_id}/api-keys/{key_id}/revoke",
+    tag = "admin",
+    operation_id = "adminRevokeApiKey",
+    summary = "Revoke an API key (soft; row kept for audit)",
+    params(
+        ("env_id" = String, Path, description = "Environment TypeID (env_…)."),
+        ("key_id" = String, Path, description = "API key TypeID (key_…).")
+    ),
+    responses((status = 204, description = "Revoked (now or already)."),
+              (status = 401, description = "Admin authentication required."),
+              (status = 404, description = "No such API key.", body = crate::api::contract::Error)),
+    security(("AdminToken" = []))
+)]
+pub async fn revoke_api_key(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Path((env_id, key_id)): Path<(String, String)>,
+) -> Result<StatusCode, ApiError> {
+    let env = parse_env_id(&env_id)?;
+    let key = ids::parse_typeid(ids::API_KEY, &key_id)
+        .ok_or_else(|| ApiError::not_found("no such API key"))?;
+    // Soft revoke: keep the row for audit, set revoked_at if not already set.
+    let affected = sqlx::query!(
+        r#"UPDATE api_keys SET revoked_at = COALESCE(revoked_at, now())
+           WHERE environment_id = $1 AND id = $2"#,
+        env,
+        key,
+    )
+    .execute(&state.pool)
+    .await
+    .map_err(ApiError::from)?
+    .rows_affected();
+    if affected == 0 {
+        return Err(ApiError::not_found("no such API key"));
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// =============================================================================
+// Notification / status-timeline browser
+// =============================================================================
+
+#[derive(Deserialize, IntoParams)]
+pub struct AdminNotificationFilter {
+    /// Customer-provided subscriber id.
+    pub subscriber_id: Option<String>,
+    pub category: Option<String>,
+    /// Lower bound on `visible_at` (inclusive), RFC 3339.
+    pub after: Option<DateTime<Utc>>,
+    /// Upper bound on `visible_at` (exclusive), RFC 3339.
+    pub before: Option<DateTime<Utc>>,
+    pub limit: Option<i64>,
+    /// Opaque keyset cursor from the previous page's `next_cursor`.
+    pub cursor: Option<String>,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct AdminNotification {
+    /// TypeID, `notif_…`.
+    pub id: String,
+    pub subscriber_id: String,
+    pub category: String,
+    pub payload: Value,
+    pub created_at: String,
+    pub deliver_at: Option<String>,
+    pub visible_at: String,
+    pub read_at: Option<String>,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct AdminNotificationPage {
+    pub items: Vec<AdminNotification>,
+    pub next_cursor: Option<String>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/admin/api/environments/{env_id}/notifications",
+    tag = "admin",
+    operation_id = "adminListNotifications",
+    summary = "Browse direct notifications (filter by subscriber, category, time)",
+    params(
+        ("env_id" = String, Path, description = "Environment TypeID (env_…)."),
+        AdminNotificationFilter
+    ),
+    responses((status = 200, description = "A page of notifications.", body = AdminNotificationPage),
+              (status = 400, description = "Malformed cursor or out-of-range limit.", body = crate::api::contract::Error),
+              (status = 401, description = "Admin authentication required."),
+              (status = 404, description = "No such environment.", body = crate::api::contract::Error)),
+    security(("AdminToken" = []))
+)]
+pub async fn list_notifications(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Path(env_id): Path<String>,
+    ApiQuery(filter): ApiQuery<AdminNotificationFilter>,
+) -> Result<Json<AdminNotificationPage>, ApiError> {
+    let env = parse_env_id(&env_id)?;
+    ensure_environment(&state, env).await?;
+    let limit = filter.limit.unwrap_or(ADMIN_NOTIFICATION_PAGE);
+    if !(1..=ADMIN_NOTIFICATION_MAX_PAGE).contains(&limit) {
+        return Err(ApiError::bad_request("limit must be between 1 and 200"));
+    }
+    let (cursor_ts, cursor_id) = match &filter.cursor {
+        None => (DateTime::<Utc>::MAX_UTC, Uuid::max()),
+        Some(c) => {
+            inbox::decode_cursor(c).ok_or_else(|| ApiError::bad_request("malformed cursor"))?
+        }
+    };
+
+    // Cross-partition, env-scoped admin scan (not a hot path). Keyset on
+    // (visible_at, id) descending, mirroring the inbox ordering spine.
+    let rows = sqlx::query!(
+        r#"SELECT n.id, s.subscriber_id AS "subscriber_id!", n.category, n.payload,
+                  n.created_at, n.deliver_at, n.visible_at, n.read_at
+             FROM notifications n
+             JOIN subscribers s ON s.environment_id = n.environment_id
+                               AND s.id = n.subscriber_id
+            WHERE n.environment_id = $1
+              AND ($2::text IS NULL OR s.subscriber_id = $2)
+              AND ($3::text IS NULL OR n.category = $3)
+              AND ($4::timestamptz IS NULL OR n.visible_at >= $4)
+              AND ($5::timestamptz IS NULL OR n.visible_at < $5)
+              AND (n.visible_at, n.id) < ($6, $7)
+            ORDER BY n.visible_at DESC, n.id DESC
+            LIMIT $8"#,
+        env,
+        filter.subscriber_id.as_deref(),
+        filter.category.as_deref(),
+        filter.after,
+        filter.before,
+        cursor_ts,
+        cursor_id,
+        limit,
+    )
+    .fetch_all(&state.pool)
+    .await
+    .map_err(ApiError::from)?;
+
+    let next_cursor = (rows.len() as i64 == limit)
+        .then(|| {
+            rows.last()
+                .map(|r| inbox::encode_cursor(r.visible_at, r.id))
+        })
+        .flatten();
+    let items = rows
+        .into_iter()
+        .map(|r| AdminNotification {
+            id: ids::typeid(ids::NOTIFICATION, r.id),
+            subscriber_id: r.subscriber_id,
+            category: r.category,
+            payload: r.payload,
+            created_at: format_ts(r.created_at),
+            deliver_at: r.deliver_at.map(format_ts),
+            visible_at: format_ts(r.visible_at),
+            read_at: r.read_at.map(format_ts),
+        })
+        .collect();
+
+    Ok(Json(AdminNotificationPage { items, next_cursor }))
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct AdminTimelineEntry {
+    pub status: String,
+    pub occurred_at: String,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct AdminNotificationTimeline {
+    pub id: String,
+    pub subscriber_id: String,
+    pub timeline: Vec<AdminTimelineEntry>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/admin/api/environments/{env_id}/notifications/{notif_id}/timeline",
+    tag = "admin",
+    operation_id = "adminNotificationTimeline",
+    summary = "Status timeline for one notification (the \"did it send?\" answer)",
+    params(
+        ("env_id" = String, Path, description = "Environment TypeID (env_…)."),
+        ("notif_id" = String, Path, description = "Notification TypeID (notif_…).")
+    ),
+    responses((status = 200, description = "The timeline so far.", body = AdminNotificationTimeline),
+              (status = 401, description = "Admin authentication required."),
+              (status = 404, description = "No such notification.", body = crate::api::contract::Error)),
+    security(("AdminToken" = []))
+)]
+pub async fn notification_timeline(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Path((env_id, notif_id)): Path<(String, String)>,
+) -> Result<Json<AdminNotificationTimeline>, ApiError> {
+    let env = parse_env_id(&env_id)?;
+    let id = ids::parse_typeid(ids::NOTIFICATION, &notif_id)
+        .ok_or_else(|| ApiError::not_found("no such notification"))?;
+
+    let subscriber = sqlx::query_scalar!(
+        r#"SELECT s.subscriber_id FROM notifications n
+             JOIN subscribers s ON s.environment_id = n.environment_id
+                               AND s.id = n.subscriber_id
+            WHERE n.environment_id = $1 AND n.id = $2"#,
+        env,
+        id,
+    )
+    .fetch_optional(&state.pool)
+    .await
+    .map_err(ApiError::from)?
+    .ok_or_else(|| ApiError::not_found("no such notification"))?;
+
+    // Same read as the management-plane timeline: min() per status is a
+    // defensive read-time dedupe (writers guarantee one row per status).
+    let rows = sqlx::query!(
+        r#"SELECT status, min(occurred_at) AS "occurred_at!"
+             FROM notification_status_log
+            WHERE environment_id = $1 AND notification_id = $2
+            GROUP BY status ORDER BY 2, 1"#,
+        env,
+        id,
+    )
+    .fetch_all(&state.pool)
+    .await
+    .map_err(ApiError::from)?;
+
+    Ok(Json(AdminNotificationTimeline {
+        id: ids::typeid(ids::NOTIFICATION, id),
+        subscriber_id: subscriber,
+        timeline: rows
+            .into_iter()
+            .map(|r| AdminTimelineEntry {
+                status: r.status,
+                occurred_at: format_ts(r.occurred_at),
+            })
+            .collect(),
+    }))
+}
+
+// =============================================================================
+// Broadcast composer (reuses the canonical write-path)
+// =============================================================================
+
+#[derive(Deserialize, ToSchema)]
+pub struct AdminCreateBroadcastRequest {
+    pub category: String,
+    pub payload: Option<Value>,
+    pub idempotency_key: Option<String>,
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/api/environments/{env_id}/broadcasts",
+    tag = "admin",
+    operation_id = "adminCreateBroadcast",
+    summary = "Compose a broadcast (one row, fan-out on read)",
+    description = "Composing is creating: the same idempotent management-plane write-path. One row per announcement, never materialized per subscriber.",
+    params(("env_id" = String, Path, description = "Environment TypeID (env_…).")),
+    request_body = AdminCreateBroadcastRequest,
+    responses((status = 201, description = "Created.", body = crate::api::contract::Broadcast),
+              (status = 200, description = "Idempotent replay.", body = crate::api::contract::Broadcast),
+              (status = 400, description = "Validation error.", body = crate::api::contract::Error),
+              (status = 401, description = "Admin authentication required."),
+              (status = 404, description = "No such environment.", body = crate::api::contract::Error)),
+    security(("AdminToken" = []))
+)]
+pub async fn create_broadcast(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Path(env_id): Path<String>,
+    ApiJson(req): ApiJson<AdminCreateBroadcastRequest>,
+) -> Result<Response, ApiError> {
+    let env = parse_env_id(&env_id)?;
+    ensure_environment(&state, env).await?;
+    let category = management::validate_category(&req.category)?.to_owned();
+    let payload = management::validate_payload(req.payload)?;
+    let key = management::validate_idempotency_key(req.idempotency_key)?;
+    let (status, snapshot) =
+        management::create_broadcast_idempotent(&state, env, category, payload, key).await?;
+    Ok((status, Json(snapshot)).into_response())
+}
+
+// =============================================================================
+// Subscriber lookup (reuses the canonical merge + count queries)
+// =============================================================================
+
+#[derive(Serialize, ToSchema)]
+pub struct AdminPreference {
+    pub category: String,
+    pub channel: String,
+    pub enabled: bool,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct AdminInboxItem {
+    pub id: String,
+    pub source: String,
+    pub category: String,
+    pub payload: Value,
+    pub occurred_at: String,
+    pub read: bool,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct AdminSubscriberView {
+    pub subscriber_id: String,
+    /// Governs broadcast visibility (`broadcast.created_at >= this`).
+    pub created_at: String,
+    pub counters: AdminCounts,
+    pub read_watermark: String,
+    pub seen_watermark: String,
+    pub preferences: Vec<AdminPreference>,
+    /// The subscriber's recent merged inbox, from the SAME canonical query
+    /// the subscriber plane serves.
+    pub inbox: Vec<AdminInboxItem>,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct AdminCounts {
+    pub unread: i32,
+    pub unseen: i32,
+}
+
+impl From<InboxCounts> for AdminCounts {
+    fn from(c: InboxCounts) -> Self {
+        Self {
+            unread: c.unread,
+            unseen: c.unseen,
+        }
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/admin/api/environments/{env_id}/subscribers/{subscriber_id}",
+    tag = "admin",
+    operation_id = "adminGetSubscriber",
+    summary = "Subscriber lookup: counters, watermarks, preferences, merged inbox",
+    params(
+        ("env_id" = String, Path, description = "Environment TypeID (env_…)."),
+        ("subscriber_id" = String, Path, description = "Customer-provided subscriber id.")
+    ),
+    responses((status = 200, description = "Subscriber view.", body = AdminSubscriberView),
+              (status = 401, description = "Admin authentication required."),
+              (status = 404, description = "No such subscriber.", body = crate::api::contract::Error)),
+    security(("AdminToken" = []))
+)]
+pub async fn get_subscriber(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Path((env_id, subscriber_id)): Path<(String, String)>,
+) -> Result<Json<AdminSubscriberView>, ApiError> {
+    let env = parse_env_id(&env_id)?;
+    let identity = sqlx::query!(
+        r#"SELECT s.id, s.created_at,
+                  c.read_watermark AS "read_watermark!",
+                  c.seen_watermark AS "seen_watermark!"
+             FROM subscribers s
+             JOIN subscriber_counters c
+               ON c.environment_id = s.environment_id AND c.subscriber_id = s.id
+            WHERE s.environment_id = $1 AND s.subscriber_id = $2"#,
+        env,
+        subscriber_id,
+    )
+    .fetch_optional(&state.pool)
+    .await
+    .map_err(ApiError::from)?
+    .ok_or_else(|| ApiError::not_found("no such subscriber"))?;
+
+    let mut conn = state.pool.acquire().await.map_err(ApiError::from)?;
+    let counts = inbox::fetch_counts_for(&mut conn, env, identity.id, identity.created_at).await?;
+    let inbox_rows = inbox::list_items_for(
+        &mut *conn,
+        env,
+        identity.id,
+        identity.created_at,
+        DateTime::<Utc>::MAX_UTC,
+        Uuid::max(),
+        ADMIN_INBOX_PREVIEW,
+    )
+    .await
+    .map_err(ApiError::from)?;
+    drop(conn);
+
+    let preferences = sqlx::query!(
+        r#"SELECT category, channel, enabled FROM preferences
+            WHERE environment_id = $1 AND subscriber_id = $2
+            ORDER BY category, channel"#,
+        env,
+        identity.id,
+    )
+    .fetch_all(&state.pool)
+    .await
+    .map_err(ApiError::from)?;
+
+    Ok(Json(AdminSubscriberView {
+        subscriber_id,
+        created_at: format_ts(identity.created_at),
+        counters: counts.into(),
+        read_watermark: format_ts(identity.read_watermark),
+        seen_watermark: format_ts(identity.seen_watermark),
+        preferences: preferences
+            .into_iter()
+            .map(|p| AdminPreference {
+                category: p.category,
+                channel: p.channel,
+                enabled: p.enabled,
+            })
+            .collect(),
+        inbox: inbox_rows
+            .into_iter()
+            .map(|r| AdminInboxItem {
+                id: ids::typeid(
+                    if r.source == "notification" {
+                        ids::NOTIFICATION
+                    } else {
+                        ids::BROADCAST
+                    },
+                    r.id,
+                ),
+                source: r.source.to_owned(),
+                category: r.category,
+                payload: r.payload,
+                occurred_at: format_ts(r.occurred_at),
+                read: r.read,
+            })
+            .collect(),
+    }))
+}
+
+// =============================================================================
+// DLQ browser + replay (the documented cross-environment admin path)
+// =============================================================================
+
+#[derive(Serialize, ToSchema)]
+pub struct AdminDeadLetter {
+    /// TypeID, `job_…` (stable across park/replay).
+    pub id: String,
+    pub environment_slug: String,
+    pub job_type: String,
+    pub attempts: i32,
+    pub last_error: String,
+    pub parked_at: String,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct AdminReplayResult {
+    /// Number of parked jobs moved back into the claim path.
+    pub replayed: i64,
+}
+
+#[utoipa::path(
+    get,
+    path = "/admin/api/dlq",
+    tag = "admin",
+    operation_id = "adminListDeadLetters",
+    summary = "List parked jobs across environments",
+    responses((status = 200, description = "Parked jobs.", body = Vec<AdminDeadLetter>),
+              (status = 401, description = "Admin authentication required.")),
+    security(("AdminToken" = []))
+)]
+pub async fn list_dlq(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+) -> Result<Json<Vec<AdminDeadLetter>>, ApiError> {
+    let letters = dlq::list(&state.pool).await.map_err(ApiError::from)?;
+    Ok(Json(
+        letters
+            .into_iter()
+            .map(|l| AdminDeadLetter {
+                id: l.typeid(),
+                environment_slug: l.environment_slug,
+                job_type: l.job_type,
+                attempts: l.attempts,
+                last_error: l.last_error,
+                parked_at: format_ts(l.parked_at),
+            })
+            .collect(),
+    ))
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/api/dlq/{job_id}/replay",
+    tag = "admin",
+    operation_id = "adminReplayDeadLetter",
+    summary = "Replay one parked job (re-enters the normal claim path)",
+    description = "Moves the parked row back into `jobs` with a fresh attempt budget; the normal worker loop (SKIP LOCKED, per-environment fairness, delete-on-completion) runs it. Never executed inline.",
+    params(("job_id" = String, Path, description = "Job TypeID (job_…).")),
+    responses((status = 200, description = "Replayed.", body = AdminReplayResult),
+              (status = 401, description = "Admin authentication required."),
+              (status = 404, description = "No such parked job.", body = crate::api::contract::Error)),
+    security(("AdminToken" = []))
+)]
+pub async fn replay_dead_letter(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Path(job_id): Path<String>,
+) -> Result<Json<AdminReplayResult>, ApiError> {
+    let id = ids::parse_typeid(ids::JOB, &job_id)
+        .ok_or_else(|| ApiError::not_found("no such parked job"))?;
+    // Cross-environment admin path: job ids are globally unique UUIDv7s.
+    let replayed = dlq::replay(&state.pool, id, None)
+        .await
+        .map_err(ApiError::from)?;
+    if !replayed {
+        return Err(ApiError::not_found("no such parked job"));
+    }
+    Ok(Json(AdminReplayResult { replayed: 1 }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/api/dlq/replay-all",
+    tag = "admin",
+    operation_id = "adminReplayAllDeadLetters",
+    summary = "Replay every parked job",
+    responses((status = 200, description = "Replayed.", body = AdminReplayResult),
+              (status = 401, description = "Admin authentication required.")),
+    security(("AdminToken" = []))
+)]
+pub async fn replay_all_dead_letters(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+) -> Result<Json<AdminReplayResult>, ApiError> {
+    let replayed = dlq::replay_all(&state.pool, None)
+        .await
+        .map_err(ApiError::from)? as i64;
+    Ok(Json(AdminReplayResult { replayed }))
+}
+
+// =============================================================================
+// Shared helpers
+// =============================================================================
+
+fn parse_env_id(env_id: &str) -> Result<Uuid, ApiError> {
+    ids::parse_typeid(ids::ENVIRONMENT, env_id)
+        .ok_or_else(|| ApiError::not_found("no such environment"))
+}
+
+async fn ensure_environment(state: &AppState, env: Uuid) -> Result<(), ApiError> {
+    let exists = sqlx::query_scalar!(
+        r#"SELECT EXISTS(SELECT 1 FROM environments WHERE id = $1) AS "exists!""#,
+        env,
+    )
+    .fetch_one(&state.pool)
+    .await
+    .map_err(ApiError::from)?;
+    if exists {
+        Ok(())
+    } else {
+        Err(ApiError::not_found("no such environment"))
+    }
+}

--- a/server/src/api/inbox.rs
+++ b/server/src/api/inbox.rs
@@ -154,9 +154,71 @@ pub async fn list_items(
         return Ok((StatusCode::NOT_MODIFIED, response_headers).into_response());
     }
 
-    // The canonical merged list query (specs/schema.sql header). Both arms
-    // are keyset range scans over notifications_inbox_idx /
-    // broadcasts_window_idx; category mutes are read-time NOT EXISTS probes.
+    let rows = list_items_for(
+        &state.pool,
+        auth.environment_id,
+        auth.subscriber_id,
+        auth.subscriber_created_at,
+        cursor_ts,
+        cursor_id,
+        limit,
+    )
+    .await
+    .map_err(ApiError::from)?;
+
+    let next_cursor = (rows.len() as i64 == limit)
+        .then(|| rows.last().map(|r| encode_cursor(r.occurred_at, r.id)))
+        .flatten();
+    let items: Vec<InboxItem> = rows.into_iter().map(InboxItem::from).collect();
+
+    Ok((response_headers, Json(InboxPage { items, next_cursor })).into_response())
+}
+
+/// One row of the merged two-source inbox, with the source's native id type
+/// and ordering timestamp intact (so callers can keyset-paginate). The
+/// subscriber plane and the admin subscriber-lookup BOTH read through this
+/// one function: a second implementation of the merge would be a bug
+/// (specs/phase-4-admin.md, "admin reads reuse the canonical queries").
+pub struct MergedRow {
+    pub source: &'static str,
+    pub id: Uuid,
+    pub category: String,
+    pub payload: Value,
+    pub occurred_at: DateTime<Utc>,
+    pub read: bool,
+}
+
+impl From<MergedRow> for InboxItem {
+    fn from(row: MergedRow) -> Self {
+        let prefix = match row.source {
+            "notification" => ids::NOTIFICATION,
+            _ => ids::BROADCAST,
+        };
+        Self {
+            id: ids::typeid(prefix, row.id),
+            source: row.source,
+            category: row.category,
+            payload: row.payload,
+            occurred_at: format_ts(row.occurred_at),
+            read: row.read,
+        }
+    }
+}
+
+/// The canonical merged list query (specs/schema.sql header). Both arms are
+/// keyset range scans over notifications_inbox_idx / broadcasts_window_idx;
+/// category mutes are read-time NOT EXISTS probes. `(cursor_ts, cursor_id)`
+/// is the last item of the previous page, or `(MAX_UTC, Uuid::max())` for
+/// the first page.
+pub async fn list_items_for<'e, E: sqlx::PgExecutor<'e>>(
+    executor: E,
+    environment_id: Uuid,
+    subscriber_id: Uuid,
+    subscriber_created_at: DateTime<Utc>,
+    cursor_ts: DateTime<Utc>,
+    cursor_id: Uuid,
+    limit: i64,
+) -> sqlx::Result<Vec<MergedRow>> {
     let rows = sqlx::query!(
         r#"SELECT merged.source AS "source!", merged.id AS "id!",
                   merged.category AS "category!", merged.payload AS "payload!",
@@ -200,39 +262,31 @@ pub async fn list_items(
            ) merged
            ORDER BY occurred_at DESC, id DESC
            LIMIT $5"#,
-        auth.environment_id,
-        auth.subscriber_id,
+        environment_id,
+        subscriber_id,
         cursor_ts,
         cursor_id,
         limit,
-        auth.subscriber_created_at,
+        subscriber_created_at,
     )
-    .fetch_all(&state.pool)
-    .await
-    .map_err(ApiError::from)?;
+    .fetch_all(executor)
+    .await?;
 
-    let next_cursor = (rows.len() as i64 == limit)
-        .then(|| rows.last().map(|r| encode_cursor(r.occurred_at, r.id)))
-        .flatten();
-    let items: Vec<InboxItem> = rows
+    Ok(rows
         .into_iter()
-        .map(|r| {
-            let (source, prefix) = match r.source.as_str() {
-                "notification" => ("notification", ids::NOTIFICATION),
-                _ => ("broadcast", ids::BROADCAST),
-            };
-            InboxItem {
-                id: ids::typeid(prefix, r.id),
-                source,
-                category: r.category,
-                payload: r.payload,
-                occurred_at: format_ts(r.occurred_at),
-                read: r.read,
-            }
+        .map(|r| MergedRow {
+            source: if r.source == "notification" {
+                "notification"
+            } else {
+                "broadcast"
+            },
+            id: r.id,
+            category: r.category,
+            payload: r.payload,
+            occurred_at: r.occurred_at,
+            read: r.read,
         })
-        .collect();
-
-    Ok((response_headers, Json(InboxPage { items, next_cursor })).into_response())
+        .collect())
 }
 
 #[utoipa::path(
@@ -290,6 +344,24 @@ pub async fn fetch_counts(
     conn: &mut sqlx::PgConnection,
     auth: &SubscriberAuth,
 ) -> Result<InboxCounts, ApiError> {
+    fetch_counts_for(
+        conn,
+        auth.environment_id,
+        auth.subscriber_id,
+        auth.subscriber_created_at,
+    )
+    .await
+}
+
+/// The canonical unread/unseen count, by explicit identity. The subscriber
+/// plane and the admin subscriber-lookup share this one implementation so the
+/// admin view can never disagree with what the subscriber sees.
+pub async fn fetch_counts_for(
+    conn: &mut sqlx::PgConnection,
+    environment_id: Uuid,
+    subscriber_id: Uuid,
+    subscriber_created_at: DateTime<Utc>,
+) -> Result<InboxCounts, ApiError> {
     let row = sqlx::query!(
         r#"SELECT
                greatest(0, c.unread_direct_count
@@ -318,9 +390,9 @@ pub async fn fetch_counts(
                                AND p.enabled = false)))::int AS "unseen!"
            FROM subscriber_counters c
            WHERE c.environment_id = $1 AND c.subscriber_id = $2"#,
-        auth.environment_id,
-        auth.subscriber_id,
-        auth.subscriber_created_at,
+        environment_id,
+        subscriber_id,
+        subscriber_created_at,
     )
     .fetch_one(conn)
     .await

--- a/server/src/api/management.rs
+++ b/server/src/api/management.rs
@@ -294,7 +294,8 @@ pub async fn create_broadcast(
     let category = validate_category(&req.category)?.to_owned();
     let payload = validate_payload(req.payload)?;
     let key = validate_idempotency_key(req.idempotency_key)?;
-    let (status, snapshot) = create_broadcast_idempotent(&state, env, category, payload, key).await?;
+    let (status, snapshot) =
+        create_broadcast_idempotent(&state, env, category, payload, key).await?;
     Ok((status, Json(snapshot)).into_response())
 }
 

--- a/server/src/api/management.rs
+++ b/server/src/api/management.rs
@@ -294,16 +294,30 @@ pub async fn create_broadcast(
     let category = validate_category(&req.category)?.to_owned();
     let payload = validate_payload(req.payload)?;
     let key = validate_idempotency_key(req.idempotency_key)?;
+    let (status, snapshot) = create_broadcast_idempotent(&state, env, category, payload, key).await?;
+    Ok((status, Json(snapshot)).into_response())
+}
 
+/// The single broadcast write-path, shared by the management plane and the
+/// admin composer (specs/phase-4-admin.md: "composing is creating, same
+/// idempotent management-plane semantics"). One row per announcement,
+/// fan-out on read, NEVER materialized per subscriber, plus one env-wide hint
+/// regardless of subscriber count. Returns 201 on first acceptance, 200 on
+/// idempotent replay (byte-identical snapshot).
+pub(crate) async fn create_broadcast_idempotent(
+    state: &AppState,
+    env: Uuid,
+    category: String,
+    payload: Value,
+    key: String,
+) -> Result<(StatusCode, Value), ApiError> {
     if let Some(snapshot) = fetch_snapshot(&state.pool, env, "broadcast", &key).await? {
-        return Ok((StatusCode::OK, Json(snapshot)).into_response());
+        return Ok((StatusCode::OK, snapshot));
     }
 
     let result: sqlx::Result<Value> = async {
         let mut tx = state.pool.begin().await?;
         let id = ids::new_uuid();
-        // One row per announcement, fan-out on read: NEVER materialized per
-        // subscriber, and one env-wide hint regardless of subscriber count.
         let row = sqlx::query!(
             r#"INSERT INTO broadcasts (environment_id, id, category, payload)
                VALUES ($1, $2, $3, $4) RETURNING created_at"#,
@@ -329,12 +343,12 @@ pub async fn create_broadcast(
     .await;
 
     match result {
-        Ok(snapshot) => Ok((StatusCode::CREATED, Json(snapshot)).into_response()),
+        Ok(snapshot) => Ok((StatusCode::CREATED, snapshot)),
         Err(err) if is_idempotency_conflict(&err) => {
             let snapshot = fetch_snapshot(&state.pool, env, "broadcast", &key)
                 .await?
                 .ok_or_else(|| ApiError::from(anyhow::anyhow!("idempotency snapshot vanished")))?;
-            Ok((StatusCode::OK, Json(snapshot)).into_response())
+            Ok((StatusCode::OK, snapshot))
         }
         Err(err) => Err(err.into()),
     }
@@ -548,14 +562,14 @@ fn validate_recipients(req: &CreateNotificationsRequest) -> Result<Vec<String>, 
         .collect())
 }
 
-fn validate_category(category: &str) -> Result<&str, ApiError> {
+pub(crate) fn validate_category(category: &str) -> Result<&str, ApiError> {
     if category.is_empty() || category.len() > 255 {
         return Err(ApiError::bad_request("category must be 1–255 characters"));
     }
     Ok(category)
 }
 
-fn validate_payload(payload: Option<Value>) -> Result<Value, ApiError> {
+pub(crate) fn validate_payload(payload: Option<Value>) -> Result<Value, ApiError> {
     let payload = payload.unwrap_or_else(|| json!({}));
     if !payload.is_object() {
         return Err(ApiError::bad_request("payload must be a JSON object"));
@@ -567,7 +581,7 @@ fn validate_payload(payload: Option<Value>) -> Result<Value, ApiError> {
     Ok(payload)
 }
 
-fn validate_idempotency_key(key: Option<String>) -> Result<String, ApiError> {
+pub(crate) fn validate_idempotency_key(key: Option<String>) -> Result<String, ApiError> {
     match key {
         Some(key) if key.is_empty() || key.len() > 255 => Err(ApiError::bad_request(
             "idempotency_key must be 1–255 characters",

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -1,5 +1,6 @@
 //! The v1 HTTP surface (specs/openapi.yaml is the convergence target).
 
+pub mod admin;
 pub mod contract;
 pub mod inbox;
 pub mod management;

--- a/server/src/auth.rs
+++ b/server/src/auth.rs
@@ -9,10 +9,17 @@
 //! slot so secret rotation never invalidates live sessions. Headers with
 //! query-parameter fallbacks (EventSource cannot set headers).
 
+use axum::Json;
 use axum::extract::FromRequestParts;
+use axum::http::header::{AUTHORIZATION, WWW_AUTHENTICATE};
 use axum::http::request::Parts;
+use axum::http::{HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use chrono::{DateTime, Utc};
 use hmac::{Hmac, Mac};
+use serde_json::json;
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
@@ -78,6 +85,82 @@ impl FromRequestParts<AppState> for ManagementAuth {
             api_key_id: row.id,
         })
     }
+}
+
+/// An instance admin caller (the embedded `/admin` dashboard plane).
+/// Single-org: ONE static credential for the whole instance, no admin users.
+/// Authenticated with HTTP Basic — the password is the configured admin
+/// token, the username is ignored. Basic (not Bearer) so the browser prompts
+/// for the credential on a bare `/admin` navigation and then attaches it to
+/// every same-origin asset and API request, which is what makes every SPA
+/// route gate on the credential without a separate login screen.
+pub struct AdminAuth;
+
+/// The 401 for the admin plane. Carries `WWW-Authenticate: Basic` so the
+/// browser shows its native credential prompt. The error envelope matches
+/// the rest of the API. The token is never named in the body or any header.
+pub struct AdminAuthRejection;
+
+impl IntoResponse for AdminAuthRejection {
+    fn into_response(self) -> Response {
+        let body = json!({
+            "error": { "code": "unauthorized", "message": "admin authentication required" }
+        });
+        let mut response = (StatusCode::UNAUTHORIZED, Json(body)).into_response();
+        response.headers_mut().insert(
+            WWW_AUTHENTICATE,
+            HeaderValue::from_static("Basic realm=\"dronte admin\", charset=\"UTF-8\""),
+        );
+        response
+    }
+}
+
+impl FromRequestParts<AppState> for AdminAuth {
+    type Rejection = AdminAuthRejection;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, AdminAuthRejection> {
+        // No token configured ⇒ the admin plane is disabled: nothing can
+        // authenticate, so every route 401s.
+        let configured = state.cfg.admin_token.as_deref().ok_or(AdminAuthRejection)?;
+
+        let password = parts
+            .headers
+            .get(AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("Basic "))
+            .and_then(|b64| BASE64_STANDARD.decode(b64.trim()).ok())
+            .and_then(|bytes| String::from_utf8(bytes).ok())
+            .map(|creds| {
+                // `user:password`; the username is ignored.
+                let mut parts = creds.splitn(2, ':');
+                let _user = parts.next();
+                parts.next().unwrap_or("").to_owned()
+            })
+            .ok_or(AdminAuthRejection)?;
+
+        if admin_token_matches(configured, &password) {
+            Ok(Self)
+        } else {
+            Err(AdminAuthRejection)
+        }
+    }
+}
+
+/// Constant-time credential comparison. Both sides are hashed to a fixed
+/// 32 bytes first, so neither the running time nor any early exit depends on
+/// the length of the supplied value, and the comparison is a full XOR-fold
+/// over equal-length digests.
+fn admin_token_matches(configured: &str, provided: &str) -> bool {
+    let configured = Sha256::digest(configured.as_bytes());
+    let provided = Sha256::digest(provided.as_bytes());
+    let mut diff = 0u8;
+    for (a, b) in configured.iter().zip(provided.iter()) {
+        diff |= a ^ b;
+    }
+    diff == 0
 }
 
 /// A subscriber-plane caller. Resolving it authenticates the request AND

--- a/server/src/bootstrap.rs
+++ b/server/src/bootstrap.rs
@@ -27,7 +27,7 @@ pub async fn run(pool: &PgPool, cfg: &Config) -> anyhow::Result<()> {
     // would silently break hashes computed against it, and downgrading
     // require_subscriber_hash would disable auth on an environment this
     // bootstrap does not own.
-    let hmac_secret = format!("whsec_{}", ids::new_uuid().as_simple());
+    let hmac_secret = format!("shmac_{}", ids::new_uuid().as_simple());
     let inserted = sqlx::query_scalar!(
         r#"INSERT INTO environments
                (id, slug, name, subscriber_hmac_secret, require_subscriber_hash)

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -42,6 +42,12 @@ pub struct Config {
     /// the quickstart curl is copy-pasteable. Ignored without
     /// `dev_environment`.
     pub dev_api_key: Option<String>,
+    /// Static credential for the embedded `/admin` dashboard and its API
+    /// (the HTTP Basic password; the username is ignored). One credential
+    /// for the whole instance — there are no admin users (single-org).
+    /// `None` disables the admin plane: every `/admin` route answers 401.
+    /// Supplied only via env var; never logged or echoed.
+    pub admin_token: Option<String>,
     /// First retry delay for a failed job. Attempt n waits roughly
     /// `base * 2^(n-1)`, equal-jittered, capped below.
     pub retry_backoff_base: Duration,
@@ -92,6 +98,9 @@ impl Config {
                 .ok()
                 .filter(|s| !s.is_empty()),
             dev_api_key: std::env::var("DRONTE_DEV_API_KEY")
+                .ok()
+                .filter(|s| !s.is_empty()),
+            admin_token: std::env::var("DRONTE_ADMIN_TOKEN")
                 .ok()
                 .filter(|s| !s.is_empty()),
             retry_backoff_base: Duration::from_millis(parse_var(

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -10,7 +10,7 @@ use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 use tower_http::cors::{Any, CorsLayer};
 use utoipa_scalar::Servable as _;
 
-use crate::api::{inbox, management, preferences, sse};
+use crate::api::{admin, inbox, management, preferences, sse};
 use crate::state::AppState;
 use crate::{db, openapi};
 
@@ -76,6 +76,11 @@ pub fn router(state: AppState) -> Router {
         )
         // Subscriber plane (CORS-enabled)
         .merge(subscriber_plane)
+        // Admin plane (the embedded /admin dashboard). Every route gates on
+        // AdminAuth (HTTP Basic, the static DRONTE_ADMIN_TOKEN). No CORS:
+        // the dashboard is same-origin, served from this binary. Explicit
+        // API routes are matched before the SPA wildcard fallback.
+        .merge(admin_plane())
         // Operational plane
         .route("/healthz", get(healthz))
         .route("/readyz", get(readyz))
@@ -86,6 +91,66 @@ pub fn router(state: AppState) -> Router {
         .merge(utoipa_scalar::Scalar::with_url("/docs", openapi::api_doc()))
         .layer(middleware::from_fn(access_log))
         .with_state(state)
+}
+
+/// The embedded admin dashboard: its JSON API plus the rust-embedded SPA.
+/// Every handler resolves `AdminAuth` first, so an unauthenticated request to
+/// any path here — API or SPA — is a 401 with `WWW-Authenticate: Basic`.
+fn admin_plane() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/admin/api/environments",
+            get(admin::list_environments).post(admin::create_environment),
+        )
+        .route(
+            "/admin/api/environments/{env_id}",
+            get(admin::get_environment),
+        )
+        .route(
+            "/admin/api/environments/{env_id}/hmac/rotate",
+            post(admin::rotate_hmac),
+        )
+        .route(
+            "/admin/api/environments/{env_id}/hmac/rotate/complete",
+            post(admin::complete_hmac_rotation),
+        )
+        .route(
+            "/admin/api/environments/{env_id}/api-keys",
+            get(admin::list_api_keys).post(admin::create_api_key),
+        )
+        .route(
+            "/admin/api/environments/{env_id}/api-keys/{key_id}/revoke",
+            post(admin::revoke_api_key),
+        )
+        .route(
+            "/admin/api/environments/{env_id}/notifications",
+            get(admin::list_notifications),
+        )
+        .route(
+            "/admin/api/environments/{env_id}/notifications/{notif_id}/timeline",
+            get(admin::notification_timeline),
+        )
+        .route(
+            "/admin/api/environments/{env_id}/broadcasts",
+            post(admin::create_broadcast),
+        )
+        .route(
+            "/admin/api/environments/{env_id}/subscribers/{subscriber_id}",
+            get(admin::get_subscriber),
+        )
+        .route("/admin/api/dlq", get(admin::list_dlq))
+        .route(
+            "/admin/api/dlq/replay-all",
+            post(admin::replay_all_dead_letters),
+        )
+        .route(
+            "/admin/api/dlq/{job_id}/replay",
+            post(admin::replay_dead_letter),
+        )
+        // The SPA shell + assets. The wildcard is matched only after the
+        // explicit API routes above (matchit prefers specific routes).
+        .route("/admin", get(admin::serve_spa))
+        .route("/admin/{*path}", get(admin::serve_spa))
 }
 
 /// The recorder is process-global. Tests build many routers in one process.

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -58,7 +58,8 @@ conventional status codes. 429 carries `Retry-After`.
     info(title = "Dronte API", version = "1.0.0"),
     tags(
         (name = "management", description = "Backend-to-Dronte. Bearer API key."),
-        (name = "subscriber", description = "Widget-to-Dronte. HMAC subscriber hash.")
+        (name = "subscriber", description = "Widget-to-Dronte. HMAC subscriber hash."),
+        (name = "admin", description = "Instance admin dashboard. HTTP Basic (static credential).")
     ),
     paths(
         crate::api::management::create_notifications,
@@ -76,6 +77,24 @@ conventional status codes. 429 carries `Retry-After`.
         crate::api::preferences::get_inbox_preferences,
         crate::api::preferences::set_inbox_preferences,
         crate::api::sse::stream,
+        // Phase 4 admin plane (specs/phase-4-admin.md). Additive post-freeze
+        // surface: stripped from the contract convergence diff (ci.yml), kept
+        // in the served/generated spec under the `admin` tag.
+        crate::api::admin::list_environments,
+        crate::api::admin::create_environment,
+        crate::api::admin::get_environment,
+        crate::api::admin::rotate_hmac,
+        crate::api::admin::complete_hmac_rotation,
+        crate::api::admin::list_api_keys,
+        crate::api::admin::create_api_key,
+        crate::api::admin::revoke_api_key,
+        crate::api::admin::list_notifications,
+        crate::api::admin::notification_timeline,
+        crate::api::admin::create_broadcast,
+        crate::api::admin::get_subscriber,
+        crate::api::admin::list_dlq,
+        crate::api::admin::replay_dead_letter,
+        crate::api::admin::replay_all_dead_letters,
     ),
     components(
         schemas(
@@ -121,6 +140,17 @@ pub fn api_doc() -> utoipa::openapi::OpenApi {
             utoipa::openapi::security::HttpBuilder::new()
                 .scheme(HttpAuthScheme::Bearer)
                 .description(Some("Environment-scoped management API key."))
+                .build(),
+        ),
+    );
+    components.add_security_scheme(
+        "AdminToken",
+        SecurityScheme::Http(
+            utoipa::openapi::security::HttpBuilder::new()
+                .scheme(HttpAuthScheme::Basic)
+                .description(Some(
+                    "Instance admin credential (DRONTE_ADMIN_TOKEN) as the HTTP Basic password.",
+                ))
                 .build(),
         ),
     );
@@ -394,7 +424,7 @@ mod tests {
             .into_iter()
             .map(|t| t.name)
             .collect();
-        assert_eq!(tags, ["management", "subscriber"]);
+        assert_eq!(tags, ["management", "subscriber", "admin"]);
     }
 
     #[test]

--- a/server/tests/admin.rs
+++ b/server/tests/admin.rs
@@ -1,0 +1,566 @@
+//! Phase 4 admin plane (specs/phase-4-admin.md acceptance criteria).
+//!
+//! Auth gating, environment/API-key lifecycle, HMAC two-slot rotation,
+//! broadcast composing as ONE row, the subscriber-lookup golden test (admin
+//! merged inbox == subscriber-plane API), DLQ replay through the normal claim
+//! path, and the status-timeline browser.
+
+mod support;
+
+use dronte::auth::compute_subscriber_hash;
+use dronte::ids;
+use reqwest::header::HeaderValue;
+use serde_json::{Value, json};
+
+fn env_typeid(app: &support::TestApp) -> String {
+    ids::typeid(ids::ENVIRONMENT, app.env.id)
+}
+
+/// Subscriber-plane GET /v1/inbox/counts with a hash computed from `secret`.
+async fn counts_status_with_secret(
+    app: &support::TestApp,
+    subscriber: &str,
+    secret: &str,
+) -> reqwest::StatusCode {
+    let hash = compute_subscriber_hash(secret, subscriber);
+    app.client
+        .get(format!("{}/v1/inbox/counts", app.base))
+        .header("X-Dronte-Environment", app.env.slug.clone())
+        .header("X-Dronte-Subscriber", subscriber)
+        .header("X-Dronte-Subscriber-Hash", hash)
+        .send()
+        .await
+        .expect("counts")
+        .status()
+}
+
+// =============================================================================
+// Auth
+// =============================================================================
+
+#[tokio::test]
+async fn every_admin_route_401s_without_the_credential() {
+    let app = support::spawn().await;
+
+    // API route, no credential.
+    let res = app
+        .client
+        .get(format!("{}/admin/api/environments", app.base))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+    // The 401 prompts the browser via Basic.
+    assert_eq!(
+        res.headers().get("www-authenticate"),
+        Some(&HeaderValue::from_static(
+            "Basic realm=\"dronte admin\", charset=\"UTF-8\""
+        ))
+    );
+
+    // SPA shell, no credential.
+    let spa = app
+        .client
+        .get(format!("{}/admin", app.base))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(spa.status(), 401);
+
+    // A nested SPA route, no credential.
+    let route = app
+        .client
+        .get(format!("{}/admin/environments", app.base))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(route.status(), 401);
+
+    // Wrong password.
+    let wrong = app
+        .client
+        .get(format!("{}/admin/api/environments", app.base))
+        .basic_auth("admin", Some("not-the-token"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(wrong.status(), 401);
+
+    // Correct credential succeeds for both API and SPA.
+    assert_eq!(app.admin_get("/admin/api/environments").send().await.unwrap().status(), 200);
+    let spa_ok = app.admin_get("/admin").send().await.unwrap();
+    assert_eq!(spa_ok.status(), 200);
+    assert!(
+        spa_ok
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .starts_with("text/html")
+    );
+    // A POST also gates (and a username other than the password is fine).
+    let create_unauth = app
+        .client
+        .post(format!("{}/admin/api/environments", app.base))
+        .json(&json!({"slug": "x", "name": "x"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(create_unauth.status(), 401);
+}
+
+#[tokio::test]
+async fn admin_plane_disabled_without_a_configured_token() {
+    let app = support::spawn_configured(false, |cfg| cfg.admin_token = None).await;
+    // Even a well-formed credential 401s when the plane is disabled.
+    let res = app.admin_get("/admin/api/environments").send().await.unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+// =============================================================================
+// Environment + API key lifecycle
+// =============================================================================
+
+#[tokio::test]
+async fn environment_and_api_key_create_revoke_roundtrip() {
+    let app = support::spawn().await;
+
+    // Create an environment.
+    let res = app
+        .admin_post(
+            "/admin/api/environments",
+            json!({"slug": "dashboard-prod", "name": "Dashboard (prod)", "require_subscriber_hash": true}),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 201);
+    let env: Value = res.json().await.unwrap();
+    let env_id = env["id"].as_str().unwrap().to_owned();
+    assert!(env_id.starts_with("env_"));
+    assert!(env["subscriber_hmac_secret"].as_str().unwrap().starts_with("whsec_"));
+    assert_eq!(env["has_previous_secret"], json!(false));
+
+    // It shows up in the list.
+    let list: Value = app
+        .admin_get("/admin/api/environments")
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(
+        list.as_array()
+            .unwrap()
+            .iter()
+            .any(|e| e["slug"] == json!("dashboard-prod"))
+    );
+
+    // Duplicate slug is rejected.
+    let dup = app
+        .admin_post(
+            "/admin/api/environments",
+            json!({"slug": "dashboard-prod", "name": "again"}),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(dup.status(), 400);
+
+    // Create an API key — plaintext returned exactly once.
+    let key_res = app
+        .admin_post(
+            &format!("/admin/api/environments/{env_id}/api-keys"),
+            json!({"name": "ci"}),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(key_res.status(), 201);
+    let key_body: Value = key_res.json().await.unwrap();
+    let key_id = key_body["id"].as_str().unwrap().to_owned();
+    let plaintext = key_body["key"].as_str().unwrap().to_owned();
+    assert!(plaintext.starts_with("drnt_live_"));
+    assert!(key_id.starts_with("key_"));
+
+    // The key authenticates the management plane for THIS environment.
+    let notify = app
+        .client
+        .post(format!("{}/v1/notifications", app.base))
+        .bearer_auth(&plaintext)
+        .json(&json!({"subscriber_id": "usr_new", "category": "demo"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(notify.status(), 201);
+
+    // Listing shows the prefix, last_used_at, and NEVER the key.
+    let keys: Value = app
+        .admin_get(&format!("/admin/api/environments/{env_id}/api-keys"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let key_row = keys.as_array().unwrap().iter().find(|k| k["id"] == json!(key_id)).unwrap();
+    assert_eq!(key_row["key_prefix"], json!(&plaintext[..14]));
+    assert!(key_row.get("key").is_none(), "the plaintext key must never be listed");
+    assert!(key_row["last_used_at"].is_string(), "use should record last_used_at");
+
+    // Revoke it; the key 401s immediately on the management plane.
+    let revoke = app
+        .admin_post(
+            &format!("/admin/api/environments/{env_id}/api-keys/{key_id}/revoke"),
+            json!({}),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(revoke.status(), 204);
+    let after = app
+        .client
+        .post(format!("{}/v1/notifications", app.base))
+        .bearer_auth(&plaintext)
+        .json(&json!({"subscriber_id": "usr_new", "category": "demo"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(after.status(), 401);
+
+    // The revoked row is kept for audit with revoked_at set.
+    let keys2: Value = app
+        .admin_get(&format!("/admin/api/environments/{env_id}/api-keys"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let revoked_row = keys2.as_array().unwrap().iter().find(|k| k["id"] == json!(key_id)).unwrap();
+    assert!(revoked_row["revoked_at"].is_string());
+}
+
+// =============================================================================
+// HMAC rotation (two-slot overlap) via the admin API
+// =============================================================================
+
+#[tokio::test]
+async fn hmac_rotation_overlap_then_completion() {
+    let app = support::spawn().await;
+    let env = env_typeid(&app);
+    let subscriber = "usr_rot";
+    let old_secret = app.env.hmac_secret.clone();
+
+    // The current secret authenticates a widget session.
+    assert_eq!(counts_status_with_secret(&app, subscriber, &old_secret).await, 200);
+
+    // Begin rotation: a new current secret, old secret moved to previous.
+    let rot: Value = app
+        .admin_post(&format!("/admin/api/environments/{env}/hmac/rotate"), json!({}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let new_secret = rot["subscriber_hmac_secret"].as_str().unwrap().to_owned();
+    assert_ne!(new_secret, old_secret);
+    assert_eq!(rot["has_previous_secret"], json!(true));
+    assert!(rot["subscriber_hmac_rotated_at"].is_string());
+
+    // Overlap: BOTH secrets verify live sessions (zero-downtime rotation).
+    assert_eq!(counts_status_with_secret(&app, subscriber, &old_secret).await, 200);
+    assert_eq!(counts_status_with_secret(&app, subscriber, &new_secret).await, 200);
+
+    // Rotation is observable in the environment view.
+    let detail: Value = app
+        .admin_get(&format!("/admin/api/environments/{env}"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(detail["subscriber_hmac_secret"], json!(new_secret));
+    assert_eq!(detail["has_previous_secret"], json!(true));
+
+    // Complete the rotation: the previous slot is cleared.
+    let done = app
+        .admin_post(
+            &format!("/admin/api/environments/{env}/hmac/rotate/complete"),
+            json!({}),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(done.status(), 204);
+
+    // Old secret now dies; the new one still works.
+    assert_eq!(counts_status_with_secret(&app, subscriber, &old_secret).await, 401);
+    assert_eq!(counts_status_with_secret(&app, subscriber, &new_secret).await, 200);
+}
+
+// =============================================================================
+// Broadcast composer
+// =============================================================================
+
+#[tokio::test]
+async fn admin_broadcast_lands_as_one_row_and_respects_visibility() {
+    let app = support::spawn().await;
+    let env = env_typeid(&app);
+
+    // A subscriber that exists BEFORE the broadcast sees it.
+    let _ = app.counts("usr_before").await;
+
+    let res = app
+        .admin_post(
+            &format!("/admin/api/environments/{env}/broadcasts"),
+            json!({"category": "product.update", "payload": {"title": "Launch"}}),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 201);
+    let bcast: Value = res.json().await.unwrap();
+    let bcast_id = bcast["id"].as_str().unwrap().to_owned();
+    assert!(bcast_id.starts_with("bcast_"));
+
+    // Exactly ONE row, never materialized per subscriber.
+    let row_count: i64 = sqlx::query_scalar("SELECT count(*) FROM broadcasts WHERE environment_id = $1")
+        .bind(app.env.id)
+        .fetch_one(&app.pool)
+        .await
+        .unwrap();
+    assert_eq!(row_count, 1);
+
+    // It appears in the pre-existing subscriber's merged list.
+    let before_list = app.list_items("usr_before").await;
+    assert!(
+        before_list["items"].as_array().unwrap().iter().any(|i| i["id"] == json!(bcast_id)),
+        "pre-existing subscriber should see the broadcast"
+    );
+
+    // A subscriber created AFTER the broadcast does not see it.
+    let _ = app.counts("usr_after").await;
+    let after_list = app.list_items("usr_after").await;
+    assert!(
+        !after_list["items"].as_array().unwrap().iter().any(|i| i["id"] == json!(bcast_id)),
+        "later subscriber must not see an earlier broadcast"
+    );
+}
+
+// =============================================================================
+// Subscriber lookup — golden test against the subscriber plane
+// =============================================================================
+
+#[tokio::test]
+async fn subscriber_lookup_inbox_matches_the_subscriber_plane() {
+    let app = support::spawn().await;
+    let env = env_typeid(&app);
+    let subscriber = "usr_golden";
+
+    // Make the subscriber exist first, then a mix of direct + broadcast.
+    let _ = app.counts(subscriber).await;
+    app.create_broadcast("announce.one").await;
+    for i in 0..3 {
+        app.create_notification(subscriber, &format!("cat.{i}")).await;
+    }
+    app.create_broadcast("announce.two").await;
+    app.drain_jobs().await;
+
+    // Subscriber-plane truth.
+    let plane_ids: Vec<String> = app
+        .list_all_items(subscriber, 100)
+        .await
+        .into_iter()
+        .map(|i| i["id"].as_str().unwrap().to_owned())
+        .collect();
+
+    // Admin subscriber view runs the SAME canonical merge.
+    let view: Value = app
+        .admin_get(&format!("/admin/api/environments/{env}/subscribers/{subscriber}"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let admin_ids: Vec<String> = view["inbox"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|i| i["id"].as_str().unwrap().to_owned())
+        .collect();
+
+    assert_eq!(admin_ids, plane_ids, "admin inbox must equal the subscriber plane list");
+
+    // Counters agree with the subscriber plane too.
+    let (plane_unread, plane_unseen) = app.counts(subscriber).await;
+    assert_eq!(view["counters"]["unread"].as_i64().unwrap(), plane_unread);
+    assert_eq!(view["counters"]["unseen"].as_i64().unwrap(), plane_unseen);
+    assert!(view["read_watermark"].is_string());
+    assert!(view["seen_watermark"].is_string());
+}
+
+#[tokio::test]
+async fn subscriber_lookup_404s_for_unknown_subscriber() {
+    let app = support::spawn().await;
+    let env = env_typeid(&app);
+    let res = app
+        .admin_get(&format!("/admin/api/environments/{env}/subscribers/nope"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+}
+
+// =============================================================================
+// DLQ replay through the normal claim path
+// =============================================================================
+
+#[tokio::test]
+async fn dlq_replay_re_enters_the_claim_path_and_deletes_on_completion() {
+    let app = support::spawn().await;
+
+    // A subscriber to own a replayable counter_rebuild job.
+    let _ = app.counts("usr_dlq").await;
+    let internal: uuid::Uuid =
+        sqlx::query_scalar("SELECT id FROM subscribers WHERE environment_id = $1 AND subscriber_id = 'usr_dlq'")
+            .bind(app.env.id)
+            .fetch_one(&app.pool)
+            .await
+            .unwrap();
+
+    // Park a job directly in the DLQ (as the worker would after exhausting
+    // attempts).
+    let job_id = ids::new_uuid();
+    sqlx::query(
+        "INSERT INTO dead_letters
+             (environment_id, id, job_type, payload, attempts, max_attempts, last_error, created_at)
+         VALUES ($1, $2, 'counter_rebuild', jsonb_build_object('subscriber_id', $3::text), 10, 10, 'boom', now())",
+    )
+    .bind(app.env.id)
+    .bind(job_id)
+    .bind(internal.to_string())
+    .execute(&app.pool)
+    .await
+    .unwrap();
+
+    // The admin DLQ browser lists it.
+    let job_typeid = ids::typeid(ids::JOB, job_id);
+    let dlq: Value = app.admin_get("/admin/api/dlq").send().await.unwrap().json().await.unwrap();
+    assert!(
+        dlq.as_array().unwrap().iter().any(|d| d["id"] == json!(job_typeid)),
+        "parked job should be listed"
+    );
+
+    // Replay via the admin API.
+    let replay = app
+        .admin_post(&format!("/admin/api/dlq/{job_typeid}/replay"), json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(replay.status(), 200);
+    assert_eq!(replay.json::<Value>().await.unwrap()["replayed"], json!(1));
+
+    // The DLQ row is gone (moved back into jobs).
+    assert_eq!(app.dead_letter_count().await, 0);
+    let in_jobs: i64 = sqlx::query_scalar("SELECT count(*) FROM jobs WHERE environment_id = $1 AND id = $2")
+        .bind(app.env.id)
+        .bind(job_id)
+        .fetch_one(&app.pool)
+        .await
+        .unwrap();
+    assert_eq!(in_jobs, 1, "replay re-enqueues into the normal claim path");
+
+    // The normal worker loop completes it and DELETEs the row.
+    app.drain_jobs().await;
+    let remaining: i64 = sqlx::query_scalar("SELECT count(*) FROM jobs WHERE environment_id = $1 AND id = $2")
+        .bind(app.env.id)
+        .bind(job_id)
+        .fetch_one(&app.pool)
+        .await
+        .unwrap();
+    assert_eq!(remaining, 0, "a completed job leaves no row");
+}
+
+#[tokio::test]
+async fn dlq_replay_404s_for_unknown_job() {
+    let app = support::spawn().await;
+    let missing = ids::typeid(ids::JOB, ids::new_uuid());
+    let res = app
+        .admin_post(&format!("/admin/api/dlq/{missing}/replay"), json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+}
+
+// =============================================================================
+// Status / notification browser
+// =============================================================================
+
+#[tokio::test]
+async fn status_browser_lists_notifications_and_their_timeline() {
+    let app = support::spawn().await;
+    let env = env_typeid(&app);
+    let subscriber = "usr_status";
+
+    let created = app.create_notification(subscriber, "payment.failed").await;
+    let notif_id = created["notifications"][0]["id"].as_str().unwrap().to_owned();
+    // Deliver the hint so delivered_hint appears in the timeline.
+    app.drain_jobs().await;
+
+    // The browser lists it, filtered by subscriber.
+    let page: Value = app
+        .admin_get(&format!(
+            "/admin/api/environments/{env}/notifications?subscriber_id={subscriber}"
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let listed = page["items"].as_array().unwrap();
+    assert!(listed.iter().any(|n| n["id"] == json!(notif_id)));
+    let row = listed.iter().find(|n| n["id"] == json!(notif_id)).unwrap();
+    assert_eq!(row["subscriber_id"], json!(subscriber));
+    assert_eq!(row["category"], json!("payment.failed"));
+
+    // The "did it send?" timeline shows created → delivered_hint.
+    let timeline: Value = app
+        .admin_get(&format!(
+            "/admin/api/environments/{env}/notifications/{notif_id}/timeline"
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let statuses: Vec<String> = timeline["timeline"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t["status"].as_str().unwrap().to_owned())
+        .collect();
+    assert!(statuses.contains(&"created".to_owned()));
+    assert!(statuses.contains(&"delivered_hint".to_owned()));
+
+    // Category filter narrows results.
+    let filtered: Value = app
+        .admin_get(&format!(
+            "/admin/api/environments/{env}/notifications?category=nonexistent"
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(filtered["items"].as_array().unwrap().is_empty());
+}

--- a/server/tests/admin.rs
+++ b/server/tests/admin.rs
@@ -154,7 +154,7 @@ async fn environment_and_api_key_create_revoke_roundtrip() {
         env["subscriber_hmac_secret"]
             .as_str()
             .unwrap()
-            .starts_with("whsec_")
+            .starts_with("shmac_")
     );
     assert_eq!(env["has_previous_secret"], json!(false));
 
@@ -306,6 +306,10 @@ async fn hmac_rotation_overlap_then_completion() {
         .unwrap();
     let new_secret = rot["subscriber_hmac_secret"].as_str().unwrap().to_owned();
     assert_ne!(new_secret, old_secret);
+    assert!(
+        new_secret.starts_with("shmac_"),
+        "rotation mints a shmac_-prefixed secret"
+    );
     assert_eq!(rot["has_previous_secret"], json!(true));
     assert!(rot["subscriber_hmac_rotated_at"].is_string());
 
@@ -350,6 +354,34 @@ async fn hmac_rotation_overlap_then_completion() {
     assert_eq!(
         counts_status_with_secret(&app, subscriber, &new_secret).await,
         200
+    );
+}
+
+/// The secret prefix is cosmetic and never parsed: auth feeds the whole
+/// secret string into HMAC-SHA256. A legacy `whsec_`-minted secret keeps
+/// authenticating after the prefix rename, so existing customer secrets do
+/// not need re-minting.
+#[tokio::test]
+async fn legacy_whsec_prefixed_secret_still_authenticates() {
+    let app = support::spawn().await;
+    let legacy_secret = "whsec_pre_rename_minted_secret";
+
+    sqlx::query("UPDATE environments SET subscriber_hmac_secret = $1 WHERE id = $2")
+        .bind(legacy_secret)
+        .bind(app.env.id)
+        .execute(&app.pool)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        counts_status_with_secret(&app, "usr_legacy", legacy_secret).await,
+        200,
+        "a whsec_-prefixed secret must still verify"
+    );
+    // The prefix is not what grants access: a wrong secret is still rejected.
+    assert_eq!(
+        counts_status_with_secret(&app, "usr_legacy", "whsec_wrong").await,
+        401
     );
 }
 

--- a/server/tests/admin.rs
+++ b/server/tests/admin.rs
@@ -87,7 +87,14 @@ async fn every_admin_route_401s_without_the_credential() {
     assert_eq!(wrong.status(), 401);
 
     // Correct credential succeeds for both API and SPA.
-    assert_eq!(app.admin_get("/admin/api/environments").send().await.unwrap().status(), 200);
+    assert_eq!(
+        app.admin_get("/admin/api/environments")
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        200
+    );
     let spa_ok = app.admin_get("/admin").send().await.unwrap();
     assert_eq!(spa_ok.status(), 200);
     assert!(
@@ -114,7 +121,11 @@ async fn every_admin_route_401s_without_the_credential() {
 async fn admin_plane_disabled_without_a_configured_token() {
     let app = support::spawn_configured(false, |cfg| cfg.admin_token = None).await;
     // Even a well-formed credential 401s when the plane is disabled.
-    let res = app.admin_get("/admin/api/environments").send().await.unwrap();
+    let res = app
+        .admin_get("/admin/api/environments")
+        .send()
+        .await
+        .unwrap();
     assert_eq!(res.status(), 401);
 }
 
@@ -139,7 +150,12 @@ async fn environment_and_api_key_create_revoke_roundtrip() {
     let env: Value = res.json().await.unwrap();
     let env_id = env["id"].as_str().unwrap().to_owned();
     assert!(env_id.starts_with("env_"));
-    assert!(env["subscriber_hmac_secret"].as_str().unwrap().starts_with("whsec_"));
+    assert!(
+        env["subscriber_hmac_secret"]
+            .as_str()
+            .unwrap()
+            .starts_with("whsec_")
+    );
     assert_eq!(env["has_previous_secret"], json!(false));
 
     // It shows up in the list.
@@ -205,10 +221,21 @@ async fn environment_and_api_key_create_revoke_roundtrip() {
         .json()
         .await
         .unwrap();
-    let key_row = keys.as_array().unwrap().iter().find(|k| k["id"] == json!(key_id)).unwrap();
+    let key_row = keys
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|k| k["id"] == json!(key_id))
+        .unwrap();
     assert_eq!(key_row["key_prefix"], json!(&plaintext[..14]));
-    assert!(key_row.get("key").is_none(), "the plaintext key must never be listed");
-    assert!(key_row["last_used_at"].is_string(), "use should record last_used_at");
+    assert!(
+        key_row.get("key").is_none(),
+        "the plaintext key must never be listed"
+    );
+    assert!(
+        key_row["last_used_at"].is_string(),
+        "use should record last_used_at"
+    );
 
     // Revoke it; the key 401s immediately on the management plane.
     let revoke = app
@@ -239,7 +266,12 @@ async fn environment_and_api_key_create_revoke_roundtrip() {
         .json()
         .await
         .unwrap();
-    let revoked_row = keys2.as_array().unwrap().iter().find(|k| k["id"] == json!(key_id)).unwrap();
+    let revoked_row = keys2
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|k| k["id"] == json!(key_id))
+        .unwrap();
     assert!(revoked_row["revoked_at"].is_string());
 }
 
@@ -255,11 +287,17 @@ async fn hmac_rotation_overlap_then_completion() {
     let old_secret = app.env.hmac_secret.clone();
 
     // The current secret authenticates a widget session.
-    assert_eq!(counts_status_with_secret(&app, subscriber, &old_secret).await, 200);
+    assert_eq!(
+        counts_status_with_secret(&app, subscriber, &old_secret).await,
+        200
+    );
 
     // Begin rotation: a new current secret, old secret moved to previous.
     let rot: Value = app
-        .admin_post(&format!("/admin/api/environments/{env}/hmac/rotate"), json!({}))
+        .admin_post(
+            &format!("/admin/api/environments/{env}/hmac/rotate"),
+            json!({}),
+        )
         .send()
         .await
         .unwrap()
@@ -272,8 +310,14 @@ async fn hmac_rotation_overlap_then_completion() {
     assert!(rot["subscriber_hmac_rotated_at"].is_string());
 
     // Overlap: BOTH secrets verify live sessions (zero-downtime rotation).
-    assert_eq!(counts_status_with_secret(&app, subscriber, &old_secret).await, 200);
-    assert_eq!(counts_status_with_secret(&app, subscriber, &new_secret).await, 200);
+    assert_eq!(
+        counts_status_with_secret(&app, subscriber, &old_secret).await,
+        200
+    );
+    assert_eq!(
+        counts_status_with_secret(&app, subscriber, &new_secret).await,
+        200
+    );
 
     // Rotation is observable in the environment view.
     let detail: Value = app
@@ -299,8 +343,14 @@ async fn hmac_rotation_overlap_then_completion() {
     assert_eq!(done.status(), 204);
 
     // Old secret now dies; the new one still works.
-    assert_eq!(counts_status_with_secret(&app, subscriber, &old_secret).await, 401);
-    assert_eq!(counts_status_with_secret(&app, subscriber, &new_secret).await, 200);
+    assert_eq!(
+        counts_status_with_secret(&app, subscriber, &old_secret).await,
+        401
+    );
+    assert_eq!(
+        counts_status_with_secret(&app, subscriber, &new_secret).await,
+        200
+    );
 }
 
 // =============================================================================
@@ -329,17 +379,22 @@ async fn admin_broadcast_lands_as_one_row_and_respects_visibility() {
     assert!(bcast_id.starts_with("bcast_"));
 
     // Exactly ONE row, never materialized per subscriber.
-    let row_count: i64 = sqlx::query_scalar("SELECT count(*) FROM broadcasts WHERE environment_id = $1")
-        .bind(app.env.id)
-        .fetch_one(&app.pool)
-        .await
-        .unwrap();
+    let row_count: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM broadcasts WHERE environment_id = $1")
+            .bind(app.env.id)
+            .fetch_one(&app.pool)
+            .await
+            .unwrap();
     assert_eq!(row_count, 1);
 
     // It appears in the pre-existing subscriber's merged list.
     let before_list = app.list_items("usr_before").await;
     assert!(
-        before_list["items"].as_array().unwrap().iter().any(|i| i["id"] == json!(bcast_id)),
+        before_list["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|i| i["id"] == json!(bcast_id)),
         "pre-existing subscriber should see the broadcast"
     );
 
@@ -347,7 +402,11 @@ async fn admin_broadcast_lands_as_one_row_and_respects_visibility() {
     let _ = app.counts("usr_after").await;
     let after_list = app.list_items("usr_after").await;
     assert!(
-        !after_list["items"].as_array().unwrap().iter().any(|i| i["id"] == json!(bcast_id)),
+        !after_list["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|i| i["id"] == json!(bcast_id)),
         "later subscriber must not see an earlier broadcast"
     );
 }
@@ -366,7 +425,8 @@ async fn subscriber_lookup_inbox_matches_the_subscriber_plane() {
     let _ = app.counts(subscriber).await;
     app.create_broadcast("announce.one").await;
     for i in 0..3 {
-        app.create_notification(subscriber, &format!("cat.{i}")).await;
+        app.create_notification(subscriber, &format!("cat.{i}"))
+            .await;
     }
     app.create_broadcast("announce.two").await;
     app.drain_jobs().await;
@@ -381,7 +441,9 @@ async fn subscriber_lookup_inbox_matches_the_subscriber_plane() {
 
     // Admin subscriber view runs the SAME canonical merge.
     let view: Value = app
-        .admin_get(&format!("/admin/api/environments/{env}/subscribers/{subscriber}"))
+        .admin_get(&format!(
+            "/admin/api/environments/{env}/subscribers/{subscriber}"
+        ))
         .send()
         .await
         .unwrap()
@@ -395,7 +457,10 @@ async fn subscriber_lookup_inbox_matches_the_subscriber_plane() {
         .map(|i| i["id"].as_str().unwrap().to_owned())
         .collect();
 
-    assert_eq!(admin_ids, plane_ids, "admin inbox must equal the subscriber plane list");
+    assert_eq!(
+        admin_ids, plane_ids,
+        "admin inbox must equal the subscriber plane list"
+    );
 
     // Counters agree with the subscriber plane too.
     let (plane_unread, plane_unseen) = app.counts(subscriber).await;
@@ -427,12 +492,13 @@ async fn dlq_replay_re_enters_the_claim_path_and_deletes_on_completion() {
 
     // A subscriber to own a replayable counter_rebuild job.
     let _ = app.counts("usr_dlq").await;
-    let internal: uuid::Uuid =
-        sqlx::query_scalar("SELECT id FROM subscribers WHERE environment_id = $1 AND subscriber_id = 'usr_dlq'")
-            .bind(app.env.id)
-            .fetch_one(&app.pool)
-            .await
-            .unwrap();
+    let internal: uuid::Uuid = sqlx::query_scalar(
+        "SELECT id FROM subscribers WHERE environment_id = $1 AND subscriber_id = 'usr_dlq'",
+    )
+    .bind(app.env.id)
+    .fetch_one(&app.pool)
+    .await
+    .unwrap();
 
     // Park a job directly in the DLQ (as the worker would after exhausting
     // attempts).
@@ -451,9 +517,19 @@ async fn dlq_replay_re_enters_the_claim_path_and_deletes_on_completion() {
 
     // The admin DLQ browser lists it.
     let job_typeid = ids::typeid(ids::JOB, job_id);
-    let dlq: Value = app.admin_get("/admin/api/dlq").send().await.unwrap().json().await.unwrap();
+    let dlq: Value = app
+        .admin_get("/admin/api/dlq")
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
     assert!(
-        dlq.as_array().unwrap().iter().any(|d| d["id"] == json!(job_typeid)),
+        dlq.as_array()
+            .unwrap()
+            .iter()
+            .any(|d| d["id"] == json!(job_typeid)),
         "parked job should be listed"
     );
 
@@ -468,22 +544,24 @@ async fn dlq_replay_re_enters_the_claim_path_and_deletes_on_completion() {
 
     // The DLQ row is gone (moved back into jobs).
     assert_eq!(app.dead_letter_count().await, 0);
-    let in_jobs: i64 = sqlx::query_scalar("SELECT count(*) FROM jobs WHERE environment_id = $1 AND id = $2")
-        .bind(app.env.id)
-        .bind(job_id)
-        .fetch_one(&app.pool)
-        .await
-        .unwrap();
+    let in_jobs: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM jobs WHERE environment_id = $1 AND id = $2")
+            .bind(app.env.id)
+            .bind(job_id)
+            .fetch_one(&app.pool)
+            .await
+            .unwrap();
     assert_eq!(in_jobs, 1, "replay re-enqueues into the normal claim path");
 
     // The normal worker loop completes it and DELETEs the row.
     app.drain_jobs().await;
-    let remaining: i64 = sqlx::query_scalar("SELECT count(*) FROM jobs WHERE environment_id = $1 AND id = $2")
-        .bind(app.env.id)
-        .bind(job_id)
-        .fetch_one(&app.pool)
-        .await
-        .unwrap();
+    let remaining: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM jobs WHERE environment_id = $1 AND id = $2")
+            .bind(app.env.id)
+            .bind(job_id)
+            .fetch_one(&app.pool)
+            .await
+            .unwrap();
     assert_eq!(remaining, 0, "a completed job leaves no row");
 }
 
@@ -510,7 +588,10 @@ async fn status_browser_lists_notifications_and_their_timeline() {
     let subscriber = "usr_status";
 
     let created = app.create_notification(subscriber, "payment.failed").await;
-    let notif_id = created["notifications"][0]["id"].as_str().unwrap().to_owned();
+    let notif_id = created["notifications"][0]["id"]
+        .as_str()
+        .unwrap()
+        .to_owned();
     // Deliver the hint so delivered_hint appears in the timeline.
     app.drain_jobs().await;
 

--- a/server/tests/auth.rs
+++ b/server/tests/auth.rs
@@ -103,7 +103,7 @@ async fn rotation_verifies_current_then_previous_secret() {
     let old_hash = compute_subscriber_hash(&old_secret, SUB);
 
     // Rotate: new secret current, old secret in the previous slot.
-    let new_secret = "whsec_rotated_secret";
+    let new_secret = "shmac_rotated_secret";
     sqlx::query(
         "UPDATE environments SET
              subscriber_hmac_secret = $2,

--- a/server/tests/chaos.rs
+++ b/server/tests/chaos.rs
@@ -489,6 +489,7 @@ async fn sustained_jobs_churn_stays_bounded_under_autovacuum() {
         sse_max_connections_per_subscriber: 8,
         dev_environment: None,
         dev_api_key: None,
+        admin_token: None,
         retry_backoff_base: Duration::from_millis(100),
         retry_backoff_cap: Duration::from_secs(2),
         metrics_sample_interval: Duration::from_secs(1),

--- a/server/tests/chaos.rs
+++ b/server/tests/chaos.rs
@@ -468,7 +468,7 @@ async fn sustained_jobs_churn_stays_bounded_under_autovacuum() {
     let env = Uuid::now_v7();
     sqlx::query(
         "INSERT INTO environments (id, slug, name, subscriber_hmac_secret)
-         VALUES ($1, 'churn', 'churn', 'whsec_churn')",
+         VALUES ($1, 'churn', 'churn', 'shmac_churn')",
     )
     .bind(env)
     .execute(&pool)

--- a/server/tests/quickstart.rs
+++ b/server/tests/quickstart.rs
@@ -25,6 +25,15 @@ async fn dev_bootstrap_seeds_an_environment_and_key_idempotently() {
             .await
             .unwrap();
     assert_eq!(environments, 1, "rerun must not duplicate the environment");
+    let bootstrapped_secret: String =
+        sqlx::query_scalar("SELECT subscriber_hmac_secret FROM environments WHERE slug = 'demo'")
+            .fetch_one(&app.pool)
+            .await
+            .unwrap();
+    assert!(
+        bootstrapped_secret.starts_with("shmac_"),
+        "the dev bootstrap mints a shmac_-prefixed subscriber secret"
+    );
     let keys: i64 = sqlx::query_scalar(
         "SELECT count(*) FROM api_keys WHERE name = 'dev-bootstrap' AND revoked_at IS NULL",
     )

--- a/server/tests/support/mod.rs
+++ b/server/tests/support/mod.rs
@@ -28,6 +28,8 @@ use testcontainers_modules::testcontainers::{ContainerAsync, ImageExt as _};
 use uuid::Uuid;
 
 pub const RETENTION_MONTHS: u32 = 12;
+/// The admin Basic-auth password the harness configures by default.
+pub const ADMIN_TEST_TOKEN: &str = "admin-test-token";
 
 pub struct TestApp {
     pub pool: PgPool,
@@ -123,6 +125,7 @@ async fn spawn_inner(
         sse_max_connections_per_subscriber: 2,
         dev_environment: None,
         dev_api_key: None,
+        admin_token: Some(ADMIN_TEST_TOKEN.to_owned()),
         retry_backoff_base: Duration::from_millis(40),
         retry_backoff_cap: Duration::from_millis(500),
         metrics_sample_interval: Duration::from_millis(200),
@@ -264,6 +267,21 @@ impl TestApp {
         self.client
             .post(format!("{}{path}", self.base))
             .bearer_auth(&self.env.api_key)
+            .json(&body)
+    }
+
+    /// Admin-plane GET with HTTP Basic auth (username ignored, password is
+    /// the admin token).
+    pub fn admin_get(&self, path: &str) -> reqwest::RequestBuilder {
+        self.client
+            .get(format!("{}{path}", self.base))
+            .basic_auth("admin", Some(ADMIN_TEST_TOKEN))
+    }
+
+    pub fn admin_post(&self, path: &str, body: serde_json::Value) -> reqwest::RequestBuilder {
+        self.client
+            .post(format!("{}{path}", self.base))
+            .basic_auth("admin", Some(ADMIN_TEST_TOKEN))
             .json(&body)
     }
 

--- a/server/tests/support/mod.rs
+++ b/server/tests/support/mod.rs
@@ -223,7 +223,7 @@ impl TestApp {
     pub async fn create_environment(&self, require_hash: bool) -> TestEnvironment {
         let id = ids::new_uuid();
         let slug = format!("env-{}", &id.as_simple().to_string()[..12]);
-        let hmac_secret = format!("whsec_{}", ids::new_uuid().as_simple());
+        let hmac_secret = format!("shmac_{}", ids::new_uuid().as_simple());
         sqlx::query(
             "INSERT INTO environments
                  (id, slug, name, subscriber_hmac_secret, require_subscriber_hash)


### PR DESCRIPTION
Implements Phase 4 (specs/phase-4-admin.md): an embedded admin dashboard served from the single binary, plus the Dronte brand palette applied to both the dashboard and the default `<Inbox />` theme.

## Admin plane (server)

A new `/admin/api/*` surface (`server/src/api/admin.rs`) gated by one static instance credential, `DRONTE_ADMIN_TOKEN`, over HTTP Basic. A bare `/admin` navigation 401s with `WWW-Authenticate`, so the browser prompts once and then attaches the credential to every same-origin asset and API request — no separate login screen. The comparison is constant-time (both sides hashed to a fixed length, then XOR-folded) and the token never reaches a log line. With the variable unset, the whole admin plane is disabled.

Endpoints cover environment and API-key management (create/list, soft-revoke, plaintext shown exactly once), subscriber-HMAC two-slot rotation (current then previous, cleared on completion), the notification/status-timeline browser, the broadcast composer, subscriber lookup, and a cross-environment DLQ browser with replay. Admin reads reuse the canonical two-source merge and count queries — extracted as `list_items_for` / `fetch_counts_for` so there is exactly one implementation — and admin writes reuse the canonical broadcast write-path and `dlq::replay`, so the admin view can never disagree with the subscriber plane and replays re-enter the normal claim path rather than running inline.

## Admin SPA

`server/admin` is a Vite + React + TanStack Router/Query SPA using shadcn/ui components and shadcn charts (Recharts), embedded into the binary via rust-embed and served at `/admin`. It joins the pnpm workspace (typechecked by its own tsc, excluded from biome). The Dockerfile gains a Node stage that builds the bundle into `server/admin/dist` before the Rust build embeds it; `.dockerignore` becomes a blacklist so the SPA source reaches that stage. A `build.rs` placeholder lets the crate compile before the SPA is built, so `cargo nextest` and `cargo run -- openapi` work without a Node build. The single-file deploy story holds: `docker run dronte` ships the dashboard.

## Brand palette

The default `<Inbox />` theme now ships the accent `#1264FF` (primary actions, links, unread badge, unread dot, focus rings) with a deep accent `#004F32` for hover/section accents — a values-only change to the existing `--dronte-*` custom properties, no new dependency. The admin shadcn theme maps `--primary` to `#1264FF`, hover to `#004F32`, and builds `--chart-1..5` from the semantic set (success / warning / warning-hi / danger) so the status and DLQ views encode state rather than decoration. Both light and dark modes ship; the brand lime green is deliberately excluded and the secondary palette is strictly semantic.

## Contract

The admin surface is utoipa-annotated under an `admin` tag with an `AdminToken` Basic scheme, additive post-freeze. The contract convergence job strips the `/admin` paths, the `admin` tag, `Admin*` schemas and `AdminToken` from the generated document before oasdiff (the same mechanism as the Phase 3 status timeline), so convergence against the frozen spec stays empty; the served and generated specs keep the admin surface, and the regenerated `docs/openapi/dronte.yaml` and `@dronte/client` types are committed.

## Verification

- `cargo clippy --all-targets -- -D warnings` clean; 132 server tests pass, including a golden test asserting the admin merged inbox equals the subscriber-plane list for the same subscriber, the HMAC rotation overlap, one-row broadcast composing, the DLQ replay-and-delete path, and auth gating.
- `oasdiff` against the frozen spec is empty after the admin strip; `cargo deny check licenses` ok (rust-embed tree permissive).
- Workspace TS: biome clean, every project typechecks (including the SPA), package tests and SDK conformance pass.
- Ran the binary with the embedded bundle: `/admin` 401s without the credential, serves the real SPA with it, serves assets, the API returns JSON, client-side route fallback works, and a wrong password 401s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)