### PR TITLE
ci(release): publish only on GitHub Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
     branches: [main]
-    tags: ['v*']
   pull_request:
 
 env:
@@ -195,36 +194,17 @@ jobs:
       - name: Semantic diff against the frozen convergence target
         run: oasdiff diff specs/openapi.yaml /tmp/openapi.gen.stripped.yaml --fail-on-diff
 
+  # Build-only validation of the Dockerfile on every main push and PR. The
+  # push to GHCR happens on a GitHub Release (publish.yml), never from CI.
   docker:
-    name: docker image
+    name: docker image (build)
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
-      - name: Log in to GHCR
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=sha
       - uses: docker/build-push-action@v6
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,79 @@
+# Publishes on a GitHub Release (the Release creates the tag). Two
+# independent artifacts, different licenses and registries:
+#   - npm: @dronte/* packages (MIT, packages/*) via `changeset publish`. The
+#     versions were already bumped on main by the Version Packages PR (see
+#     release.yml), so this only pushes the new versions to the registry.
+#   - docker: the server image (FSL-1.1-MIT, server/) to GHCR, tagged with
+#     the release version derived from the tag.
+#
+# Release ritual: merge the changesets "Version Packages" PR to main, then
+# publish a GitHub Release whose tag is v<x.y.z>.
+#
+# Prerequisites (repo settings, one-time, human):
+#   - NPM_TOKEN secret: an npm automation token with publish rights to the
+#     @dronte scope
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+concurrency: publish-${{ github.ref }}
+
+jobs:
+  npm:
+    name: npm (@dronte/*)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter "./packages/*" build
+      # The publish path must never outrun the gates.
+      - run: pnpm typecheck
+      - run: pnpm test
+      - run: pnpm conformance
+      - name: Publish to npm
+        run: pnpm changeset publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  docker:
+    name: docker image (push)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          # Release tag v1.2.3 -> image tags 1.2.3 and 1.2 (plus the sha).
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,11 @@
-# Changesets-driven release of the SDK packages (MIT, packages/*).
+# Changesets version management for the SDK packages (MIT, packages/*).
 #
 # On every push to main with pending changesets, changesets/action opens or
-# updates a "Version Packages" PR. Merging that PR re-triggers this
-# workflow, which then publishes to npm.
-#
-# Prerequisites (repo settings, one-time, human):
-#   - NPM_TOKEN secret: an npm automation token with publish rights to the
-#     @dronte scope
-#   - the @dronte scope must exist on npm and grant that token access
-name: Release
+# updates a "Version Packages" PR. That PR only bumps versions and writes
+# CHANGELOGs. It publishes nothing. Merging it lands the bumped versions on
+# main. The actual npm publish runs from a GitHub Release (see publish.yml),
+# so nothing is published by pushing to main.
+name: Release (version PR)
 
 on:
   push:
@@ -21,7 +18,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  release:
+  version:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,17 +28,11 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter "./packages/*" build
-      # The publish path must never outrun the gates. CI covers PRs, but
-      # this workflow runs on push to main, which branch protection alone
-      # does not make test-clean.
-      - run: pnpm typecheck
-      - run: pnpm test
-      - run: pnpm conformance
-      - name: Version PR or publish
+      # No `publish:` arg: the action only opens or updates the Version
+      # Packages PR. Publishing lives in publish.yml, gated on a Release.
+      - name: Open or update the Version Packages PR
         uses: changesets/action@v1
         with:
-          publish: pnpm changeset publish
+          version: pnpm changeset version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Publishing (npm + GHCR image) no longer happens on a push to `main`. It is gated on a GitHub Release.

## Changes
- **`release.yml`** (push to `main`): `changesets/action` runs without `publish:`, so it only opens/updates the **Version Packages** PR (version bumps + CHANGELOGs). Nothing publishes on a main push. `NPM_TOKEN` removed here.
- **`publish.yml`** (new, `on: release: published`): runs the gates then `pnpm changeset publish` to npm, and builds + **pushes the server image to GHCR** tagged `{{version}}` / `{{major}}.{{minor}}` / `sha` from the release tag.
- **`ci.yml`**: docker job is now **build-only** (validates the Dockerfile on main/PRs, never pushes); dropped the `tags: ['v*']` trigger.

## New release ritual
1. PRs merge to `main`, each with a changeset (existing CI gate).
2. Merge the **Version Packages** PR → bumped versions land on `main` (no publish).
3. Cut a **GitHub Release** `vX.Y.Z` → `publish.yml` publishes npm + GHCR `:X.Y.Z`.

## Note (pre-existing, not introduced here)
The `ts` job's "Release readiness" step (`changeset status --since=origin/main`) fails when no changesets are pending — i.e. on the Version Packages PR itself. If that check is required, the Version PR needs an exemption. Happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)