### PR TITLE
refactor(auth): rename secret prefix to shmac_

### DIFF
--- a/server/src/api/admin.rs
+++ b/server/src/api/admin.rs
@@ -210,7 +210,7 @@ pub async fn create_environment(
     }
 
     let id = ids::new_uuid();
-    let hmac_secret = format!("whsec_{}", ids::new_uuid().as_simple());
+    let hmac_secret = format!("shmac_{}", ids::new_uuid().as_simple());
     let created = sqlx::query!(
         r#"INSERT INTO environments
                (id, slug, name, subscriber_hmac_secret, require_subscriber_hash)
@@ -325,7 +325,7 @@ pub async fn rotate_hmac(
     Path(env_id): Path<String>,
 ) -> Result<Json<AdminHmacRotation>, ApiError> {
     let env = parse_env_id(&env_id)?;
-    let new_secret = format!("whsec_{}", ids::new_uuid().as_simple());
+    let new_secret = format!("shmac_{}", ids::new_uuid().as_simple());
     let row = sqlx::query!(
         r#"UPDATE environments SET
                subscriber_hmac_secret = $2,

--- a/server/src/bootstrap.rs
+++ b/server/src/bootstrap.rs
@@ -27,7 +27,7 @@ pub async fn run(pool: &PgPool, cfg: &Config) -> anyhow::Result<()> {
     // would silently break hashes computed against it, and downgrading
     // require_subscriber_hash would disable auth on an environment this
     // bootstrap does not own.
-    let hmac_secret = format!("whsec_{}", ids::new_uuid().as_simple());
+    let hmac_secret = format!("shmac_{}", ids::new_uuid().as_simple());
     let inserted = sqlx::query_scalar!(
         r#"INSERT INTO environments
                (id, slug, name, subscriber_hmac_secret, require_subscriber_hash)

--- a/server/tests/admin.rs
+++ b/server/tests/admin.rs
@@ -154,7 +154,7 @@ async fn environment_and_api_key_create_revoke_roundtrip() {
         env["subscriber_hmac_secret"]
             .as_str()
             .unwrap()
-            .starts_with("whsec_")
+            .starts_with("shmac_")
     );
     assert_eq!(env["has_previous_secret"], json!(false));
 
@@ -306,6 +306,10 @@ async fn hmac_rotation_overlap_then_completion() {
         .unwrap();
     let new_secret = rot["subscriber_hmac_secret"].as_str().unwrap().to_owned();
     assert_ne!(new_secret, old_secret);
+    assert!(
+        new_secret.starts_with("shmac_"),
+        "rotation mints a shmac_-prefixed secret"
+    );
     assert_eq!(rot["has_previous_secret"], json!(true));
     assert!(rot["subscriber_hmac_rotated_at"].is_string());
 
@@ -350,6 +354,34 @@ async fn hmac_rotation_overlap_then_completion() {
     assert_eq!(
         counts_status_with_secret(&app, subscriber, &new_secret).await,
         200
+    );
+}
+
+/// The secret prefix is cosmetic and never parsed: auth feeds the whole
+/// secret string into HMAC-SHA256. A legacy `whsec_`-minted secret keeps
+/// authenticating after the prefix rename, so existing customer secrets do
+/// not need re-minting.
+#[tokio::test]
+async fn legacy_whsec_prefixed_secret_still_authenticates() {
+    let app = support::spawn().await;
+    let legacy_secret = "whsec_pre_rename_minted_secret";
+
+    sqlx::query("UPDATE environments SET subscriber_hmac_secret = $1 WHERE id = $2")
+        .bind(legacy_secret)
+        .bind(app.env.id)
+        .execute(&app.pool)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        counts_status_with_secret(&app, "usr_legacy", legacy_secret).await,
+        200,
+        "a whsec_-prefixed secret must still verify"
+    );
+    // The prefix is not what grants access: a wrong secret is still rejected.
+    assert_eq!(
+        counts_status_with_secret(&app, "usr_legacy", "whsec_wrong").await,
+        401
     );
 }
 

--- a/server/tests/auth.rs
+++ b/server/tests/auth.rs
@@ -103,7 +103,7 @@ async fn rotation_verifies_current_then_previous_secret() {
     let old_hash = compute_subscriber_hash(&old_secret, SUB);
 
     // Rotate: new secret current, old secret in the previous slot.
-    let new_secret = "whsec_rotated_secret";
+    let new_secret = "shmac_rotated_secret";
     sqlx::query(
         "UPDATE environments SET
              subscriber_hmac_secret = $2,

--- a/server/tests/chaos.rs
+++ b/server/tests/chaos.rs
@@ -468,7 +468,7 @@ async fn sustained_jobs_churn_stays_bounded_under_autovacuum() {
     let env = Uuid::now_v7();
     sqlx::query(
         "INSERT INTO environments (id, slug, name, subscriber_hmac_secret)
-         VALUES ($1, 'churn', 'churn', 'whsec_churn')",
+         VALUES ($1, 'churn', 'churn', 'shmac_churn')",
     )
     .bind(env)
     .execute(&pool)

--- a/server/tests/quickstart.rs
+++ b/server/tests/quickstart.rs
@@ -25,6 +25,15 @@ async fn dev_bootstrap_seeds_an_environment_and_key_idempotently() {
             .await
             .unwrap();
     assert_eq!(environments, 1, "rerun must not duplicate the environment");
+    let bootstrapped_secret: String =
+        sqlx::query_scalar("SELECT subscriber_hmac_secret FROM environments WHERE slug = 'demo'")
+            .fetch_one(&app.pool)
+            .await
+            .unwrap();
+    assert!(
+        bootstrapped_secret.starts_with("shmac_"),
+        "the dev bootstrap mints a shmac_-prefixed subscriber secret"
+    );
     let keys: i64 = sqlx::query_scalar(
         "SELECT count(*) FROM api_keys WHERE name = 'dev-bootstrap' AND revoked_at IS NULL",
     )

--- a/server/tests/support/mod.rs
+++ b/server/tests/support/mod.rs
@@ -223,7 +223,7 @@ impl TestApp {
     pub async fn create_environment(&self, require_hash: bool) -> TestEnvironment {
         let id = ids::new_uuid();
         let slug = format!("env-{}", &id.as_simple().to_string()[..12]);
-        let hmac_secret = format!("whsec_{}", ids::new_uuid().as_simple());
+        let hmac_secret = format!("shmac_{}", ids::new_uuid().as_simple());
         sqlx::query(
             "INSERT INTO environments
                  (id, slug, name, subscriber_hmac_secret, require_subscriber_hash)


### PR DESCRIPTION
## What

Rename the subscriber HMAC secret prefix from `whsec_` to `shmac_`.

## Why

`whsec_` is the de-facto **webhook secret** prefix (Stripe/Svix convention), but Dronte has no outbound webhooks (explicitly out of scope in the project plan). The secret is the per-environment subscriber HMAC signing secret — `hex(HMAC-SHA256(secret, subscriber_id))`. `shmac_` names what it actually is.

## Safety

The prefix is purely cosmetic — it's never parsed or validated, just generated and fed wholesale into HMAC-SHA256. **Existing secrets minted with `whsec_` keep verifying unchanged**; nothing inspects the prefix.

## Tests

- `dev_bootstrap_*` asserts bootstrap mints a `shmac_`-prefixed secret
- `hmac_rotation_overlap_then_completion` asserts rotation mints a `shmac_`-prefixed secret
- new `legacy_whsec_prefixed_secret_still_authenticates` proves a legacy `whsec_` secret still authenticates (backward compatibility)

Local: `cargo fmt --check`, `clippy --all-targets -D warnings`, and the affected nextest binaries (`admin`, `quickstart`, `auth`, `chaos`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)