### PR TITLE
chore: rename project to chimely

### DIFF
--- a/.changeset/comment-and-lint-cleanup.md
+++ b/.changeset/comment-and-lint-cleanup.md
@@ -1,6 +1,6 @@
 ---
-'@dronte/client': patch
-'@dronte/react': patch
+'@chimely/client': patch
+'@chimely/react': patch
 'docs': patch
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,13 @@ jobs:
       postgres:
         image: postgres:15
         env:
-          POSTGRES_USER: dronte
-          POSTGRES_PASSWORD: dronte
-          POSTGRES_DB: dronte
+          POSTGRES_USER: chimely
+          POSTGRES_PASSWORD: chimely
+          POSTGRES_DB: chimely
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U dronte"
+          --health-cmd "pg_isready -U chimely"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10
@@ -54,7 +54,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     env:
-      DATABASE_URL: postgres://dronte:dronte@localhost:5432/dronte
+      DATABASE_URL: postgres://chimely:chimely@localhost:5432/chimely
       REDIS_URL: redis://localhost:6379
       SQLX_OFFLINE: "true"
     steps:
@@ -86,7 +86,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
-      # @dronte/react typechecks against @dronte/client's build output
+      # @chimely/react typechecks against @chimely/client's build output
       - run: pnpm --filter "./packages/*" build
       - run: pnpm typecheck
       - run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@
 #
 # Prerequisites (repo settings, one-time, human):
 #   - NPM_TOKEN secret: an npm automation token with publish rights to the
-#     @dronte scope, and the @dronte scope must grant that token access.
+#     @chimely scope, and the @chimely scope must grant that token access.
 #   - "Allow GitHub Actions to create and approve pull requests" enabled.
 #     The `version` job opens the Version Packages PR. The `publish` job does
 #     NOT need this (no pull-requests permission), so the publish path is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Dronte
+# Chimely
 
 Fair-source, self-hostable in-app notification inbox infrastructure: one Rust
 binary + Postgres (source of truth) + Redis (real-time plane), a small HTTP
@@ -8,8 +8,8 @@ API, and a drop-in `<Inbox />`.
 
 ```
 server/            Rust binary (single crate): API, SSE, workers
-packages/client/   @dronte/client — headless TS core
-packages/react/    @dronte/react  — hooks + <Inbox />
+packages/client/   @chimely/client — headless TS core
+packages/react/    @chimely/react  — hooks + <Inbox />
 docs/              Fumadocs site
 ```
 
@@ -91,8 +91,8 @@ require a CLA so exclusive commercialization rights hold.
 
 ## OpenAPI spec
 
-- The spec is **code-first via utoipa**; `dronte openapi` exports it. The docs
-  site and `@dronte/client` types are built from the export.
+- The spec is **code-first via utoipa**; `chimely openapi` exports it. The docs
+  site and `@chimely/client` types are built from the export.
 - `packages/client/src/generated/` and `docs/openapi/` are **generated**
   (`pnpm generate`) — never hand-edit them; regenerate and commit the result.
 
@@ -130,7 +130,7 @@ require a CLA so exclusive commercialization rights hold.
 
 **Server:** Rust stable (2024 edition, pinned via rust-toolchain.toml), axum 0.8 on tokio, sqlx (compile-time-checked raw SQL; built-in migrator, run on boot under advisory lock), Postgres ≥15, `fred` Redis client (resilient pub/sub), Redis Lua token bucket for cross-replica rate limiting, RustCrypto hmac+sha2, thiserror/anyhow, tracing + OTLP, metrics + Prometheus exporter. Single crate until compile times force a split.
 
-**OpenAPI tooling:** code-first via utoipa, rendered docs served from the binary via utoipa-scalar at /docs. The generated spec (`cargo run -- openapi`) is the published artifact. openapi-typescript consumes it for @dronte/client types. Annotation-vs-handler drift (utoipa response codes are hand-annotated) is guarded by the Rust contract-drift integration tests (server/tests/redteam_contract_drift*.rs), which assert the status a handler returns is the status its annotation declares.
+**OpenAPI tooling:** code-first via utoipa, rendered docs served from the binary via utoipa-scalar at /docs. The generated spec (`cargo run -- openapi`) is the published artifact. openapi-typescript consumes it for @chimely/client types. Annotation-vs-handler drift (utoipa response codes are hand-annotated) is guarded by the Rust contract-drift integration tests (server/tests/redteam_contract_drift*.rs), which assert the status a handler returns is the status its annotation declares.
 
 **Testing:** testcontainers-rs (Postgres + Redis), cargo-nextest, proptest for two-source merge and watermark invariants.
 
@@ -138,7 +138,7 @@ require a CLA so exclusive commercialization rights hold.
 
 **Admin SPA:** Vite + React + TanStack Query/Router, embedded via rust-embed.
 
-**Build/ship:** GitHub Actions (Swatinem/rust-cache), cargo-chef multi-stage Docker, debian-slim image. Docs: Fumadocs (Next.js), with fumadocs-openapi rendering the exported spec so the docs site stays generated-from-code too. `npx dronte dev`: postgresql_embedded, Redis-less mode (exercises the LISTEN/NOTIFY fallback).
+**Build/ship:** GitHub Actions (Swatinem/rust-cache), cargo-chef multi-stage Docker, debian-slim image. Docs: Fumadocs (Next.js), with fumadocs-openapi rendering the exported spec so the docs site stays generated-from-code too. `npx chimely dev`: postgresql_embedded, Redis-less mode (exercises the LISTEN/NOTIFY fallback).
 
 ## Commands
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Multi-stage build. A Node stage builds the embedded admin SPA
 # (server/admin -> server/admin/dist); the cargo-chef Rust stages then embed
 # that bundle into the single binary via rust-embed. The image stays one file:
-# `docker run dronte` ships the dashboard with no extra artifact.
+# `docker run chimely` ships the dashboard with no extra artifact.
 
 # --- Admin SPA: server/admin -> server/admin/dist ---
 FROM node:24-slim AS admin
@@ -12,8 +12,8 @@ WORKDIR /app
 # The whole workspace is needed so pnpm can resolve the committed lockfile;
 # the focused install pulls only the admin SPA's subtree.
 COPY . .
-RUN pnpm install --frozen-lockfile --filter dronte-admin...
-RUN pnpm --filter dronte-admin build
+RUN pnpm install --frozen-lockfile --filter chimely-admin...
+RUN pnpm --filter chimely-admin build
 
 # --- Rust build (cargo-chef: dependency layers cached independently of src) ---
 FROM lukemathwalker/cargo-chef:latest-rust-1.96.0 AS chef
@@ -39,15 +39,15 @@ COPY server/migrations ./migrations
 # populated admin/dist untouched (it only writes a placeholder when missing).
 COPY --from=admin /app/server/admin/dist ./admin/dist
 ENV SQLX_OFFLINE=true
-RUN cargo build --release --bin dronte
+RUN cargo build --release --bin chimely
 
 FROM debian:trixie-slim AS runtime
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && useradd --system --uid 10001 --user-group dronte
-COPY --from=builder /app/target/release/dronte /usr/local/bin/dronte
-USER dronte
+    && useradd --system --uid 10001 --user-group chimely
+COPY --from=builder /app/target/release/chimely /usr/local/bin/chimely
+USER chimely
 EXPOSE 8080
-ENTRYPOINT ["/usr/local/bin/dronte"]
+ENTRYPOINT ["/usr/local/bin/chimely"]
 CMD ["serve"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Dronte
+# Chimely
 
 Fair-source, self-hostable **in-app notification inbox infrastructure**.
 One Rust binary + Postgres + Redis, a deliberately small HTTP API, and a
@@ -9,8 +9,8 @@ primitive.
 
 ```
 server/            Rust binary: API, SSE, workers          (FSL-1.1-MIT)
-packages/client/   @dronte/client — headless TS core       (MIT)
-packages/react/    @dronte/react  — hooks + <Inbox />      (MIT)
+packages/client/   @chimely/client — headless TS core       (MIT)
+packages/react/    @chimely/react  — hooks + <Inbox />      (MIT)
 examples/          quickstarts and integration examples    (MIT)
 docs/              Fumadocs site                           (MIT)
 ```
@@ -20,7 +20,7 @@ docs/              Fumadocs site                           (MIT)
 The server embeds an operator dashboard at `/admin` (status/timeline browser,
 broadcast composer, subscriber lookup, DLQ replay, environment + API key
 management, HMAC rotation, and admin-user management). It ships inside the
-binary — `docker run dronte` serves it with no extra artifact.
+binary — `docker run chimely` serves it with no extra artifact.
 
 **Built-in users with roles.** The dashboard has its own login (email +
 password, Argon2id-hashed) backed by a server-side session cookie. Four fixed
@@ -34,23 +34,23 @@ per-environment user scoping):
 - **admin** — everything, including creating environments, rotating HMAC
   secrets, and managing users.
 
-**Bootstrap (root) admin.** On boot, if `DRONTE_ADMIN_EMAIL` and
-`DRONTE_ADMIN_PASSWORD` are set, Dronte ensures an `admin` account with that
+**Bootstrap (root) admin.** On boot, if `CHIMELY_ADMIN_EMAIL` and
+`CHIMELY_ADMIN_PASSWORD` are set, Chimely ensures an `admin` account with that
 email — creating it, or resetting its password to the env value if it drifted.
 This is the lockout-recovery path: restart with the env vars to restore admin
 access. Everyone else gets their own account from the Users page.
 
 ```bash
-DRONTE_ADMIN_EMAIL=ops@example.com \
-DRONTE_ADMIN_PASSWORD="$(openssl rand -hex 24)" \
-DRONTE_ADMIN_TLS_TERMINATED=true \
-  dronte serve
+CHIMELY_ADMIN_EMAIL=ops@example.com \
+CHIMELY_ADMIN_PASSWORD="$(openssl rand -hex 24)" \
+CHIMELY_ADMIN_TLS_TERMINATED=true \
+  chimely serve
 ```
 
 **TLS is required.** The session cookie is `HttpOnly; SameSite=Strict;
-Path=/admin`, marked `Secure` only when `DRONTE_ADMIN_TLS_TERMINATED=true`.
+Path=/admin`, marked `Secure` only when `CHIMELY_ADMIN_TLS_TERMINATED=true`.
 The binary serves plain HTTP, so terminate TLS at a proxy and set that flag;
-without it Dronte logs a boot-time warning and the cookie omits `Secure`.
+without it Chimely logs a boot-time warning and the cookie omits `Secure`.
 Passwords and session ids are never logged.
 
 ## License FAQ
@@ -62,13 +62,13 @@ MIT — they embed in your frontend, and they carry their own `LICENSE`
 files.
 
 **What does FSL mean for me?** You can use, self-host, modify, and
-redistribute Dronte freely — internally, in production, commercially, at
+redistribute Chimely freely — internally, in production, commercially, at
 any scale, for free, forever. The single thing the license prohibits is
-offering Dronte itself to others as a competing commercial product or
+offering Chimely itself to others as a competing commercial product or
 hosted service. Each release additionally converts to plain MIT two years
 after it ships.
 
-**Does the server license affect my application?** No. You run the Dronte
+**Does the server license affect my application?** No. You run the Chimely
 binary as a standalone network service and integrate over HTTP through the
 MIT-licensed SDKs. Nothing about the server's license reaches your
 codebase, and calling the HTTP API creates no obligations.
@@ -82,7 +82,7 @@ second anniversary.
 the documentation content are MIT, so third-party clients, bindings, and
 integrations are unambiguous.
 
-**The name and logo?** Not licensed. "Dronte" and the logo remain with the
+**The name and logo?** Not licensed. "Chimely" and the logo remain with the
 project regardless of code license — that, not the code license, is the
 protection against confusing forks.
 

--- a/docs/app/docs/layout.tsx
+++ b/docs/app/docs/layout.tsx
@@ -4,7 +4,7 @@ import { source } from '@/lib/source';
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <DocsLayout tree={source.pageTree} nav={{ title: 'Dronte' }}>
+    <DocsLayout tree={source.pageTree} nav={{ title: 'Chimely' }}>
       {children}
     </DocsLayout>
   );

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import './global.css';
 
 export const metadata = {
-  title: 'Dronte',
+  title: 'Chimely',
   description: 'In-app notification inbox infrastructure.',
 };
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Dronte
+title: Chimely
 description: In-app notification inbox infrastructure — placeholder.
 ---
 

--- a/docs/content/docs/operations.mdx
+++ b/docs/content/docs/operations.mdx
@@ -11,48 +11,48 @@ data, drift a counter, or starve a neighbor.
 ## Metrics
 
 `GET /metrics` (Prometheus text format). Gauges marked *sampled* are
-recomputed from Postgres on a fixed cadence (`DRONTE_METRICS_SAMPLE_MS`,
+recomputed from Postgres on a fixed cadence (`CHIMELY_METRICS_SAMPLE_MS`,
 default 15s) — they survive restarts and cannot freeze when a subsystem
 stalls.
 
 | Metric | Kind | Meaning |
 |---|---|---|
-| `dronte_queue_depth{environment,job_type}` | gauge, sampled | All pending job rows |
-| `dronte_queue_due{environment,job_type}` | gauge, sampled | Jobs past `run_at` |
-| `dronte_job_wait_seconds{job_type}` | histogram | Due-to-claim latency (the fairness signal) |
-| `dronte_jobs_processed_total{environment}` | counter | Completed claims |
-| `dronte_jobs_failed_total{environment}` | counter | Failed claims (will retry) |
-| `dronte_jobs_retried_total{job_type}` | counter | Backoff reschedules |
-| `dronte_jobs_parked_total{job_type}` | counter | Moves into `dead_letters` |
-| `dronte_dead_letters{job_type}` | gauge, sampled | Parked jobs awaiting replay |
-| `dronte_hint_publish_duration_seconds` | histogram | Pub/sub round trip |
-| `dronte_hint_delivery_lag_seconds` | histogram | Enqueue-to-publish lag (includes queue wait + debounce) |
-| `dronte_sse_connections` | gauge | Open SSE streams on this replica |
-| `dronte_counter_drift_unread` / `_unseen` | gauge, sampled | Σ&#124;recount − maintained&#124; over recently-active subscribers |
-| `dronte_partitions_remaining{table}` | gauge, sampled | Pre-created future partitions |
-| `dronte_rate_limited_total` | counter | Requests answered 429 |
-| `dronte_rate_limit_errors_total` | counter | Limiter fail-opens (Redis unreachable) |
+| `chimely_queue_depth{environment,job_type}` | gauge, sampled | All pending job rows |
+| `chimely_queue_due{environment,job_type}` | gauge, sampled | Jobs past `run_at` |
+| `chimely_job_wait_seconds{job_type}` | histogram | Due-to-claim latency (the fairness signal) |
+| `chimely_jobs_processed_total{environment}` | counter | Completed claims |
+| `chimely_jobs_failed_total{environment}` | counter | Failed claims (will retry) |
+| `chimely_jobs_retried_total{job_type}` | counter | Backoff reschedules |
+| `chimely_jobs_parked_total{job_type}` | counter | Moves into `dead_letters` |
+| `chimely_dead_letters{job_type}` | gauge, sampled | Parked jobs awaiting replay |
+| `chimely_hint_publish_duration_seconds` | histogram | Pub/sub round trip |
+| `chimely_hint_delivery_lag_seconds` | histogram | Enqueue-to-publish lag (includes queue wait + debounce) |
+| `chimely_sse_connections` | gauge | Open SSE streams on this replica |
+| `chimely_counter_drift_unread` / `_unseen` | gauge, sampled | Σ&#124;recount − maintained&#124; over recently-active subscribers |
+| `chimely_partitions_remaining{table}` | gauge, sampled | Pre-created future partitions |
+| `chimely_rate_limited_total` | counter | Requests answered 429 |
+| `chimely_rate_limit_errors_total` | counter | Limiter fail-opens (Redis unreachable) |
 
 ## Alerts
 
-- **`dronte_partitions_remaining < 2`** — the partition-maintenance job has
+- **`chimely_partitions_remaining < 2`** — the partition-maintenance job has
   been dead for ~11 months; with headroom exhausted, inserts fail loudly
   (there is deliberately no DEFAULT partition). The gauge decays by one per
   month while the job is stalled, so this alert fires with a full month of
   pre-created headroom still left.
-- **`dronte_counter_drift_unread > 0` (sustained)** — a counter-maintenance
+- **`chimely_counter_drift_unread > 0` (sustained)** — a counter-maintenance
   bug. Transient nonzero readings right after a preference flip resolve as
   soon as the enqueued `counter_rebuild` lands.
-- **`dronte_dead_letters > 0`** — jobs exhausted `max_attempts` and need an
+- **`chimely_dead_letters > 0`** — jobs exhausted `max_attempts` and need an
   operator (see below).
-- **`dronte_job_wait_seconds` p99 growing without a matching queue-depth
+- **`chimely_job_wait_seconds` p99 growing without a matching queue-depth
   flood** — claim starvation; check for a stuck worker.
 - **Timeline write latency vs retention.** The status log's idempotency
   guard probes every `notification_status_log` partition (the table is
   range-partitioned on `occurred_at`, and a prior status row can live in
   any month), so each append costs one index probe per partition. With
   the default 12-month retention that is ~26 cheap B-tree probes; if you
-  raise `DRONTE_RETENTION_MONTHS` substantially, watch notification
+  raise `CHIMELY_RETENTION_MONTHS` substantially, watch notification
   create/read latency grow with the partition count.
 
 ## Dead-letter replay
@@ -63,9 +63,9 @@ table itself stays near-empty (completed work leaves no row; parked work
 does not live in the hot claim path).
 
 ```bash
-dronte dlq list                 # one line per parked job
-dronte dlq replay job_01h4…     # replay one (fresh attempt budget, runs now)
-dronte dlq replay --all
+chimely dlq list                 # one line per parked job
+chimely dlq replay job_01h4…     # replay one (fresh attempt budget, runs now)
+chimely dlq replay --all
 ```
 
 Replay re-enqueues the original row (same id, payload, and cursor), so a
@@ -76,11 +76,11 @@ chunked fan-out resumes where it died and side effects apply exactly once.
 On SIGTERM/SIGINT, in order:
 
 1. `/readyz` flips to 503 while the listener keeps serving
-   (`DRONTE_SHUTDOWN_GRACE_MS`, default 5000) so load balancers drain the
+   (`CHIMELY_SHUTDOWN_GRACE_MS`, default 5000) so load balancers drain the
    replica without dropping in-flight requests.
 2. The listener stops accepting; SSE streams receive a jittered `retry:`
    directive and close (no reconnect stampede); workers stop claiming.
-3. In-flight jobs get `DRONTE_SHUTDOWN_DRAIN_DEADLINE_MS` (default 30000)
+3. In-flight jobs get `CHIMELY_SHUTDOWN_DRAIN_DEADLINE_MS` (default 30000)
    to finish. Past the deadline the worker is aborted — the open
    transaction rolls back and the job is re-claimed elsewhere
    (at-least-once by design, side effects keyed by job deletion).
@@ -96,8 +96,8 @@ applies per replica.
 
 | Knob | Default | Applies to |
 |---|---|---|
-| `DRONTE_API_KEY_RATE_PER_SEC` / `_BURST` | 50 / 200 | per API key: `POST /v1/notifications`, `POST /v1/broadcasts` |
-| `DRONTE_SUBSCRIBER_RATE_PER_SEC` / `_BURST` | 10 / 50 | per subscriber: `GET /v1/inbox/items` |
+| `CHIMELY_API_KEY_RATE_PER_SEC` / `_BURST` | 50 / 200 | per API key: `POST /v1/notifications`, `POST /v1/broadcasts` |
+| `CHIMELY_SUBSCRIBER_RATE_PER_SEC` / `_BURST` | 10 / 50 | per subscriber: `GET /v1/inbox/items` |
 
 A rate of `0` disables the limit.
 
@@ -105,15 +105,15 @@ A rate of `0` disables the limit.
 
 Failed jobs reschedule with equal-jittered exponential backoff: attempt
 *n* waits in `[exp/2, exp]` where
-`exp = min(DRONTE_RETRY_BACKOFF_CAP_MS, DRONTE_RETRY_BACKOFF_BASE_MS × 2^(n−1))`
+`exp = min(CHIMELY_RETRY_BACKOFF_CAP_MS, CHIMELY_RETRY_BACKOFF_BASE_MS × 2^(n−1))`
 (defaults 5s base, 15min cap).
 
 ## Retention
 
 Monthly partitions on `notifications` and `notification_status_log` are
 pre-created 13 months ahead (covering the `deliver_at` cap) and dropped
-(DETACH + DROP) past `DRONTE_RETENTION_MONTHS` (default 12). Idempotency
-snapshots are purged after `DRONTE_IDEMPOTENCY_RETENTION_DAYS` (default
+(DETACH + DROP) past `CHIMELY_RETENTION_MONTHS` (default 12). Idempotency
+snapshots are purged after `CHIMELY_IDEMPOTENCY_RETENTION_DAYS` (default
 30).
 
 ## Measured capacity

--- a/docs/lib/openapi.ts
+++ b/docs/lib/openapi.ts
@@ -1,10 +1,10 @@
 import { createOpenAPI } from 'fumadocs-openapi/server';
 
 /**
- * The docs site consumes the exported spec (`dronte openapi`, committed at
- * docs/openapi/dronte.yaml by `pnpm generate`). Generated from code, never
+ * The docs site consumes the exported spec (`chimely openapi`, committed at
+ * docs/openapi/chimely.yaml by `pnpm generate`). Generated from code, never
  * hand-edited.
  */
 export const openapi = createOpenAPI({
-  input: ['./openapi/dronte.yaml'],
+  input: ['./openapi/chimely.yaml'],
 });

--- a/docs/openapi/chimely.yaml
+++ b/docs/openapi/chimely.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: Dronte API
+  title: Chimely API
   description: |
     Two planes, one binary:
 
@@ -8,7 +8,7 @@ info:
       key. Creates notifications and broadcasts, manages subscribers and their
       preferences. API keys are environment-scoped; the environment is implied
       by the key.
-    * **Subscriber plane** — called by `@dronte/client` (the `<Inbox />`
+    * **Subscriber plane** — called by `@chimely/client` (the `<Inbox />`
       widget) on behalf of one end user. Authenticated with an HMAC subscriber
       hash: `hex(HMAC-SHA256(environment.subscriber_hmac_secret, subscriber_id))`
       computed by the customer's backend. Mandatory in environments with
@@ -20,9 +20,9 @@ info:
 
     | Header | Query fallback | Meaning |
     |---|---|---|
-    | `X-Dronte-Environment` | `environment` | environment slug |
-    | `X-Dronte-Subscriber` | `subscriber_id` | customer-provided subscriber id |
-    | `X-Dronte-Subscriber-Hash` | `subscriber_hash` | HMAC hash (when required) |
+    | `X-Chimely-Environment` | `environment` | environment slug |
+    | `X-Chimely-Subscriber` | `subscriber_id` | customer-provided subscriber id |
+    | `X-Chimely-Subscriber-Hash` | `subscriber_hash` | HMAC hash (when required) |
 
     **Idempotency.** Every create accepts `idempotency_key` (client-supplied or
     server-generated and echoed). Uniqueness is per environment per resource
@@ -39,7 +39,7 @@ info:
     conventional status codes. 429 carries `Retry-After`.
   version: 0.1.0
 servers:
-- url: https://dronte.example.com
+- url: https://chimely.dev
 paths:
   /admin/api/dlq:
     get:
@@ -647,7 +647,7 @@ paths:
       tags:
       - admin
       summary: Log in with email + password; starts a server-side session
-      description: On success sets the `dronte_admin` session cookie (HttpOnly, SameSite=Strict, Path=/admin). Failure returns a generic error that does not reveal which field was wrong.
+      description: On success sets the `chimely_admin` session cookie (HttpOnly, SameSite=Strict, Path=/admin). Failure returns a generic error that does not reveal which field was wrong.
       operationId: adminLogin
       requestBody:
         content:
@@ -669,7 +669,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         '403':
-          description: Missing X-Dronte-Admin header.
+          description: Missing X-Chimely-Admin header.
           content:
             application/json:
               schema:
@@ -686,7 +686,7 @@ paths:
         '401':
           description: Authentication required (no or expired session).
         '403':
-          description: Missing X-Dronte-Admin header.
+          description: Missing X-Chimely-Admin header.
           content:
             application/json:
               schema:
@@ -2250,7 +2250,7 @@ components:
     AdminSession:
       type: apiKey
       in: cookie
-      name: dronte_admin
+      name: chimely_admin
       description: Server-side admin session cookie, set by POST /admin/api/login.
     ApiKeyBearer:
       type: http
@@ -2259,7 +2259,7 @@ components:
     SubscriberEnv:
       type: apiKey
       in: header
-      name: X-Dronte-Environment
+      name: X-Chimely-Environment
     SubscriberEnvQ:
       type: apiKey
       in: query
@@ -2267,7 +2267,7 @@ components:
     SubscriberHash:
       type: apiKey
       in: header
-      name: X-Dronte-Subscriber-Hash
+      name: X-Chimely-Subscriber-Hash
       description: Optional when the environment has require_subscriber_hash = false.
     SubscriberHashQ:
       type: apiKey
@@ -2276,7 +2276,7 @@ components:
     SubscriberId:
       type: apiKey
       in: header
-      name: X-Dronte-Subscriber
+      name: X-Chimely-Subscriber
     SubscriberIdQ:
       type: apiKey
       in: query
@@ -2305,8 +2305,8 @@ components:
 security: []
 tags:
 - name: management
-  description: Backend-to-Dronte. Bearer API key.
+  description: Backend-to-Chimely. Bearer API key.
 - name: subscriber
-  description: Widget-to-Dronte. HMAC subscriber hash.
+  description: Widget-to-Chimely. HMAC subscriber hash.
 - name: admin
   description: Instance admin dashboard. Built-in users, session cookie.

--- a/examples/LICENSE
+++ b/examples/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Dronte contributors
+Copyright (c) 2026 Chimely contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,7 @@
 # Examples
 
 - [`nextjs/`](./nextjs) — the 30-second quickstart and live demo: the
-  drop-in `<Inbox />` against a local Redis-less dronte. Start here.
+  drop-in `<Inbox />` against a local Redis-less chimely. Start here.
 
 A Vite example and an axum trigger example follow as stretch deliverables
 (see `specs/phase-2-sdk.md`).

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -1,6 +1,6 @@
-# Dronte quickstart (Next.js)
+# Chimely quickstart (Next.js)
 
-The drop-in `<Inbox />` running against a local dronte in Redis-less mode
+The drop-in `<Inbox />` running against a local chimely in Redis-less mode
 (hints ride Postgres LISTEN/NOTIFY — no Redis needed for the quickstart).
 
 ## 30-second quickstart
@@ -9,21 +9,21 @@ From the repository root:
 
 ```bash
 # 1. Postgres (skip if you have one; any reachable instance works)
-docker run -d --name dronte-quickstart-pg \
-  -e POSTGRES_PASSWORD=dronte -p 5432:5432 postgres:16-alpine
+docker run -d --name chimely-quickstart-pg \
+  -e POSTGRES_PASSWORD=chimely -p 5432:5432 postgres:16-alpine
 
-# 2. Dronte, with the dev bootstrap: seeds environment `demo`
+# 2. Chimely, with the dev bootstrap: seeds environment `demo`
 #    (no subscriber hashes) and the API key `dev-secret-key`
-DATABASE_URL=postgres://postgres:dronte@localhost:5432/postgres \
-DRONTE_DEV_ENVIRONMENT=demo \
-DRONTE_DEV_API_KEY=dev-secret-key \
-DRONTE_LISTEN_ADDR=127.0.0.1:8080 \
+DATABASE_URL=postgres://postgres:chimely@localhost:5432/postgres \
+CHIMELY_DEV_ENVIRONMENT=demo \
+CHIMELY_DEV_API_KEY=dev-secret-key \
+CHIMELY_LISTEN_ADDR=127.0.0.1:8080 \
 cargo run --manifest-path server/Cargo.toml -- serve
 
 # 3. This example (new terminal)
 pnpm install
 pnpm --filter "./packages/*" build
-pnpm --filter dronte-example-nextjs dev
+pnpm --filter chimely-example-nextjs dev
 ```
 
 Open <http://localhost:3000>, then send yourself a notification:
@@ -44,9 +44,9 @@ SSE hint and the widget refetches conditionally (ETag, mostly 304s).
   subscriberId))`, computed by **your backend**, never in the browser.
   The dev bootstrap turns the requirement off; production environments
   keep it on.
-- `DRONTE_DEV_ENVIRONMENT` / `DRONTE_DEV_API_KEY` are for local
+- `CHIMELY_DEV_ENVIRONMENT` / `CHIMELY_DEV_API_KEY` are for local
   quickstarts only. Real environments and keys are managed in the admin
   UI (Phase 4).
-- Point `NEXT_PUBLIC_DRONTE_URL`, `NEXT_PUBLIC_DRONTE_ENVIRONMENT`, and
-  `NEXT_PUBLIC_DRONTE_SUBSCRIBER_ID` at your deployment to reuse this app
+- Point `NEXT_PUBLIC_CHIMELY_URL`, `NEXT_PUBLIC_CHIMELY_ENVIRONMENT`, and
+  `NEXT_PUBLIC_CHIMELY_SUBSCRIBER_ID` at your deployment to reuse this app
   against it.

--- a/examples/nextjs/app/layout.tsx
+++ b/examples/nextjs/app/layout.tsx
@@ -3,8 +3,8 @@ import type { ReactNode } from 'react';
 import './globals.css';
 
 export const metadata: Metadata = {
-  title: 'Dronte quickstart',
-  description: 'The drop-in <Inbox /> running against a local dronte.',
+  title: 'Chimely quickstart',
+  description: 'The drop-in <Inbox /> running against a local chimely.',
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/examples/nextjs/app/page.tsx
+++ b/examples/nextjs/app/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { Inbox } from '@dronte/react';
+import { Inbox } from '@chimely/react';
 
 // The dev-bootstrap defaults from the README. Override with NEXT_PUBLIC_*
-// env vars when your dronte runs elsewhere.
-const serverUrl = process.env.NEXT_PUBLIC_DRONTE_URL ?? 'http://localhost:8080';
-const environment = process.env.NEXT_PUBLIC_DRONTE_ENVIRONMENT ?? 'demo';
-const subscriberId = process.env.NEXT_PUBLIC_DRONTE_SUBSCRIBER_ID ?? 'usr_demo';
+// env vars when your chimely runs elsewhere.
+const serverUrl = process.env.NEXT_PUBLIC_CHIMELY_URL ?? 'http://localhost:8080';
+const environment = process.env.NEXT_PUBLIC_CHIMELY_ENVIRONMENT ?? 'demo';
+const subscriberId = process.env.NEXT_PUBLIC_CHIMELY_SUBSCRIBER_ID ?? 'usr_demo';
 
 const curl = `curl -X POST ${serverUrl}/v1/notifications \\
   -H 'Authorization: Bearer dev-secret-key' \\
@@ -25,14 +25,14 @@ export default function Page() {
   return (
     <>
       <header className="topbar">
-        <h1>Dronte quickstart</h1>
+        <h1>Chimely quickstart</h1>
         {/* The whole integration: one component, three props. In production
             add subscriberHash, computed by your backend. */}
         <Inbox serverUrl={serverUrl} environment={environment} subscriberId={subscriberId} />
       </header>
       <main>
         <p>
-          The bell above is <code>&lt;Inbox /&gt;</code> from <code>@dronte/react</code>, connected
+          The bell above is <code>&lt;Inbox /&gt;</code> from <code>@chimely/react</code>, connected
           to <code>{serverUrl}</code> as subscriber <code>{subscriberId}</code> in the{' '}
           <code>{environment}</code> environment.
         </p>

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "dronte-example-nextjs",
+  "name": "chimely-example-nextjs",
   "version": "0.0.0",
   "private": true,
-  "description": "Dronte 30-second quickstart: the drop-in <Inbox /> in a Next.js app.",
+  "description": "Chimely 30-second quickstart: the drop-in <Inbox /> in a Next.js app.",
   "license": "MIT",
   "scripts": {
     "dev": "next dev",
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@dronte/react": "workspace:*",
+    "@chimely/react": "workspace:*",
     "next": "16.2.8",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dronte-monorepo",
+  "name": "chimely-monorepo",
   "private": true,
   "packageManager": "pnpm@11.5.2",
   "scripts": {

--- a/packages/client/LICENSE
+++ b/packages/client/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Dronte contributors
+Copyright (c) 2026 Chimely contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@dronte/client",
+  "name": "@chimely/client",
   "version": "0.0.0",
-  "description": "Framework-agnostic headless core for the Dronte in-app notification inbox.",
+  "description": "Framework-agnostic headless core for the Chimely in-app notification inbox.",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,
@@ -33,7 +33,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/that-ambuj/dronte.git",
+    "url": "git+https://github.com/that-ambuj/chimely.git",
     "directory": "packages/client"
   }
 }

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1,13 +1,13 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
-import { DronteClient } from './client';
-import { DronteError } from './errors';
+import { ChimelyClient } from './client';
+import { ChimelyError } from './errors';
 import type { StubServer } from './test-support/stub-server';
 import { createStubServer } from './test-support/stub-server';
-import type { DronteClientConfig, InboxItem, InboxSnapshot } from './types';
+import type { ChimelyClientConfig, InboxItem, InboxSnapshot } from './types';
 
-function makeClient(stub: StubServer, config: Partial<DronteClientConfig> = {}): DronteClient {
-  return new DronteClient({
-    serverUrl: 'https://dronte.test',
+function makeClient(stub: StubServer, config: Partial<ChimelyClientConfig> = {}): ChimelyClient {
+  return new ChimelyClient({
+    serverUrl: 'https://chimely.test',
     environment: stub.environment,
     subscriberId: stub.subscriberId,
     fetchFn: stub.fetchFn,
@@ -23,7 +23,7 @@ function must<T>(value: T | undefined, label = 'value'): T {
   return value;
 }
 
-async function connectAndLoad(client: DronteClient, stub: StubServer): Promise<void> {
+async function connectAndLoad(client: ChimelyClient, stub: StubServer): Promise<void> {
   client.connect();
   stub.openStream();
   await vi.waitFor(() => {
@@ -63,9 +63,9 @@ describe('connection and auth', () => {
     expect(client.getSnapshot().counts).toEqual({ unread: 1, unseen: 1 });
 
     const listRequest = must(stub.requestsFor('/v1/inbox/items')[0]);
-    expect(listRequest.headers['x-dronte-environment']).toBe(stub.environment);
-    expect(listRequest.headers['x-dronte-subscriber']).toBe(stub.subscriberId);
-    expect(listRequest.headers['x-dronte-subscriber-hash']).toBe('deadbeef');
+    expect(listRequest.headers['x-chimely-environment']).toBe(stub.environment);
+    expect(listRequest.headers['x-chimely-subscriber']).toBe(stub.subscriberId);
+    expect(listRequest.headers['x-chimely-subscriber-hash']).toBe('deadbeef');
   });
 
   test('subscriber hash is omitted everywhere when not configured', async () => {
@@ -75,7 +75,7 @@ describe('connection and auth', () => {
 
     expect(new URL(stub.stream().url).searchParams.has('subscriber_hash')).toBe(false);
     const listRequest = must(stub.requestsFor('/v1/inbox/items')[0]);
-    expect('x-dronte-subscriber-hash' in listRequest.headers).toBe(false);
+    expect('x-chimely-subscriber-hash' in listRequest.headers).toBe(false);
   });
 
   test('a wrong hash surfaces unauthorized on the error channel', async () => {
@@ -83,7 +83,7 @@ describe('connection and auth', () => {
     const client = makeClient(stub, { subscriberHash: 'wrong' });
     client.connect();
     await vi.waitFor(() => {
-      expect(client.getSnapshot().error).toBeInstanceOf(DronteError);
+      expect(client.getSnapshot().error).toBeInstanceOf(ChimelyError);
     });
     expect(client.getSnapshot().error?.code).toBe('unauthorized');
     expect(client.getSnapshot().error?.status).toBe(401);
@@ -349,7 +349,7 @@ describe('optimistic read state', () => {
     const after = client.getSnapshot();
     expect(must(after.items[0]).read).toBe(false);
     expect(after.counts).toEqual(before.counts);
-    expect(after.error).toBeInstanceOf(DronteError);
+    expect(after.error).toBeInstanceOf(ChimelyError);
     expect(after.error?.code).toBe('internal');
     expect(after.error?.status).toBe(500);
   });

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,10 +1,10 @@
 import type { ResolvedBackoff } from './backoff';
 import { backoffDelayMs, resolveBackoff } from './backoff';
-import { DronteError, errorFromResponse, networkError } from './errors';
+import { ChimelyError, errorFromResponse, networkError } from './errors';
 import type { components } from './generated/api';
 import { InboxStore } from './store';
 import type {
-  DronteClientConfig,
+  ChimelyClientConfig,
   EventSourceLike,
   InboxItem,
   InboxItemId,
@@ -43,14 +43,14 @@ function isOlderThan<T>(item: InboxItem<T>, boundary: InboxItem<T>): boolean {
   return item.id < boundary.id;
 }
 
-function asDronteError(cause: unknown): DronteError {
-  return cause instanceof DronteError ? cause : networkError(cause);
+function asChimelyError(cause: unknown): ChimelyError {
+  return cause instanceof ChimelyError ? cause : networkError(cause);
 }
 
 const defaultCreateEventSource = (url: string): EventSourceLike => {
   const Ctor = (globalThis as { EventSource?: new (url: string) => EventSourceLike }).EventSource;
   if (!Ctor) {
-    throw new DronteError(
+    throw new ChimelyError(
       'no EventSource implementation available, pass createEventSource in the client config',
       { code: 'no_event_source' },
     );
@@ -67,11 +67,11 @@ const defaultCreateEventSource = (url: string): EventSourceLike => {
  * - Mutations are optimistic. The snapshot updates synchronously, the
  *   server call follows, and a failure rolls back and surfaces on the
  *   'error' channel. Void mutations resolve either way. Calls that return
- *   data (getPreferences, setPreferences) also reject with the DronteError.
+ *   data (getPreferences, setPreferences) also reject with the ChimelyError.
  * - markAllSeen() zeroes unseen without touching read state.
  */
-export class DronteClient<TPayload = WellKnownPayload> {
-  private readonly config: DronteClientConfig;
+export class ChimelyClient<TPayload = WellKnownPayload> {
+  private readonly config: ChimelyClientConfig;
   private readonly baseUrl: string;
   private readonly pageSize: number;
   private readonly backoff: ResolvedBackoff;
@@ -99,7 +99,7 @@ export class DronteClient<TPayload = WellKnownPayload> {
   private refreshAgain = false;
   private fetchingMore: Promise<void> | null = null;
 
-  constructor(config: DronteClientConfig) {
+  constructor(config: ChimelyClientConfig) {
     this.config = config;
     this.baseUrl = config.serverUrl.replace(/\/+$/, '');
     this.pageSize = Math.min(100, Math.max(1, config.pageSize ?? 20));
@@ -203,7 +203,7 @@ export class DronteClient<TPayload = WellKnownPayload> {
       this.clearError();
     } catch (cause) {
       const rollback = changed ? { items: prev.items, counts: prev.counts } : {};
-      this.store.patch({ ...rollback, error: asDronteError(cause) });
+      this.store.patch({ ...rollback, error: asChimelyError(cause) });
       this.reconcileAfterFailedMutation();
     }
   }
@@ -226,7 +226,7 @@ export class DronteClient<TPayload = WellKnownPayload> {
         error: null,
       });
     } catch (cause) {
-      this.store.patch({ items: prev.items, counts: prev.counts, error: asDronteError(cause) });
+      this.store.patch({ items: prev.items, counts: prev.counts, error: asChimelyError(cause) });
       this.reconcileAfterFailedMutation();
     }
   }
@@ -247,7 +247,7 @@ export class DronteClient<TPayload = WellKnownPayload> {
         error: null,
       });
     } catch (cause) {
-      this.store.patch({ counts: prev.counts, error: asDronteError(cause) });
+      this.store.patch({ counts: prev.counts, error: asChimelyError(cause) });
       this.reconcileAfterFailedMutation();
     }
   }
@@ -274,7 +274,7 @@ export class DronteClient<TPayload = WellKnownPayload> {
       void this.refresh();
       return body.preferences;
     } catch (cause) {
-      const error = asDronteError(cause);
+      const error = asChimelyError(cause);
       this.store.patch({ error });
       throw error;
     }
@@ -319,7 +319,7 @@ export class DronteClient<TPayload = WellKnownPayload> {
       }
       this.store.patch(patch);
     } catch (cause) {
-      this.store.patch({ isLoading: false, error: asDronteError(cause) });
+      this.store.patch({ isLoading: false, error: asChimelyError(cause) });
     }
   }
 
@@ -376,7 +376,7 @@ export class DronteClient<TPayload = WellKnownPayload> {
         error: null,
       });
     } catch (cause) {
-      this.store.patch({ error: asDronteError(cause) });
+      this.store.patch({ error: asChimelyError(cause) });
     }
   }
 
@@ -386,11 +386,11 @@ export class DronteClient<TPayload = WellKnownPayload> {
     init?: { ifNoneMatch?: string | null; body?: unknown },
   ): Promise<Response> {
     const headers: Record<string, string> = {
-      'X-Dronte-Environment': this.config.environment,
-      'X-Dronte-Subscriber': this.config.subscriberId,
+      'X-Chimely-Environment': this.config.environment,
+      'X-Chimely-Subscriber': this.config.subscriberId,
     };
     if (this.config.subscriberHash !== undefined) {
-      headers['X-Dronte-Subscriber-Hash'] = this.config.subscriberHash;
+      headers['X-Chimely-Subscriber-Hash'] = this.config.subscriberHash;
     }
     if (init?.ifNoneMatch) {
       headers['If-None-Match'] = init.ifNoneMatch;
@@ -489,7 +489,7 @@ export class DronteClient<TPayload = WellKnownPayload> {
       this.generation += 1;
       this.store.patch({
         status: 'closed',
-        error: new DronteError('stream closed after maxAttempts consecutive failures', {
+        error: new ChimelyError('stream closed after maxAttempts consecutive failures', {
           code: 'connection_failed',
         }),
       });

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -2,7 +2,7 @@ import type { components } from './generated/api';
 
 type ErrorEnvelope = components['schemas']['Error'];
 
-export class DronteError extends Error {
+export class ChimelyError extends Error {
   /** Server error-envelope code, or a client-side code ('network', 'unauthorized'). */
   readonly code: string;
   /** HTTP status when the error came from the server. */
@@ -10,7 +10,7 @@ export class DronteError extends Error {
 
   constructor(message: string, options: { code: string; status?: number; cause?: unknown }) {
     super(message, options.cause === undefined ? undefined : { cause: options.cause });
-    this.name = 'DronteError';
+    this.name = 'ChimelyError';
     this.code = options.code;
     if (options.status !== undefined) {
       this.status = options.status;
@@ -31,8 +31,8 @@ function fallbackCode(status: number): string {
   }
 }
 
-/** Builds a DronteError from a non-2xx response, reading the error envelope when present. */
-export async function errorFromResponse(response: Response): Promise<DronteError> {
+/** Builds a ChimelyError from a non-2xx response, reading the error envelope when present. */
+export async function errorFromResponse(response: Response): Promise<ChimelyError> {
   let code = fallbackCode(response.status);
   let message = `request failed with status ${response.status}`;
   try {
@@ -44,11 +44,11 @@ export async function errorFromResponse(response: Response): Promise<DronteError
   } catch {
     // Envelope absent or unparsable. The status-derived code stands.
   }
-  return new DronteError(message, { code, status: response.status });
+  return new ChimelyError(message, { code, status: response.status });
 }
 
 /** Wraps a thrown fetch failure (DNS, refused connection, abort) as a network error. */
-export function networkError(cause: unknown): DronteError {
+export function networkError(cause: unknown): ChimelyError {
   const message = cause instanceof Error ? cause.message : 'network request failed';
-  return new DronteError(message, { code: 'network', cause });
+  return new ChimelyError(message, { code: 'network', cause });
 }

--- a/packages/client/src/generated/api.d.ts
+++ b/packages/client/src/generated/api.d.ts
@@ -251,7 +251,7 @@ export interface paths {
         put?: never;
         /**
          * Log in with email + password; starts a server-side session
-         * @description On success sets the `dronte_admin` session cookie (HttpOnly, SameSite=Strict, Path=/admin). Failure returns a generic error that does not reveal which field was wrong.
+         * @description On success sets the `chimely_admin` session cookie (HttpOnly, SameSite=Strict, Path=/admin). Failure returns a generic error that does not reveal which field was wrong.
          */
         post: operations["adminLogin"];
         delete?: never;
@@ -1828,7 +1828,7 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
-            /** @description Missing X-Dronte-Admin header. */
+            /** @description Missing X-Chimely-Admin header. */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -1862,7 +1862,7 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Missing X-Dronte-Admin header. */
+            /** @description Missing X-Chimely-Admin header. */
             403: {
                 headers: {
                     [name: string]: unknown;

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -1,16 +1,16 @@
 import { expect, test } from 'vitest';
-import { BACKOFF_DEFAULTS, DronteClient, DronteError } from './index';
+import { BACKOFF_DEFAULTS, ChimelyClient, ChimelyError } from './index';
 
 test('public surface exports', () => {
-  expect(typeof DronteClient).toBe('function');
-  expect(typeof DronteError).toBe('function');
+  expect(typeof ChimelyClient).toBe('function');
+  expect(typeof ChimelyError).toBe('function');
   expect(BACKOFF_DEFAULTS.initialDelayMs).toBe(1000);
 });
 
-test('DronteError carries code and status', () => {
-  const error = new DronteError('nope', { code: 'unauthorized', status: 401 });
+test('ChimelyError carries code and status', () => {
+  const error = new ChimelyError('nope', { code: 'unauthorized', status: 401 });
   expect(error).toBeInstanceOf(Error);
   expect(error.code).toBe('unauthorized');
   expect(error.status).toBe(401);
-  expect(error.name).toBe('DronteError');
+  expect(error.name).toBe('ChimelyError');
 });

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @dronte/client, the framework-agnostic headless core.
+ * @chimely/client, the framework-agnostic headless core.
  *
  * The public surface is stable and additive-only. Wire types under ./generated
  * are produced from the server's exported OpenAPI document. Never hand-edit
@@ -7,13 +7,13 @@
  */
 
 export { BACKOFF_DEFAULTS } from './backoff';
-export { DronteClient } from './client';
-export { DronteError } from './errors';
+export { ChimelyClient } from './client';
+export { ChimelyError } from './errors';
 export type {
   BackoffConfig,
   BroadcastId,
+  ChimelyClientConfig,
   ConnectionStatus,
-  DronteClientConfig,
   EventSourceLike,
   InboxCounts,
   InboxItem,

--- a/packages/client/src/test-support/stub-server.ts
+++ b/packages/client/src/test-support/stub-server.ts
@@ -1,5 +1,5 @@
 /**
- * In-process stub of the Dronte subscriber-plane API, typed against the
+ * In-process stub of the Chimely subscriber-plane API, typed against the
  * generated wire types in ../generated/api. Never touches server/. The
  * generated types are the contract.
  */
@@ -25,7 +25,7 @@ export interface RecordedRequest {
 export interface StubServerOptions {
   environment?: string;
   subscriberId?: string;
-  /** When set, X-Dronte-Subscriber-Hash must equal it or the stub returns 401. */
+  /** When set, X-Chimely-Subscriber-Hash must equal it or the stub returns 401. */
   requireHash?: string;
   baseTimeMs?: number;
 }
@@ -286,9 +286,9 @@ export class StubServer {
     }
 
     if (
-      headers['x-dronte-environment'] !== this.environment ||
-      headers['x-dronte-subscriber'] !== this.subscriberId ||
-      (this.requireHash !== undefined && headers['x-dronte-subscriber-hash'] !== this.requireHash)
+      headers['x-chimely-environment'] !== this.environment ||
+      headers['x-chimely-subscriber'] !== this.subscriberId ||
+      (this.requireHash !== undefined && headers['x-chimely-subscriber-hash'] !== this.requireHash)
     ) {
       return json(401, errorBody('unauthorized', 'missing or invalid subscriber auth'));
     }

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -4,7 +4,7 @@
  * Payloads are the exception. They are wire format, passed through verbatim.
  */
 
-import type { DronteError } from './errors';
+import type { ChimelyError } from './errors';
 
 export type InboxItemSource = 'notification' | 'broadcast';
 
@@ -17,7 +17,7 @@ export type InboxItemId = NotificationId | BroadcastId;
 /**
  * The payload convention the default <Inbox /> rendering understands.
  * All fields optional. Payloads are customer-defined and pass through
- * Dronte verbatim (snake_case keys, never case-transformed by the SDK).
+ * Chimely verbatim (snake_case keys, never case-transformed by the SDK).
  * Unknown fields ride along for custom renderers. This interface only
  * ever gains optional fields.
  */
@@ -35,7 +35,7 @@ export interface WellKnownPayload {
 
 /**
  * One merged-inbox entry. `TPayload` lets apps type their own payloads.
- * Dronte never interprets payloads.
+ * Chimely never interprets payloads.
  */
 export interface InboxItem<TPayload = WellKnownPayload> {
   /** The TypeID prefix encodes the source. `source` is the ergonomic discriminator. */
@@ -93,8 +93,8 @@ export interface BackoffConfig {
   maxAttempts?: number;
 }
 
-export interface DronteClientConfig {
-  /** Dronte server origin, e.g. `https://dronte.example.com`. */
+export interface ChimelyClientConfig {
+  /** Chimely server origin, e.g. `https://chimely.dev`. */
   serverUrl: string;
   /** Environment slug, e.g. `dashboard-prod`. */
   environment: string;
@@ -149,5 +149,5 @@ export interface InboxSnapshot<TPayload = WellKnownPayload> {
   /** True during the initial load and refreshes (not during fetchMore). */
   isLoading: boolean;
   /** Last unrecovered error. Cleared by the next successful operation. */
-  error: DronteError | null;
+  error: ChimelyError | null;
 }

--- a/packages/react/LICENSE
+++ b/packages/react/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Dronte contributors
+Copyright (c) 2026 Chimely contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@dronte/react",
+  "name": "@chimely/react",
   "version": "0.0.0",
-  "description": "React bindings and the drop-in <Inbox /> component for Dronte.",
+  "description": "React bindings and the drop-in <Inbox /> component for Chimely.",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,
@@ -27,7 +27,7 @@
     "react": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@dronte/client": "workspace:*",
+    "@chimely/client": "workspace:*",
     "@floating-ui/dom": "^1.7.6"
   },
   "devDependencies": {
@@ -47,7 +47,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/that-ambuj/dronte.git",
+    "url": "git+https://github.com/that-ambuj/chimely.git",
     "directory": "packages/react"
   }
 }

--- a/packages/react/src/Inbox.tsx
+++ b/packages/react/src/Inbox.tsx
@@ -1,9 +1,9 @@
-import type { DronteClientConfig, InboxItem, WellKnownPayload } from '@dronte/client';
-import { DronteClient } from '@dronte/client';
+import type { ChimelyClientConfig, InboxItem, WellKnownPayload } from '@chimely/client';
+import { ChimelyClient } from '@chimely/client';
 import { autoUpdate, computePosition, flip, offset, shift } from '@floating-ui/dom';
 import type { CSSProperties, ReactNode } from 'react';
 import { useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { DronteContext, useDronteClient } from './context';
+import { ChimelyContext, useChimelyClient } from './context';
 import { useNotifications, usePreferences, useUnseenCount } from './hooks';
 import type { InboxLocalization } from './localization';
 import { mergeLocalization } from './localization';
@@ -43,7 +43,7 @@ export interface InboxAppearance {
     borderRadius?: string;
     fontFamily?: string;
     fontSize?: string;
-    /** Extension point: forwarded as `--dronte-<key>` verbatim. */
+    /** Extension point: forwarded as `--chimely-<key>` verbatim. */
     [customProperty: string]: string | undefined;
   };
   classNames?: Partial<Record<InboxSlot, string>>;
@@ -55,7 +55,7 @@ export interface InboxAppearance {
  * Two usage modes:
  * - Standalone: pass `serverUrl`/`environment`/`subscriberId`(/`subscriberHash`)
  *   and <Inbox /> constructs and owns its client.
- * - Provided: render inside <DronteProvider> and pass no connection props.
+ * - Provided: render inside <ChimelyProvider> and pass no connection props.
  *   Connection props, when present, take precedence over the provider.
  *
  * Built-in behavior (part of the contract):
@@ -69,7 +69,7 @@ export interface InboxProps<TPayload = WellKnownPayload> {
   environment?: string;
   subscriberId?: string;
   subscriberHash?: string;
-  backoff?: DronteClientConfig['backoff'];
+  backoff?: ChimelyClientConfig['backoff'];
 
   appearance?: InboxAppearance;
   localization?: Partial<InboxLocalization>;
@@ -92,7 +92,7 @@ export interface InboxProps<TPayload = WellKnownPayload> {
 
 export function Inbox<TPayload = WellKnownPayload>(props: InboxProps<TPayload>): ReactNode {
   const { serverUrl, environment, subscriberId, subscriberHash, backoff } = props;
-  const contextClient = useContext(DronteContext);
+  const contextClient = useContext(ChimelyContext);
   // Connection props are all-or-nothing and take precedence over the provider.
   const [owned] = useState(() => {
     if (serverUrl === undefined) {
@@ -101,18 +101,18 @@ export function Inbox<TPayload = WellKnownPayload>(props: InboxProps<TPayload>):
     if (environment === undefined || subscriberId === undefined) {
       throw new Error('standalone <Inbox /> requires serverUrl, environment, and subscriberId');
     }
-    const config: DronteClientConfig = { serverUrl, environment, subscriberId };
+    const config: ChimelyClientConfig = { serverUrl, environment, subscriberId };
     if (subscriberHash !== undefined) {
       config.subscriberHash = subscriberHash;
     }
     if (backoff !== undefined) {
       config.backoff = backoff;
     }
-    return new DronteClient(config);
+    return new ChimelyClient(config);
   });
   const client = owned ?? contextClient;
   if (!client) {
-    throw new Error('<Inbox /> requires connection props or an enclosing <DronteProvider>');
+    throw new Error('<Inbox /> requires connection props or an enclosing <ChimelyProvider>');
   }
   useEffect(() => {
     if (!owned) {
@@ -124,14 +124,14 @@ export function Inbox<TPayload = WellKnownPayload>(props: InboxProps<TPayload>):
     };
   }, [owned]);
   return (
-    <DronteContext.Provider value={client}>
+    <ChimelyContext.Provider value={client}>
       <InboxView<TPayload> {...props} />
-    </DronteContext.Provider>
+    </ChimelyContext.Provider>
   );
 }
 
 function InboxView<TPayload>(props: InboxProps<TPayload>): ReactNode {
-  const client = useDronteClient();
+  const client = useChimelyClient();
   const { items, isLoading, hasMore, fetchMore, markRead, markAllRead } =
     useNotifications<TPayload>();
   const { count: unseenCount } = useUnseenCount();
@@ -149,7 +149,7 @@ function InboxView<TPayload>(props: InboxProps<TPayload>): ReactNode {
   const classNames = props.appearance?.classNames;
 
   const cls = (slot: InboxSlot): string => {
-    const base = `dronte-${slot.replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`)}`;
+    const base = `chimely-${slot.replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`)}`;
     const custom = classNames?.[slot];
     return custom ? `${base} ${custom}` : base;
   };
@@ -160,7 +160,7 @@ function InboxView<TPayload>(props: InboxProps<TPayload>): ReactNode {
     if (variables) {
       for (const [key, value] of Object.entries(variables)) {
         if (value !== undefined) {
-          style[`--dronte-${key}`] = value;
+          style[`--chimely-${key}`] = value;
         }
       }
     }
@@ -325,19 +325,19 @@ function InboxView<TPayload>(props: InboxProps<TPayload>): ReactNode {
               <>
                 <button
                   type="button"
-                  className="dronte-header-action"
+                  className="chimely-header-action"
                   aria-label="Back"
                   onClick={() => setShowPreferences(false)}
                 >
                   ←
                 </button>
-                <span className="dronte-header-title">{strings.preferencesTitle}</span>
+                <span className="chimely-header-title">{strings.preferencesTitle}</span>
               </>
             ) : (
               <>
                 <button
                   type="button"
-                  className="dronte-header-action"
+                  className="chimely-header-action"
                   onClick={() => {
                     void markAllRead();
                   }}
@@ -347,7 +347,7 @@ function InboxView<TPayload>(props: InboxProps<TPayload>): ReactNode {
                 {props.preferencesPanel !== false && (
                   <button
                     type="button"
-                    className="dronte-header-action"
+                    className="chimely-header-action"
                     aria-label={strings.preferencesTitle}
                     title={strings.preferencesTitle}
                     onClick={() => setShowPreferences(true)}
@@ -361,7 +361,7 @@ function InboxView<TPayload>(props: InboxProps<TPayload>): ReactNode {
           {showPreferences ? (
             <div className={cls('preferences')}>
               {categories.map((category) => (
-                <label key={category} className="dronte-preference">
+                <label key={category} className="chimely-preference">
                   <span>{category}</span>
                   <input
                     type="checkbox"
@@ -383,14 +383,14 @@ function InboxView<TPayload>(props: InboxProps<TPayload>): ReactNode {
                     props.renderEmpty()
                   ) : (
                     <>
-                      <p className="dronte-empty-title">{strings.emptyTitle}</p>
-                      <p className="dronte-empty-body">{strings.emptyBody}</p>
+                      <p className="chimely-empty-title">{strings.emptyTitle}</p>
+                      <p className="chimely-empty-body">{strings.emptyBody}</p>
                     </>
                   )}
                 </li>
               ) : (
                 items.map((item) => (
-                  <li key={item.id} className="dronte-list-row">
+                  <li key={item.id} className="chimely-list-row">
                     {props.renderItem ? (
                       props.renderItem({
                         item,
@@ -406,7 +406,7 @@ function InboxView<TPayload>(props: InboxProps<TPayload>): ReactNode {
                   </li>
                 ))
               )}
-              <li ref={sentinelRef} className="dronte-sentinel" aria-hidden="true" />
+              <li ref={sentinelRef} className="chimely-sentinel" aria-hidden="true" />
             </ul>
           )}
           <div className={cls('footer')} aria-busy={isLoading} />
@@ -426,21 +426,21 @@ function DefaultItem<TPayload>(props: {
   return (
     <button type="button" className={className} onClick={onClick}>
       {typeof payload.icon_url === 'string' && payload.icon_url.length > 0 && (
-        <img className="dronte-item-icon" src={payload.icon_url} alt="" />
+        <img className="chimely-item-icon" src={payload.icon_url} alt="" />
       )}
-      <span className="dronte-item-text">
-        <span className="dronte-item-title">
+      <span className="chimely-item-text">
+        <span className="chimely-item-title">
           {typeof payload.title === 'string' ? payload.title : item.category}
         </span>
         {typeof payload.body === 'string' && payload.body.length > 0 && (
           // Plain text by construction. React escaping keeps it that way.
-          <span className="dronte-item-body">{payload.body}</span>
+          <span className="chimely-item-body">{payload.body}</span>
         )}
-        <time className="dronte-item-time" dateTime={item.occurredAt}>
+        <time className="chimely-item-time" dateTime={item.occurredAt}>
           {new Date(item.occurredAt).toLocaleString()}
         </time>
       </span>
-      {!item.read && <span className="dronte-item-dot" aria-hidden="true" />}
+      {!item.read && <span className="chimely-item-dot" aria-hidden="true" />}
     </button>
   );
 }

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -1,29 +1,29 @@
-import type { DronteClientConfig } from '@dronte/client';
-import { DronteClient } from '@dronte/client';
+import type { ChimelyClientConfig } from '@chimely/client';
+import { ChimelyClient } from '@chimely/client';
 import type { ReactNode } from 'react';
 import { createContext, useContext, useEffect, useState } from 'react';
 
-export const DronteContext = createContext<DronteClient | null>(null);
+export const ChimelyContext = createContext<ChimelyClient | null>(null);
 
 /**
- * Provides one shared DronteClient to all hooks. Either `client` or `config`
+ * Provides one shared ChimelyClient to all hooks. Either `client` or `config`
  * is set. A passed `client` is caller-owned. A passed `config` is constructed
  * here, connected on mount, and closed on unmount.
  */
-export interface DronteProviderProps {
-  client?: DronteClient;
-  config?: DronteClientConfig;
+export interface ChimelyProviderProps {
+  client?: ChimelyClient;
+  config?: ChimelyClientConfig;
   children?: ReactNode;
 }
 
-export function DronteProvider(props: DronteProviderProps): ReactNode {
+export function ChimelyProvider(props: ChimelyProviderProps): ReactNode {
   const { client, config, children } = props;
   // The owned client is constructed once per provider instance. Later
   // changes to the config prop do not rebuild it.
-  const [owned] = useState(() => (client || !config ? null : new DronteClient(config)));
+  const [owned] = useState(() => (client || !config ? null : new ChimelyClient(config)));
   const value = client ?? owned;
   if (!value) {
-    throw new Error('DronteProvider requires a client or a config prop');
+    throw new Error('ChimelyProvider requires a client or a config prop');
   }
   useEffect(() => {
     if (client || !owned) {
@@ -34,14 +34,14 @@ export function DronteProvider(props: DronteProviderProps): ReactNode {
       owned.close();
     };
   }, [client, owned]);
-  return <DronteContext.Provider value={value}>{children}</DronteContext.Provider>;
+  return <ChimelyContext.Provider value={value}>{children}</ChimelyContext.Provider>;
 }
 
-/** The provider's client. Throws outside a <DronteProvider>. */
-export function useDronteClient(): DronteClient {
-  const client = useContext(DronteContext);
+/** The provider's client. Throws outside a <ChimelyProvider>. */
+export function useChimelyClient(): ChimelyClient {
+  const client = useContext(ChimelyContext);
   if (!client) {
-    throw new Error('useDronteClient must be called inside a <DronteProvider>');
+    throw new Error('useChimelyClient must be called inside a <ChimelyProvider>');
   }
   return client;
 }

--- a/packages/react/src/hooks.test.tsx
+++ b/packages/react/src/hooks.test.tsx
@@ -1,7 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, test } from 'vitest';
-import { DronteProvider } from './context';
+import { ChimelyProvider } from './context';
 import {
   useInbox,
   useNotifications,
@@ -16,7 +16,7 @@ async function loadedWrapper(stub: StubServer, clientConfig: { pageSize?: number
   const client = makeClient(stub, clientConfig);
   await loadClient(client, stub);
   const wrapper = ({ children }: { children?: ReactNode }) => (
-    <DronteProvider client={client}>{children}</DronteProvider>
+    <ChimelyProvider client={client}>{children}</ChimelyProvider>
   );
   return { client, wrapper };
 }

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -1,6 +1,6 @@
 import type {
+  ChimelyClient,
   ConnectionStatus,
-  DronteClient,
   InboxCounts,
   InboxItem,
   InboxItemId,
@@ -8,13 +8,13 @@ import type {
   InboxSnapshot,
   Preference,
   WellKnownPayload,
-} from '@dronte/client';
-import { DronteError } from '@dronte/client';
+} from '@chimely/client';
+import { ChimelyError } from '@chimely/client';
 import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
-import { useDronteClient } from './context';
+import { useChimelyClient } from './context';
 
-function useTypedClient<TPayload>(): DronteClient<TPayload> {
-  return useDronteClient() as unknown as DronteClient<TPayload>;
+function useTypedClient<TPayload>(): ChimelyClient<TPayload> {
+  return useChimelyClient() as unknown as ChimelyClient<TPayload>;
 }
 
 function useInboxSnapshot<TPayload>(): InboxSnapshot<TPayload> {
@@ -27,12 +27,12 @@ function useInboxSnapshot<TPayload>(): InboxSnapshot<TPayload> {
   );
 }
 
-function asDronteError(cause: unknown): DronteError {
-  if (cause instanceof DronteError) {
+function asChimelyError(cause: unknown): ChimelyError {
+  if (cause instanceof ChimelyError) {
     return cause;
   }
   const message = cause instanceof Error ? cause.message : 'request failed';
-  return new DronteError(message, { code: 'network', cause });
+  return new ChimelyError(message, { code: 'network', cause });
 }
 
 export interface UseNotificationsOptions {
@@ -43,7 +43,7 @@ export interface UseNotificationsOptions {
 export interface UseNotificationsResult<TPayload = WellKnownPayload> {
   items: ReadonlyArray<InboxItem<TPayload>>;
   isLoading: boolean;
-  error: DronteError | null;
+  error: ChimelyError | null;
   hasMore: boolean;
   fetchMore: () => Promise<void>;
   refresh: () => Promise<void>;
@@ -83,7 +83,7 @@ export function useNotifications<TPayload = WellKnownPayload>(
 export interface UseCountResult {
   count: number;
   isLoading: boolean;
-  error: DronteError | null;
+  error: ChimelyError | null;
 }
 
 /** Live unread count. */
@@ -103,7 +103,7 @@ export interface UsePreferencesResult {
   preferences: ReadonlyArray<Preference>;
   setPreferences: (preferences: Preference[]) => Promise<void>;
   isLoading: boolean;
-  error: DronteError | null;
+  error: ChimelyError | null;
 }
 
 function applyWrites(rows: ReadonlyArray<Preference>, writes: Preference[]): Preference[] {
@@ -121,9 +121,9 @@ function applyWrites(rows: ReadonlyArray<Preference>, writes: Preference[]): Pre
 }
 
 export function usePreferences(): UsePreferencesResult {
-  const client = useDronteClient();
+  const client = useChimelyClient();
   const [rows, setRows] = useState<ReadonlyArray<Preference> | null>(null);
-  const [error, setError] = useState<DronteError | null>(null);
+  const [error, setError] = useState<ChimelyError | null>(null);
 
   useEffect(() => {
     let active = true;
@@ -136,7 +136,7 @@ export function usePreferences(): UsePreferencesResult {
       },
       (cause: unknown) => {
         if (active) {
-          setError(asDronteError(cause));
+          setError(asChimelyError(cause));
         }
       },
     );
@@ -155,7 +155,7 @@ export function usePreferences(): UsePreferencesResult {
         setError(null);
       } catch (cause) {
         setRows(previous);
-        setError(asDronteError(cause));
+        setError(asChimelyError(cause));
       }
     },
     [client, rows],
@@ -175,7 +175,7 @@ export interface UseInboxResult<TPayload = WellKnownPayload> {
   status: ConnectionStatus;
   hasMore: boolean;
   isLoading: boolean;
-  error: DronteError | null;
+  error: ChimelyError | null;
   fetchMore: () => Promise<void>;
   refresh: () => Promise<void>;
   markRead: (item: { id: InboxItemId; source: InboxItemSource }) => Promise<void>;

--- a/packages/react/src/inbox.test.tsx
+++ b/packages/react/src/inbox.test.tsx
@@ -1,7 +1,7 @@
-import type { DronteClient } from '@dronte/client';
+import type { ChimelyClient } from '@chimely/client';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, test, vi } from 'vitest';
-import { DronteProvider } from './context';
+import { ChimelyProvider } from './context';
 import type { InboxProps } from './Inbox';
 import { Inbox } from './Inbox';
 import { navigation } from './navigation';
@@ -34,13 +34,13 @@ async function renderInbox(
   stub: StubServer,
   props: InboxProps = {},
   clientConfig: { pageSize?: number } = {},
-): Promise<{ client: DronteClient; unmount: () => void }> {
+): Promise<{ client: ChimelyClient; unmount: () => void }> {
   const client = makeClient(stub, clientConfig);
   await loadClient(client, stub);
   const { unmount } = render(
-    <DronteProvider client={client}>
+    <ChimelyProvider client={client}>
       <Inbox {...props} />
-    </DronteProvider>,
+    </ChimelyProvider>,
   );
   return { client, unmount };
 }
@@ -53,7 +53,7 @@ afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
   MockIntersectionObserver.instances = [];
-  document.querySelector('style[data-dronte]')?.remove();
+  document.querySelector('style[data-chimely]')?.remove();
 });
 
 describe('bell and badge', () => {
@@ -65,14 +65,14 @@ describe('bell and badge', () => {
 
     expect(bell()).toBeDefined();
     expect(screen.getByText('2')).toBeDefined();
-    expect(document.querySelectorAll('style[data-dronte]')).toHaveLength(1);
+    expect(document.querySelectorAll('style[data-chimely]')).toHaveLength(1);
   });
 
   test('no badge when nothing is unseen', async () => {
     const stub = createStubServer();
     stub.addNotification({ seen: true });
     await renderInbox(stub);
-    expect(document.querySelector('.dronte-badge')).toBeNull();
+    expect(document.querySelector('.chimely-badge')).toBeNull();
   });
 
   test('renderBell fully replaces the bell contents', async () => {
@@ -84,7 +84,7 @@ describe('bell and badge', () => {
       ),
     });
     expect(screen.getByTestId('custom-bell').textContent).toBe('1:closed');
-    expect(document.querySelector('.dronte-badge')).toBeNull();
+    expect(document.querySelector('.chimely-badge')).toBeNull();
   });
 });
 
@@ -101,7 +101,7 @@ describe('popover', () => {
     });
     expect(client.getSnapshot().counts.unseen).toBe(0);
     expect(client.getSnapshot().counts.unread).toBe(1);
-    expect(document.querySelector('.dronte-badge')).toBeNull();
+    expect(document.querySelector('.chimely-badge')).toBeNull();
   });
 
   test('escape closes the popover', async () => {
@@ -120,11 +120,11 @@ describe('popover', () => {
     await renderInbox(stub);
     fireEvent.click(bell());
 
-    const titles = [...document.querySelectorAll('.dronte-item-title')].map(
+    const titles = [...document.querySelectorAll('.chimely-item-title')].map(
       (node) => node.textContent,
     );
     expect(titles).toEqual(['newer', 'older']);
-    const unreadItems = document.querySelectorAll('.dronte-item-unread');
+    const unreadItems = document.querySelectorAll('.chimely-item-unread');
     expect(unreadItems).toHaveLength(1);
     expect(unreadItems[0]?.textContent).toContain('newer');
   });
@@ -278,7 +278,9 @@ describe('preferences panel', () => {
 
     fireEvent.click(checkbox);
     await waitFor(() => {
-      expect(stub.requestsFor('/v1/inbox/preferences').some((r) => r.method === 'PUT')).toBe(true);
+      expect(stub.requestsFor('/v1/inbox/preferences').some((r) => r.method === 'PUT')).toBe(
+        true,
+      );
     });
     const write = stub.requestsFor('/v1/inbox/preferences').find((r) => r.method === 'PUT');
     expect(write?.body).toEqual({
@@ -297,7 +299,7 @@ describe('preferences panel', () => {
 });
 
 describe('appearance', () => {
-  test('variables land on the root as --dronte-* custom properties, forwarded verbatim', async () => {
+  test('variables land on the root as --chimely-* custom properties, forwarded verbatim', async () => {
     const stub = createStubServer();
     await renderInbox(stub, {
       appearance: {
@@ -308,10 +310,10 @@ describe('appearance', () => {
         },
       },
     });
-    const root = document.querySelector('.dronte-root') as HTMLElement;
-    expect(root.style.getPropertyValue('--dronte-colorPrimary')).toBe('#ff0000');
-    expect(root.style.getPropertyValue('--dronte-fontSize')).toBe('16px');
-    expect(root.style.getPropertyValue('--dronte-customThing')).toBe('4px');
+    const root = document.querySelector('.chimely-root') as HTMLElement;
+    expect(root.style.getPropertyValue('--chimely-colorPrimary')).toBe('#ff0000');
+    expect(root.style.getPropertyValue('--chimely-fontSize')).toBe('16px');
+    expect(root.style.getPropertyValue('--chimely-customThing')).toBe('4px');
   });
 
   test('slot classNames apply alongside the default classes', async () => {
@@ -329,14 +331,14 @@ describe('appearance', () => {
         },
       },
     });
-    expect(document.querySelector('.dronte-root.my-root')).not.toBeNull();
-    expect(document.querySelector('.dronte-bell.my-bell')).not.toBeNull();
-    expect(document.querySelector('.dronte-badge.my-badge')).not.toBeNull();
+    expect(document.querySelector('.chimely-root.my-root')).not.toBeNull();
+    expect(document.querySelector('.chimely-bell.my-bell')).not.toBeNull();
+    expect(document.querySelector('.chimely-badge.my-badge')).not.toBeNull();
 
     fireEvent.click(bell());
-    expect(document.querySelector('.dronte-popover.my-popover')).not.toBeNull();
-    expect(document.querySelector('.dronte-item.my-item')).not.toBeNull();
-    expect(document.querySelector('.dronte-item-unread.my-unread')).not.toBeNull();
+    expect(document.querySelector('.chimely-popover.my-popover')).not.toBeNull();
+    expect(document.querySelector('.chimely-item.my-item')).not.toBeNull();
+    expect(document.querySelector('.chimely-item-unread.my-unread')).not.toBeNull();
   });
 });
 
@@ -378,7 +380,7 @@ describe('standalone mode', () => {
 
     const { unmount } = render(
       <Inbox
-        serverUrl="https://dronte.test"
+        serverUrl="https://chimely.test"
         environment={stub.environment}
         subscriberId={stub.subscriberId}
         subscriberHash="cafe"

--- a/packages/react/src/inbox.test.tsx
+++ b/packages/react/src/inbox.test.tsx
@@ -278,9 +278,7 @@ describe('preferences panel', () => {
 
     fireEvent.click(checkbox);
     await waitFor(() => {
-      expect(stub.requestsFor('/v1/inbox/preferences').some((r) => r.method === 'PUT')).toBe(
-        true,
-      );
+      expect(stub.requestsFor('/v1/inbox/preferences').some((r) => r.method === 'PUT')).toBe(true);
     });
     const write = stub.requestsFor('/v1/inbox/preferences').find((r) => r.method === 'PUT');
     expect(write?.body).toEqual({

--- a/packages/react/src/index.test.ts
+++ b/packages/react/src/index.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from 'vitest';
 import {
+  ChimelyProvider,
   DEFAULT_LOCALIZATION,
-  DronteProvider,
   Inbox,
-  useDronteClient,
+  useChimelyClient,
   useInbox,
   useNotifications,
   usePreferences,
@@ -12,8 +12,8 @@ import {
 } from './index';
 
 test('public surface exports', () => {
-  expect(typeof DronteProvider).toBe('function');
-  expect(typeof useDronteClient).toBe('function');
+  expect(typeof ChimelyProvider).toBe('function');
+  expect(typeof useChimelyClient).toBe('function');
   expect(typeof useNotifications).toBe('function');
   expect(typeof useUnreadCount).toBe('function');
   expect(typeof useUnseenCount).toBe('function');

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,12 +1,12 @@
 /**
- * Hooks and <Inbox /> on top of @dronte/client.
+ * Hooks and <Inbox /> on top of @chimely/client.
  *
  * The public surface is stable and additive-only.
  * Zero styling dependencies. @floating-ui/dom is the only runtime UI dependency.
  */
 
-export type { DronteProviderProps } from './context';
-export { DronteProvider, useDronteClient } from './context';
+export type { ChimelyProviderProps } from './context';
+export { ChimelyProvider, useChimelyClient } from './context';
 export type {
   UseCountResult,
   UseInboxResult,

--- a/packages/react/src/provider.test.tsx
+++ b/packages/react/src/provider.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, describe, expect, test, vi } from 'vitest';
-import { DronteProvider, useDronteClient } from './context';
+import { ChimelyProvider, useChimelyClient } from './context';
 import { useNotifications } from './hooks';
 import { createStubServer, loadClient, makeClient } from './test-support/setup';
 
@@ -14,14 +14,14 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('DronteProvider', () => {
+describe('ChimelyProvider', () => {
   test('config mode constructs a client, connects on mount, and closes on unmount', async () => {
     const stub = createStubServer();
     stub.addNotification();
     const { unmount } = render(
-      <DronteProvider
+      <ChimelyProvider
         config={{
-          serverUrl: 'https://dronte.test',
+          serverUrl: 'https://chimely.test',
           environment: stub.environment,
           subscriberId: stub.subscriberId,
           fetchFn: stub.fetchFn,
@@ -29,7 +29,7 @@ describe('DronteProvider', () => {
         }}
       >
         <Probe />
-      </DronteProvider>,
+      </ChimelyProvider>,
     );
 
     expect(stub.sources).toHaveLength(1);
@@ -49,9 +49,9 @@ describe('DronteProvider', () => {
     await loadClient(client, stub);
 
     const { unmount } = render(
-      <DronteProvider client={client}>
+      <ChimelyProvider client={client}>
         <Probe />
-      </DronteProvider>,
+      </ChimelyProvider>,
     );
     await waitFor(() => {
       expect(screen.getByText('items:1')).toBeDefined();
@@ -62,17 +62,17 @@ describe('DronteProvider', () => {
     expect(stub.stream().closed).toBe(false);
   });
 
-  test('useDronteClient throws outside a provider', () => {
+  test('useChimelyClient throws outside a provider', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
     function Bare(): ReactNode {
-      useDronteClient();
+      useChimelyClient();
       return null;
     }
-    expect(() => render(<Bare />)).toThrow(/inside a <DronteProvider>/);
+    expect(() => render(<Bare />)).toThrow(/inside a <ChimelyProvider>/);
   });
 
   test('provider without client or config throws', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    expect(() => render(<DronteProvider>x</DronteProvider>)).toThrow(/client or a config/);
+    expect(() => render(<ChimelyProvider>x</ChimelyProvider>)).toThrow(/client or a config/);
   });
 });

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -1,17 +1,17 @@
 /**
  * Plain CSS, injected once on first <Inbox /> mount. Theming happens through
- * the --dronte-* custom properties (set via InboxAppearance.variables) and
+ * the --chimely-* custom properties (set via InboxAppearance.variables) and
  * the per-slot class hooks. No styling dependency, no Tailwind.
  */
 export const INBOX_CSS = `
-.dronte-root {
+.chimely-root {
   position: relative;
   display: inline-block;
-  font-family: var(--dronte-fontFamily, system-ui, -apple-system, sans-serif);
-  font-size: var(--dronte-fontSize, 14px);
-  color: var(--dronte-colorForeground, #111827);
+  font-family: var(--chimely-fontFamily, system-ui, -apple-system, sans-serif);
+  font-size: var(--chimely-fontSize, 14px);
+  color: var(--chimely-colorForeground, #111827);
 }
-.dronte-bell {
+.chimely-bell {
   position: relative;
   display: inline-flex;
   align-items: center;
@@ -20,15 +20,15 @@ export const INBOX_CSS = `
   height: 36px;
   padding: 0;
   border: none;
-  border-radius: var(--dronte-borderRadius, 8px);
+  border-radius: var(--chimely-borderRadius, 8px);
   background: transparent;
   color: inherit;
   cursor: pointer;
 }
-.dronte-bell:hover {
-  background: var(--dronte-colorMuted, #f3f4f6);
+.chimely-bell:hover {
+  background: var(--chimely-colorMuted, #f3f4f6);
 }
-.dronte-badge {
+.chimely-badge {
   position: absolute;
   top: 2px;
   right: 2px;
@@ -36,14 +36,14 @@ export const INBOX_CSS = `
   height: 16px;
   padding: 0 4px;
   border-radius: 999px;
-  background: var(--dronte-colorBadge, #1264FF);
+  background: var(--chimely-colorBadge, #1264FF);
   color: #ffffff;
   font-size: 11px;
   font-weight: 600;
   line-height: 16px;
   text-align: center;
 }
-.dronte-popover {
+.chimely-popover {
   position: absolute;
   top: 0;
   left: 0;
@@ -52,135 +52,135 @@ export const INBOX_CSS = `
   width: 360px;
   max-height: 480px;
   overflow: hidden;
-  background: var(--dronte-colorBackground, #ffffff);
-  border: 1px solid var(--dronte-colorMuted, #e5e7eb);
-  border-radius: var(--dronte-borderRadius, 8px);
+  background: var(--chimely-colorBackground, #ffffff);
+  border: 1px solid var(--chimely-colorMuted, #e5e7eb);
+  border-radius: var(--chimely-borderRadius, 8px);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
   z-index: 1000;
 }
-.dronte-header {
+.chimely-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
   padding: 10px 14px;
-  border-bottom: 1px solid var(--dronte-colorMuted, #e5e7eb);
+  border-bottom: 1px solid var(--chimely-colorMuted, #e5e7eb);
 }
-.dronte-header-title {
+.chimely-header-title {
   font-weight: 600;
 }
-.dronte-header-action {
+.chimely-header-action {
   border: none;
   background: transparent;
-  color: var(--dronte-colorPrimary, #1264FF);
+  color: var(--chimely-colorPrimary, #1264FF);
   font: inherit;
   cursor: pointer;
   padding: 2px 4px;
-  border-radius: var(--dronte-borderRadius, 8px);
+  border-radius: var(--chimely-borderRadius, 8px);
 }
-.dronte-header-action:hover {
-  background: var(--dronte-colorMuted, #f3f4f6);
-  color: var(--dronte-colorPrimaryHover, #004F32);
+.chimely-header-action:hover {
+  background: var(--chimely-colorMuted, #f3f4f6);
+  color: var(--chimely-colorPrimaryHover, #004F32);
 }
-.dronte-bell:focus-visible,
-.dronte-header-action:focus-visible,
-.dronte-item:focus-visible {
-  outline: 2px solid var(--dronte-colorPrimary, #1264FF);
+.chimely-bell:focus-visible,
+.chimely-header-action:focus-visible,
+.chimely-item:focus-visible {
+  outline: 2px solid var(--chimely-colorPrimary, #1264FF);
   outline-offset: 2px;
 }
-.dronte-list {
+.chimely-list {
   flex: 1;
   overflow-y: auto;
   margin: 0;
   padding: 0;
   list-style: none;
 }
-.dronte-sentinel {
+.chimely-sentinel {
   height: 1px;
 }
-.dronte-item {
+.chimely-item {
   display: flex;
   align-items: flex-start;
   gap: 10px;
   width: 100%;
   padding: 12px 14px;
   border: none;
-  border-bottom: 1px solid var(--dronte-colorMuted, #f3f4f6);
+  border-bottom: 1px solid var(--chimely-colorMuted, #f3f4f6);
   background: transparent;
   color: inherit;
   font: inherit;
   text-align: left;
   cursor: pointer;
 }
-.dronte-item:hover {
-  background: var(--dronte-colorMuted, #f9fafb);
+.chimely-item:hover {
+  background: var(--chimely-colorMuted, #f9fafb);
 }
-.dronte-item-icon {
+.chimely-item-icon {
   width: 28px;
   height: 28px;
   border-radius: 50%;
   flex: none;
 }
-.dronte-item-text {
+.chimely-item-text {
   display: flex;
   flex-direction: column;
   gap: 2px;
   min-width: 0;
 }
-.dronte-item-title {
+.chimely-item-title {
   font-weight: 500;
 }
-.dronte-item-unread .dronte-item-title {
+.chimely-item-unread .chimely-item-title {
   font-weight: 700;
 }
-.dronte-item-body {
-  color: var(--dronte-colorForeground, #374151);
+.chimely-item-body {
+  color: var(--chimely-colorForeground, #374151);
   opacity: 0.8;
 }
-.dronte-item-time {
+.chimely-item-time {
   font-size: 0.85em;
   opacity: 0.6;
 }
-.dronte-item-dot {
+.chimely-item-dot {
   width: 8px;
   height: 8px;
   margin-top: 6px;
   margin-left: auto;
   border-radius: 50%;
-  background: var(--dronte-colorPrimary, #1264FF);
+  background: var(--chimely-colorPrimary, #1264FF);
   flex: none;
 }
-.dronte-empty {
+.chimely-empty {
   padding: 32px 16px;
   text-align: center;
 }
-.dronte-empty-title {
+.chimely-empty-title {
   margin: 0 0 4px;
   font-weight: 600;
 }
-.dronte-empty-body {
+.chimely-empty-body {
   margin: 0;
   opacity: 0.7;
 }
-.dronte-footer {
+.chimely-footer {
   flex: none;
-  border-top: 1px solid var(--dronte-colorMuted, #f3f4f6);
+  border-top: 1px solid var(--chimely-colorMuted, #f3f4f6);
   min-height: 4px;
 }
-.dronte-preferences {
+.chimely-preferences {
   flex: 1;
   overflow-y: auto;
   padding: 8px 0;
 }
-.dronte-preference {
+.chimely-preference {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
   padding: 10px 14px;
 }
-.dronte-preference input {
-  accent-color: var(--dronte-colorPrimary, #1264FF);
+.chimely-preference input {
+  accent-color: var(--chimely-colorPrimary, #1264FF);
 }
 `;
 
@@ -191,12 +191,12 @@ export function ensureStyles(): void {
   if (injected || typeof document === 'undefined') {
     return;
   }
-  if (document.querySelector('style[data-dronte]')) {
+  if (document.querySelector('style[data-chimely]')) {
     injected = true;
     return;
   }
   const element = document.createElement('style');
-  element.setAttribute('data-dronte', '');
+  element.setAttribute('data-chimely', '');
   element.textContent = INBOX_CSS;
   document.head.appendChild(element);
   injected = true;

--- a/packages/react/src/test-support/setup.tsx
+++ b/packages/react/src/test-support/setup.tsx
@@ -1,5 +1,5 @@
-import type { DronteClientConfig } from '@dronte/client';
-import { DronteClient } from '@dronte/client';
+import type { ChimelyClientConfig } from '@chimely/client';
+import { ChimelyClient } from '@chimely/client';
 import { vi } from 'vitest';
 import type { StubServer } from '../../../client/src/test-support/stub-server';
 import { createStubServer } from '../../../client/src/test-support/stub-server';
@@ -9,10 +9,10 @@ export { createStubServer };
 
 export function makeClient(
   stub: StubServer,
-  config: Partial<DronteClientConfig> = {},
-): DronteClient {
-  return new DronteClient({
-    serverUrl: 'https://dronte.test',
+  config: Partial<ChimelyClientConfig> = {},
+): ChimelyClient {
+  return new ChimelyClient({
+    serverUrl: 'https://chimely.test',
     environment: stub.environment,
     subscriberId: stub.subscriberId,
     fetchFn: stub.fetchFn,
@@ -21,7 +21,7 @@ export function makeClient(
   });
 }
 
-export async function loadClient(client: DronteClient, stub: StubServer): Promise<void> {
+export async function loadClient(client: ChimelyClient, stub: StubServer): Promise<void> {
   client.connect();
   stub.openStream();
   await vi.waitFor(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,7 @@ importers:
 
   examples/nextjs:
     dependencies:
-      '@dronte/react':
+      '@chimely/react':
         specifier: workspace:*
         version: link:../../packages/react
       next:
@@ -118,7 +118,7 @@ importers:
 
   packages/react:
     dependencies:
-      '@dronte/client':
+      '@chimely/client':
         specifier: workspace:*
         version: link:../client
       '@floating-ui/dom':
@@ -218,7 +218,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0))
+        version: 4.7.0(supports-color@10.2.2)(vite@6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0))
       tailwindcss:
         specifier: ^4.0.6
         version: 4.3.0
@@ -4300,7 +4300,7 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7':
+  '@babel/core@7.29.7(supports-color@10.2.2)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -4347,7 +4347,7 @@ snapshots:
 
   '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.7
@@ -4371,14 +4371,14 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/runtime@7.29.7': {}
@@ -6007,11 +6007,11 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0))':
+  '@vitejs/plugin-react@4.7.0(supports-color@10.2.2)(vite@6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -2,13 +2,13 @@
 # Regenerate every artifact derived from the code-first OpenAPI document.
 # CI runs this and fails if `git diff` is non-empty (stale generated files).
 #
-#   server (utoipa) ──dronte openapi──► docs/openapi/dronte.yaml   (docs site)
+#   server (utoipa) ──chimely openapi──► docs/openapi/chimely.yaml   (docs site)
 #                                  └──► packages/client/src/generated/api.d.ts
 #
 # Generated outputs are committed; NEVER hand-edit them (see CLAUDE.md).
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-cargo run --quiet --manifest-path server/Cargo.toml -- openapi > docs/openapi/dronte.yaml
-pnpm exec openapi-typescript docs/openapi/dronte.yaml \
+cargo run --quiet --manifest-path server/Cargo.toml -- openapi > docs/openapi/chimely.yaml
+pnpm exec openapi-typescript docs/openapi/chimely.yaml \
   --output packages/client/src/generated/api.d.ts

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -407,6 +407,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "chimely"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "argon2",
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "chrono",
+ "form_urlencoded",
+ "fred",
+ "futures",
+ "hex",
+ "hmac 0.12.1",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "proptest",
+ "rand 0.9.4",
+ "reqwest 0.12.28",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "serde_norway",
+ "sha2 0.10.9",
+ "sqlx",
+ "testcontainers-modules",
+ "thiserror",
+ "tokio",
+ "tower-http",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+ "utoipa",
+ "utoipa-scalar",
+ "uuid",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,48 +728,6 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
-
-[[package]]
-name = "dronte"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "argon2",
- "async-stream",
- "async-trait",
- "axum",
- "base64",
- "chrono",
- "form_urlencoded",
- "fred",
- "futures",
- "hex",
- "hmac 0.12.1",
- "metrics",
- "metrics-exporter-prometheus",
- "opentelemetry",
- "opentelemetry-otlp",
- "opentelemetry_sdk",
- "proptest",
- "rand 0.9.4",
- "reqwest 0.12.28",
- "rust-embed",
- "serde",
- "serde_json",
- "serde_norway",
- "sha2 0.10.9",
- "sqlx",
- "testcontainers-modules",
- "thiserror",
- "tokio",
- "tower-http",
- "tracing",
- "tracing-opentelemetry",
- "tracing-subscriber",
- "utoipa",
- "utoipa-scalar",
- "uuid",
-]
 
 [[package]]
 name = "dunce"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "dronte"
+name = "chimely"
 version = "0.1.0"
 edition = "2024"
 license = "FSL-1.1-MIT"
@@ -10,11 +10,11 @@ description = "In-app notification inbox infrastructure: one binary + Postgres +
 build = "build.rs"
 
 [lib]
-name = "dronte"
+name = "chimely"
 path = "src/lib.rs"
 
 [[bin]]
-name = "dronte"
+name = "chimely"
 path = "src/main.rs"
 
 [dependencies]

--- a/server/admin/index.html
+++ b/server/admin/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
-    <title>Dronte admin</title>
+    <title>Chimely admin</title>
   </head>
   <body>
     <div id="root"></div>

--- a/server/admin/package.json
+++ b/server/admin/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "dronte-admin",
+  "name": "chimely-admin",
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "description": "Dronte embedded admin dashboard (served at /admin by the dronte binary).",
+  "description": "Chimely embedded admin dashboard (served at /admin by the chimely binary).",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/server/admin/src/components/layout.tsx
+++ b/server/admin/src/components/layout.tsx
@@ -52,7 +52,7 @@ export function Layout() {
       <aside className="flex flex-col border-r border-border bg-card max-md:hidden">
         <div className="flex h-14 items-center gap-2 px-5">
           <span className="inline-block size-2.5 rounded-full bg-primary" />
-          <span className="text-lg font-semibold tracking-tight">Dronte</span>
+          <span className="text-lg font-semibold tracking-tight">Chimely</span>
           <span className="text-xs text-muted-foreground">admin</span>
         </div>
         <nav className="flex flex-1 flex-col gap-1 p-3">
@@ -94,7 +94,7 @@ export function Layout() {
       </aside>
       <main className="min-w-0 overflow-x-hidden">
         <header className="flex h-14 items-center justify-between gap-4 border-b border-border px-6 md:hidden">
-          <span className="font-semibold">Dronte admin</span>
+          <span className="font-semibold">Chimely admin</span>
           <div className="flex items-center gap-2">
             <ThemeToggle />
             <Button variant="outline" size="icon" aria-label="Sign out" onClick={() => void logout()}>

--- a/server/admin/src/index.css
+++ b/server/admin/src/index.css
@@ -5,7 +5,7 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 /*
-  Dronte / Dodo brand palette.
+  Chimely / Dodo brand palette.
   --primary       #1264FF  accent: primary actions, links, focus, active nav
   --primary-deep  #004F32  deep accent: hover/section accents
   base dark       #0D0D0D  dark-mode foundation (inverted for light)

--- a/server/admin/src/lib/api.ts
+++ b/server/admin/src/lib/api.ts
@@ -1,7 +1,7 @@
 // Admin API client. Every endpoint is same-origin under /admin/api/* and
 // gated by a server-side session cookie (set by POST /admin/api/login). The
 // cookie rides automatically on same-origin fetches; mutating requests also
-// send the X-Dronte-Admin header (CSRF defense — a cross-site form cannot).
+// send the X-Chimely-Admin header (CSRF defense — a cross-site form cannot).
 
 export interface ApiError {
   status: number;
@@ -29,13 +29,13 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
       ...(init?.body ? { 'Content-Type': 'application/json' } : {}),
       // CSRF: a cross-site form cannot set a custom header, and the admin
       // plane has no CORS. Required server-side on every mutating request.
-      ...(mutating ? { 'X-Dronte-Admin': '1' } : {}),
+      ...(mutating ? { 'X-Chimely-Admin': '1' } : {}),
       ...init?.headers,
     },
   });
 
   if (res.status === 401) {
-    window.dispatchEvent(new CustomEvent('dronte-admin-unauthorized'));
+    window.dispatchEvent(new CustomEvent('chimely-admin-unauthorized'));
     throw new ApiRequestError({ status: 401, code: 'unauthorized', message: 'Session expired' });
   }
 

--- a/server/admin/src/lib/auth.tsx
+++ b/server/admin/src/lib/auth.tsx
@@ -39,7 +39,7 @@ function FullScreenSpinner() {
 // Resolves the signed-in admin before rendering the app. While loading shows a
 // spinner, unauthenticated renders the login screen, authenticated provides
 // the user + capability checks to the tree. A 401 from any API call routes
-// back to login via the `dronte-admin-unauthorized` event.
+// back to login via the `chimely-admin-unauthorized` event.
 export function AuthGate({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<AdminMe | null>(null);
   const [loading, setLoading] = useState(true);
@@ -60,8 +60,8 @@ export function AuthGate({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     const onUnauthorized = () => setUser(null);
-    window.addEventListener('dronte-admin-unauthorized', onUnauthorized);
-    return () => window.removeEventListener('dronte-admin-unauthorized', onUnauthorized);
+    window.addEventListener('chimely-admin-unauthorized', onUnauthorized);
+    return () => window.removeEventListener('chimely-admin-unauthorized', onUnauthorized);
   }, []);
 
   const logout = useCallback(async () => {

--- a/server/admin/src/lib/theme.tsx
+++ b/server/admin/src/lib/theme.tsx
@@ -9,7 +9,7 @@ interface ThemeContextValue {
 }
 
 const ThemeContext = createContext<ThemeContextValue | null>(null);
-const STORAGE_KEY = 'dronte-admin-theme';
+const STORAGE_KEY = 'chimely-admin-theme';
 
 function systemPrefersDark(): boolean {
   return typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches;

--- a/server/admin/src/routes/login.tsx
+++ b/server/admin/src/routes/login.tsx
@@ -30,13 +30,13 @@ export function LoginRoute({ onAuthenticated }: { onAuthenticated: (me: AdminMe)
       <div className="w-full max-w-sm">
         <div className="mb-8 flex items-center gap-2">
           <span className="inline-block size-3 rounded-full bg-primary" />
-          <span className="text-2xl font-semibold tracking-tight">Dronte</span>
+          <span className="text-2xl font-semibold tracking-tight">Chimely</span>
           <span className="text-sm text-muted-foreground">admin</span>
         </div>
         <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
           <h1 className="text-lg font-semibold">Sign in</h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Operator access to this Dronte instance.
+            Operator access to this Chimely instance.
           </p>
           <form
             className="mt-6 flex flex-col gap-4"

--- a/server/admin/vite.config.ts
+++ b/server/admin/vite.config.ts
@@ -3,7 +3,7 @@ import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
-// Served by the dronte binary at /admin (rust-embed). The base path makes
+// Served by the chimely binary at /admin (rust-embed). The base path makes
 // every emitted asset URL absolute under /admin/.
 export default defineConfig({
   base: '/admin/',

--- a/server/build.rs
+++ b/server/build.rs
@@ -1,6 +1,6 @@
 //! Guarantees `admin/dist` exists at compile time so the rust-embed derive in
 //! `api::admin` always has a folder to embed. The real admin SPA build
-//! (`pnpm --filter dronte-admin build`, run by CI and the Dockerfile) writes
+//! (`pnpm --filter chimely-admin build`, run by CI and the Dockerfile) writes
 //! the production bundle there before `cargo build`. When it has not run — a
 //! bare `cargo nextest`, `cargo run -- openapi`, or `cargo sqlx prepare` — a
 //! minimal placeholder shell is written so the binary still compiles and
@@ -15,13 +15,13 @@ const PLACEHOLDER: &str = r#"<!doctype html>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Dronte admin</title>
+    <title>Chimely admin</title>
   </head>
   <body>
     <main style="font-family: system-ui, sans-serif; max-width: 32rem; margin: 4rem auto; padding: 0 1rem;">
-      <h1>Dronte admin</h1>
+      <h1>Chimely admin</h1>
       <p>The admin dashboard bundle has not been built. Run
-      <code>pnpm --filter dronte-admin build</code> and rebuild the server.</p>
+      <code>pnpm --filter chimely-admin build</code> and rebuild the server.</p>
     </main>
   </body>
 </html>

--- a/server/deny.toml
+++ b/server/deny.toml
@@ -22,7 +22,7 @@ allow = [
 ]
 # Our own crate is the only non-permissive code allowed in the graph.
 exceptions = [
-    { name = "dronte", allow = ["FSL-1.1-MIT"] },
+    { name = "chimely", allow = ["FSL-1.1-MIT"] },
 ]
 
 [bans]

--- a/server/migrations/0001_init.sql
+++ b/server/migrations/0001_init.sql
@@ -1,4 +1,4 @@
--- Dronte v1 core schema. Translated 1:1 from specs/schema.sql (the frozen
+-- Chimely v1 core schema. Translated 1:1 from specs/schema.sql (the frozen
 -- contract — see its header for the two-source inbox, watermark, counter, and
 -- shard-readiness invariants). Differences from the spec file, both sanctioned
 -- by it:

--- a/server/src/api/admin.rs
+++ b/server/src/api/admin.rs
@@ -92,7 +92,7 @@ pub async fn serve_spa(uri: Uri) -> Response {
             .into_response(),
         None => (
             StatusCode::NOT_FOUND,
-            "admin UI not built (run `pnpm --filter dronte-admin build`)",
+            "admin UI not built (run `pnpm --filter chimely-admin build`)",
         )
             .into_response(),
     }
@@ -1116,11 +1116,11 @@ pub struct AdminMe {
     tag = "admin",
     operation_id = "adminLogin",
     summary = "Log in with email + password; starts a server-side session",
-    description = "On success sets the `dronte_admin` session cookie (HttpOnly, SameSite=Strict, Path=/admin). Failure returns a generic error that does not reveal which field was wrong.",
+    description = "On success sets the `chimely_admin` session cookie (HttpOnly, SameSite=Strict, Path=/admin). Failure returns a generic error that does not reveal which field was wrong.",
     request_body = AdminLoginRequest,
     responses((status = 200, description = "Logged in; sets the session cookie.", body = AdminMe),
               (status = 401, description = "Invalid email or password.", body = crate::api::contract::Error),
-              (status = 403, description = "Missing X-Dronte-Admin header.", body = crate::api::contract::Error))
+              (status = 403, description = "Missing X-Chimely-Admin header.", body = crate::api::contract::Error))
 )]
 pub async fn login(
     State(state): State<AppState>,
@@ -1181,7 +1181,7 @@ pub async fn login(
     summary = "Log out: delete the session and clear the cookie",
     responses((status = 204, description = "Logged out."),
               (status = 401, description = "Authentication required (no or expired session)."),
-              (status = 403, description = "Missing X-Dronte-Admin header.", body = crate::api::contract::Error)),
+              (status = 403, description = "Missing X-Chimely-Admin header.", body = crate::api::contract::Error)),
     security(("AdminSession" = []))
 )]
 pub async fn logout(auth: AdminAuth, State(state): State<AppState>) -> Result<Response, ApiError> {

--- a/server/src/api/inbox.rs
+++ b/server/src/api/inbox.rs
@@ -836,7 +836,7 @@ async fn compute_etag(
     .map_err(ApiError::from)?;
 
     let mut hasher = Sha256::new();
-    hasher.update(b"dronte-inbox-v1|");
+    hasher.update(b"chimely-inbox-v1|");
     hasher.update(cursor.unwrap_or("").as_bytes());
     hasher.update(format!("|{limit}|{}", row.counters_updated_at.timestamp_micros()).as_bytes());
     hasher.update(

--- a/server/src/api/sse.rs
+++ b/server/src/api/sse.rs
@@ -84,7 +84,7 @@ pub async fn stream(
         }
         *count += 1;
     }
-    metrics::gauge!("dronte_sse_connections").increment(1.0);
+    metrics::gauge!("chimely_sse_connections").increment(1.0);
     let guard = ConnectionGuard {
         map: Arc::clone(&state.sse_connections),
         key,
@@ -168,7 +168,7 @@ struct ConnectionGuard {
 
 impl Drop for ConnectionGuard {
     fn drop(&mut self) {
-        metrics::gauge!("dronte_sse_connections").decrement(1.0);
+        metrics::gauge!("chimely_sse_connections").decrement(1.0);
         let mut conns = self.map.lock().expect("sse connection map");
         if let Some(count) = conns.get_mut(&self.key) {
             *count -= 1;

--- a/server/src/auth.rs
+++ b/server/src/auth.rs
@@ -33,9 +33,9 @@ use crate::ids;
 use crate::roles::{Capability, Role};
 use crate::state::AppState;
 
-pub const HEADER_ENVIRONMENT: &str = "x-dronte-environment";
-pub const HEADER_SUBSCRIBER: &str = "x-dronte-subscriber";
-pub const HEADER_SUBSCRIBER_HASH: &str = "x-dronte-subscriber-hash";
+pub const HEADER_ENVIRONMENT: &str = "x-chimely-environment";
+pub const HEADER_SUBSCRIBER: &str = "x-chimely-subscriber";
+pub const HEADER_SUBSCRIBER_HASH: &str = "x-chimely-subscriber-hash";
 pub const QUERY_ENVIRONMENT: &str = "environment";
 pub const QUERY_SUBSCRIBER: &str = "subscriber_id";
 pub const QUERY_SUBSCRIBER_HASH: &str = "subscriber_hash";
@@ -100,12 +100,12 @@ impl FromRequestParts<AppState> for ManagementAuth {
 /// The admin session cookie. `Path=/admin` scoped, `HttpOnly` (no JS access,
 /// so XSS cannot exfiltrate it), `SameSite=Strict`, and `Secure` whenever TLS
 /// terminates in front of the binary (config `admin_tls_terminated`).
-pub const ADMIN_COOKIE: &str = "dronte_admin";
+pub const ADMIN_COOKIE: &str = "chimely_admin";
 
 /// CSRF defense for mutating admin requests. A cross-site form cannot set a
 /// custom header, and the admin plane has no CORS, so requiring it (on top of
 /// `SameSite=Strict`) closes forged-request paths.
-pub const ADMIN_CSRF_HEADER: &str = "x-dronte-admin";
+pub const ADMIN_CSRF_HEADER: &str = "x-chimely-admin";
 
 /// Minimum admin password length, enforced server-side on create/reset.
 pub const MIN_PASSWORD_LEN: usize = 12;
@@ -199,7 +199,7 @@ impl FromRequestParts<AppState> for AdminAuth {
     }
 }
 
-/// The `dronte_admin` cookie value, if present.
+/// The `chimely_admin` cookie value, if present.
 fn admin_cookie(headers: &HeaderMap) -> Option<String> {
     let raw = headers.get(COOKIE)?.to_str().ok()?;
     raw.split(';')
@@ -208,7 +208,7 @@ fn admin_cookie(headers: &HeaderMap) -> Option<String> {
         .map(|(_, value)| value.to_owned())
 }
 
-/// 403 unless the request carries a non-empty `X-Dronte-Admin` header.
+/// 403 unless the request carries a non-empty `X-Chimely-Admin` header.
 pub fn require_admin_csrf(headers: &HeaderMap) -> Result<(), ApiError> {
     let present = headers
         .get(ADMIN_CSRF_HEADER)
@@ -217,7 +217,7 @@ pub fn require_admin_csrf(headers: &HeaderMap) -> Result<(), ApiError> {
     if present {
         Ok(())
     } else {
-        Err(ApiError::forbidden("missing X-Dronte-Admin header"))
+        Err(ApiError::forbidden("missing X-Chimely-Admin header"))
     }
 }
 

--- a/server/src/bootstrap.rs
+++ b/server/src/bootstrap.rs
@@ -1,11 +1,11 @@
 //! Boot-time bootstrap of the dev-quickstart environment and the root admin.
 //!
-//! Dev quickstart: `DRONTE_DEV_ENVIRONMENT` plus `DRONTE_DEV_API_KEY` seed one
+//! Dev quickstart: `CHIMELY_DEV_ENVIRONMENT` plus `CHIMELY_DEV_API_KEY` seed one
 //! dev environment with `require_subscriber_hash = false` so the widget
 //! connects without a backend, and the API key stored is the plaintext env
 //! value so the quickstart curl is copy-pasteable. Idempotent across restarts.
 //!
-//! Root admin: `DRONTE_ADMIN_EMAIL` + `DRONTE_ADMIN_PASSWORD` ensure a managed
+//! Root admin: `CHIMELY_ADMIN_EMAIL` + `CHIMELY_ADMIN_PASSWORD` ensure a managed
 //! `admin` account. This is the lockout-recovery path. Restart with the env
 //! vars set to restore admin access.
 
@@ -22,7 +22,7 @@ pub async fn run(pool: &PgPool, cfg: &Config) -> anyhow::Result<()> {
     tracing::warn!(
         environment = slug,
         "DEV bootstrap: subscriber hashes are NOT required in this environment. \
-         Unset DRONTE_DEV_ENVIRONMENT in production."
+         Unset CHIMELY_DEV_ENVIRONMENT in production."
     );
 
     // An existing environment is never modified. Rotating its HMAC secret
@@ -101,7 +101,7 @@ pub async fn ensure_admin(pool: &PgPool, cfg: &Config) -> anyhow::Result<()> {
     };
     let email = email.trim().to_lowercase();
     if password.chars().count() < crate::auth::MIN_PASSWORD_LEN {
-        anyhow::bail!("DRONTE_ADMIN_PASSWORD must be at least 12 characters");
+        anyhow::bail!("CHIMELY_ADMIN_PASSWORD must be at least 12 characters");
     }
 
     let existing = sqlx::query!(

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -86,61 +86,61 @@ impl Config {
             database_url: std::env::var("DATABASE_URL")
                 .context("DATABASE_URL is required (postgres://...)")?,
             redis_url: std::env::var("REDIS_URL").ok().filter(|s| !s.is_empty()),
-            listen_addr: var_or("DRONTE_LISTEN_ADDR", "0.0.0.0:8080"),
-            retention_months: parse_var("DRONTE_RETENTION_MONTHS", 12)?,
-            idempotency_retention_days: parse_var("DRONTE_IDEMPOTENCY_RETENTION_DAYS", 30)?,
-            hint_debounce: Duration::from_millis(parse_var("DRONTE_HINT_DEBOUNCE_MS", 1_000)?),
-            worker_poll_interval: Duration::from_millis(parse_var("DRONTE_WORKER_POLL_MS", 250)?),
-            sse_ping_interval: Duration::from_secs(parse_var("DRONTE_SSE_PING_SECS", 30)?),
-            sse_retry_base: Duration::from_millis(parse_var("DRONTE_SSE_RETRY_BASE_MS", 2_000)?),
+            listen_addr: var_or("CHIMELY_LISTEN_ADDR", "0.0.0.0:8080"),
+            retention_months: parse_var("CHIMELY_RETENTION_MONTHS", 12)?,
+            idempotency_retention_days: parse_var("CHIMELY_IDEMPOTENCY_RETENTION_DAYS", 30)?,
+            hint_debounce: Duration::from_millis(parse_var("CHIMELY_HINT_DEBOUNCE_MS", 1_000)?),
+            worker_poll_interval: Duration::from_millis(parse_var("CHIMELY_WORKER_POLL_MS", 250)?),
+            sse_ping_interval: Duration::from_secs(parse_var("CHIMELY_SSE_PING_SECS", 30)?),
+            sse_retry_base: Duration::from_millis(parse_var("CHIMELY_SSE_RETRY_BASE_MS", 2_000)?),
             sse_retry_jitter: Duration::from_millis(parse_var(
-                "DRONTE_SSE_RETRY_JITTER_MS",
+                "CHIMELY_SSE_RETRY_JITTER_MS",
                 8_000,
             )?),
             sse_max_connections_per_subscriber: parse_var(
-                "DRONTE_SSE_MAX_CONNS_PER_SUBSCRIBER",
+                "CHIMELY_SSE_MAX_CONNS_PER_SUBSCRIBER",
                 8,
             )?,
-            dev_environment: std::env::var("DRONTE_DEV_ENVIRONMENT")
+            dev_environment: std::env::var("CHIMELY_DEV_ENVIRONMENT")
                 .ok()
                 .filter(|s| !s.is_empty()),
-            dev_api_key: std::env::var("DRONTE_DEV_API_KEY")
+            dev_api_key: std::env::var("CHIMELY_DEV_API_KEY")
                 .ok()
                 .filter(|s| !s.is_empty()),
-            admin_bootstrap_email: std::env::var("DRONTE_ADMIN_EMAIL")
+            admin_bootstrap_email: std::env::var("CHIMELY_ADMIN_EMAIL")
                 .ok()
                 .filter(|s| !s.is_empty()),
-            admin_bootstrap_password: std::env::var("DRONTE_ADMIN_PASSWORD")
+            admin_bootstrap_password: std::env::var("CHIMELY_ADMIN_PASSWORD")
                 .ok()
                 .filter(|s| !s.is_empty()),
             admin_session_ttl: Duration::from_secs(parse_var(
-                "DRONTE_ADMIN_SESSION_TTL_SECS",
+                "CHIMELY_ADMIN_SESSION_TTL_SECS",
                 28_800,
             )?),
-            admin_tls_terminated: parse_var("DRONTE_ADMIN_TLS_TERMINATED", false)?,
+            admin_tls_terminated: parse_var("CHIMELY_ADMIN_TLS_TERMINATED", false)?,
             retry_backoff_base: Duration::from_millis(parse_var(
-                "DRONTE_RETRY_BACKOFF_BASE_MS",
+                "CHIMELY_RETRY_BACKOFF_BASE_MS",
                 5_000,
             )?),
             retry_backoff_cap: Duration::from_millis(parse_var(
-                "DRONTE_RETRY_BACKOFF_CAP_MS",
+                "CHIMELY_RETRY_BACKOFF_CAP_MS",
                 900_000,
             )?),
             metrics_sample_interval: Duration::from_millis(parse_var(
-                "DRONTE_METRICS_SAMPLE_MS",
+                "CHIMELY_METRICS_SAMPLE_MS",
                 15_000,
             )?),
-            counter_drift_sample_size: parse_var("DRONTE_COUNTER_DRIFT_SAMPLE_SIZE", 50)?,
-            api_key_rate_per_sec: parse_var("DRONTE_API_KEY_RATE_PER_SEC", 50.0)?,
-            api_key_rate_burst: parse_var("DRONTE_API_KEY_RATE_BURST", 200.0)?,
-            subscriber_rate_per_sec: parse_var("DRONTE_SUBSCRIBER_RATE_PER_SEC", 10.0)?,
-            subscriber_rate_burst: parse_var("DRONTE_SUBSCRIBER_RATE_BURST", 50.0)?,
+            counter_drift_sample_size: parse_var("CHIMELY_COUNTER_DRIFT_SAMPLE_SIZE", 50)?,
+            api_key_rate_per_sec: parse_var("CHIMELY_API_KEY_RATE_PER_SEC", 50.0)?,
+            api_key_rate_burst: parse_var("CHIMELY_API_KEY_RATE_BURST", 200.0)?,
+            subscriber_rate_per_sec: parse_var("CHIMELY_SUBSCRIBER_RATE_PER_SEC", 10.0)?,
+            subscriber_rate_burst: parse_var("CHIMELY_SUBSCRIBER_RATE_BURST", 50.0)?,
             shutdown_readiness_grace: Duration::from_millis(parse_var(
-                "DRONTE_SHUTDOWN_GRACE_MS",
+                "CHIMELY_SHUTDOWN_GRACE_MS",
                 5_000,
             )?),
             shutdown_drain_deadline: Duration::from_millis(parse_var(
-                "DRONTE_SHUTDOWN_DRAIN_DEADLINE_MS",
+                "CHIMELY_SHUTDOWN_DRAIN_DEADLINE_MS",
                 30_000,
             )?),
         })

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -13,7 +13,7 @@ pub static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!();
 pub async fn connect(database_url: &str) -> anyhow::Result<PgPool> {
     Ok(PgPoolOptions::new()
         .max_connections(
-            std::env::var("DRONTE_PG_POOL_SIZE")
+            std::env::var("CHIMELY_PG_POOL_SIZE")
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(16),

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -29,9 +29,9 @@ pub fn router(state: AppState) -> Router {
         .allow_headers([
             header::CONTENT_TYPE,
             header::IF_NONE_MATCH,
-            HeaderName::from_static("x-dronte-environment"),
-            HeaderName::from_static("x-dronte-subscriber"),
-            HeaderName::from_static("x-dronte-subscriber-hash"),
+            HeaderName::from_static("x-chimely-environment"),
+            HeaderName::from_static("x-chimely-subscriber"),
+            HeaderName::from_static("x-chimely-subscriber-hash"),
         ])
         .expose_headers([header::ETAG])
         .max_age(Duration::from_secs(3600));
@@ -229,7 +229,7 @@ async fn access_log(
     let span = tracing::info_span!("http.request", %method, %path);
     let response = next.run(req).instrument(span).await;
     tracing::info!(
-        target: "dronte::access",
+        target: "chimely::access",
         %method,
         %path,
         query = query.as_deref().unwrap_or(""),

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,4 +1,4 @@
-//! Dronte server library. The `dronte` binary (`src/main.rs`) is a thin
+//! Chimely server library. The `chimely` binary (`src/main.rs`) is a thin
 //! wrapper. Everything lives here so integration tests (testcontainers) can
 //! drive the router, the worker loop, and maintenance jobs in-process.
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,14 +1,14 @@
-//! Dronte in-app notification inbox infrastructure.
+//! Chimely in-app notification inbox infrastructure.
 //!
 //! Single binary, three entrypoints:
-//!   `dronte serve`   (default) API plane plus workers
-//!   `dronte openapi`           print the utoipa-generated OpenAPI spec to stdout
-//!   `dronte dlq`               list and replay dead-lettered jobs
+//!   `chimely serve`   (default) API plane plus workers
+//!   `chimely openapi`           print the utoipa-generated OpenAPI spec to stdout
+//!   `chimely dlq`               list and replay dead-lettered jobs
 
 use std::sync::Arc;
 
 use anyhow::Context;
-use dronte::{
+use chimely::{
     bootstrap, config, db, dlq, http, ids, metrics_sampler, openapi, partitions, pubsub, ratelimit,
     state, telemetry, worker,
 };
@@ -40,7 +40,7 @@ fn main() -> anyhow::Result<()> {
                 .block_on(dlq_command(args.collect()))
         }
         Some(other) => {
-            eprintln!("unknown subcommand: {other}\nusage: dronte [serve|openapi|dlq]");
+            eprintln!("unknown subcommand: {other}\nusage: chimely [serve|openapi|dlq]");
             std::process::exit(2);
         }
     }
@@ -65,7 +65,7 @@ async fn serve() -> anyhow::Result<()> {
     if !cfg.admin_tls_terminated {
         tracing::warn!(
             "Admin session cookies require TLS. This binary serves plain HTTP: terminate TLS at a \
-             proxy and set DRONTE_ADMIN_TLS_TERMINATED=true. Until then the session cookie omits \
+             proxy and set CHIMELY_ADMIN_TLS_TERMINATED=true. Until then the session cookie omits \
              its Secure attribute and admin access is exposed if served over plain HTTP."
         );
     }
@@ -116,7 +116,7 @@ async fn serve() -> anyhow::Result<()> {
     let listener = tokio::net::TcpListener::bind(&cfg.listen_addr)
         .await
         .with_context(|| format!("binding {}", cfg.listen_addr))?;
-    tracing::info!(addr = %cfg.listen_addr, "dronte listening");
+    tracing::info!(addr = %cfg.listen_addr, "chimely listening");
 
     // Graceful shutdown, two phases:
     //   1. readiness flips to 503 while the listener keeps serving, so load
@@ -178,7 +178,7 @@ async fn dlq_command(args: Vec<String>) -> anyhow::Result<()> {
             }
         }
         Some(_) => {
-            eprintln!("usage: dronte dlq replay <job_id|--all> [--env <slug>]");
+            eprintln!("usage: chimely dlq replay <job_id|--all> [--env <slug>]");
             std::process::exit(2);
         }
         None => None,
@@ -223,12 +223,12 @@ async fn dlq_command(args: Vec<String>) -> anyhow::Result<()> {
                 Ok(())
             }
             None => {
-                eprintln!("usage: dronte dlq replay <job_id|--all> [--env <slug>]");
+                eprintln!("usage: chimely dlq replay <job_id|--all> [--env <slug>]");
                 std::process::exit(2);
             }
         },
         _ => {
-            eprintln!("usage: dronte dlq [list|replay <job_id|--all> [--env <slug>]]");
+            eprintln!("usage: chimely dlq [list|replay <job_id|--all> [--env <slug>]]");
             std::process::exit(2);
         }
     }

--- a/server/src/metrics_sampler.rs
+++ b/server/src/metrics_sampler.rs
@@ -1,15 +1,15 @@
 //! Periodically sampled gauges. Everything here is recomputed from Postgres
 //! on every sample, never carried from in-process state, so the numbers stay
 //! true across restarts and a stalled subsystem cannot freeze its own alarm.
-//! `dronte_partitions_remaining` keeps decaying even when the maintenance job
+//! `chimely_partitions_remaining` keeps decaying even when the maintenance job
 //! is dead, and that decay is the partition-headroom alert.
 //!
 //! Gauges emitted:
-//! * `dronte_queue_depth{environment,job_type}`: all pending job rows
-//! * `dronte_queue_due{environment,job_type}`: rows with run_at <= now()
-//! * `dronte_dead_letters{job_type}`: parked jobs awaiting replay
-//! * `dronte_partitions_remaining{table}`: pre-created future partitions
-//! * `dronte_counter_drift_unread` / `dronte_counter_drift_unseen`: summed
+//! * `chimely_queue_depth{environment,job_type}`: all pending job rows
+//! * `chimely_queue_due{environment,job_type}`: rows with run_at <= now()
+//! * `chimely_dead_letters{job_type}`: parked jobs awaiting replay
+//! * `chimely_partitions_remaining{table}`: pre-created future partitions
+//! * `chimely_counter_drift_unread` / `chimely_counter_drift_unseen`: summed
 //!   |recount - maintained| over a sample of recently-active subscribers
 
 use std::collections::HashSet;
@@ -47,8 +47,8 @@ pub async fn sample(pool: &PgPool, cfg: &Config) -> anyhow::Result<()> {
     sample_dead_letters(pool).await?;
     sample_partitions(pool).await?;
     let (unread_drift, unseen_drift) = counter_drift(pool, cfg.counter_drift_sample_size).await?;
-    metrics::gauge!("dronte_counter_drift_unread").set(unread_drift as f64);
-    metrics::gauge!("dronte_counter_drift_unseen").set(unseen_drift as f64);
+    metrics::gauge!("chimely_counter_drift_unread").set(unread_drift as f64);
+    metrics::gauge!("chimely_counter_drift_unseen").set(unseen_drift as f64);
     Ok(())
 }
 
@@ -70,10 +70,10 @@ async fn sample_queue_depth(pool: &PgPool) -> anyhow::Result<()> {
 
     let mut seen = HashSet::new();
     for row in rows {
-        metrics::gauge!("dronte_queue_depth",
+        metrics::gauge!("chimely_queue_depth",
             "environment" => row.slug.clone(), "job_type" => row.job_type.clone())
         .set(row.total as f64);
-        metrics::gauge!("dronte_queue_due",
+        metrics::gauge!("chimely_queue_due",
             "environment" => row.slug.clone(), "job_type" => row.job_type.clone())
         .set(row.due as f64);
         seen.insert((row.slug, row.job_type));
@@ -81,10 +81,10 @@ async fn sample_queue_depth(pool: &PgPool) -> anyhow::Result<()> {
     let mut previous = QUEUE_SERIES.lock().expect("queue series lock");
     if let Some(previous) = previous.as_ref() {
         for (slug, job_type) in previous.difference(&seen) {
-            metrics::gauge!("dronte_queue_depth",
+            metrics::gauge!("chimely_queue_depth",
                 "environment" => slug.clone(), "job_type" => job_type.clone())
             .set(0.0);
-            metrics::gauge!("dronte_queue_due",
+            metrics::gauge!("chimely_queue_due",
                 "environment" => slug.clone(), "job_type" => job_type.clone())
             .set(0.0);
         }
@@ -100,14 +100,14 @@ async fn sample_dead_letters(pool: &PgPool) -> anyhow::Result<()> {
             .await?;
     let mut seen = HashSet::new();
     for row in rows {
-        metrics::gauge!("dronte_dead_letters", "job_type" => row.job_type.clone())
+        metrics::gauge!("chimely_dead_letters", "job_type" => row.job_type.clone())
             .set(row.count as f64);
         seen.insert(row.job_type);
     }
     let mut previous = DLQ_SERIES.lock().expect("dlq series lock");
     if let Some(previous) = previous.as_ref() {
         for job_type in previous.difference(&seen) {
-            metrics::gauge!("dronte_dead_letters", "job_type" => job_type.clone()).set(0.0);
+            metrics::gauge!("chimely_dead_letters", "job_type" => job_type.clone()).set(0.0);
         }
     }
     *previous = Some(seen);
@@ -122,7 +122,7 @@ async fn sample_partitions(pool: &PgPool) -> anyhow::Result<()> {
         .await?;
     for table in partitions::PARTITIONED_TABLES {
         let remaining = partitions::remaining_at(&mut conn, table, now).await?;
-        metrics::gauge!("dronte_partitions_remaining", "table" => *table).set(remaining as f64);
+        metrics::gauge!("chimely_partitions_remaining", "table" => *table).set(remaining as f64);
     }
     Ok(())
 }

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -1,5 +1,5 @@
-//! Code-first OpenAPI document (utoipa). `dronte openapi` exports it. The docs
-//! site and `@dronte/client` types are generated from the export.
+//! Code-first OpenAPI document (utoipa). `chimely openapi` exports it. The docs
+//! site and `@chimely/client` types are generated from the export.
 
 use utoipa::OpenApi;
 use utoipa::openapi::content::ContentBuilder;
@@ -15,7 +15,7 @@ const INFO_DESCRIPTION: &str = r#"Two planes, one binary:
   key. Creates notifications and broadcasts, manages subscribers and their
   preferences. API keys are environment-scoped; the environment is implied
   by the key.
-* **Subscriber plane** — called by `@dronte/client` (the `<Inbox />`
+* **Subscriber plane** — called by `@chimely/client` (the `<Inbox />`
   widget) on behalf of one end user. Authenticated with an HMAC subscriber
   hash: `hex(HMAC-SHA256(environment.subscriber_hmac_secret, subscriber_id))`
   computed by the customer's backend. Mandatory in environments with
@@ -27,9 +27,9 @@ headers are impossible, i.e. `EventSource`):
 
 | Header | Query fallback | Meaning |
 |---|---|---|
-| `X-Dronte-Environment` | `environment` | environment slug |
-| `X-Dronte-Subscriber` | `subscriber_id` | customer-provided subscriber id |
-| `X-Dronte-Subscriber-Hash` | `subscriber_hash` | HMAC hash (when required) |
+| `X-Chimely-Environment` | `environment` | environment slug |
+| `X-Chimely-Subscriber` | `subscriber_id` | customer-provided subscriber id |
+| `X-Chimely-Subscriber-Hash` | `subscriber_hash` | HMAC hash (when required) |
 
 **Idempotency.** Every create accepts `idempotency_key` (client-supplied or
 server-generated and echoed). Uniqueness is per environment per resource
@@ -49,10 +49,10 @@ conventional status codes. 429 carries `Retry-After`.
 /// info.version is the published API version.
 #[derive(OpenApi)]
 #[openapi(
-    info(title = "Dronte API", version = "0.1.0"),
+    info(title = "Chimely API", version = "0.1.0"),
     tags(
-        (name = "management", description = "Backend-to-Dronte. Bearer API key."),
-        (name = "subscriber", description = "Widget-to-Dronte. HMAC subscriber hash."),
+        (name = "management", description = "Backend-to-Chimely. Bearer API key."),
+        (name = "subscriber", description = "Widget-to-Chimely. HMAC subscriber hash."),
         (name = "admin", description = "Instance admin dashboard. Built-in users, session cookie.")
     ),
     paths(
@@ -126,9 +126,7 @@ pub fn api_doc() -> utoipa::openapi::OpenApi {
     doc.info.description = Some(INFO_DESCRIPTION.to_owned());
     doc.info.license = None;
     doc.servers = Some(vec![
-        ServerBuilder::new()
-            .url("https://dronte.example.com")
-            .build(),
+        ServerBuilder::new().url("https://chimely.dev").build(),
     ]);
     // The spec's explicit top-level `security: []`.
     doc.security = Some(vec![]);
@@ -146,22 +144,22 @@ pub fn api_doc() -> utoipa::openapi::OpenApi {
     components.add_security_scheme(
         "AdminSession",
         SecurityScheme::ApiKey(ApiKey::Cookie(ApiKeyValue::with_description(
-            "dronte_admin",
+            "chimely_admin",
             "Server-side admin session cookie, set by POST /admin/api/login.",
         ))),
     );
     components.add_security_scheme(
         "SubscriberEnv",
-        SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::new("X-Dronte-Environment"))),
+        SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::new("X-Chimely-Environment"))),
     );
     components.add_security_scheme(
         "SubscriberId",
-        SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::new("X-Dronte-Subscriber"))),
+        SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::new("X-Chimely-Subscriber"))),
     );
     components.add_security_scheme(
         "SubscriberHash",
         SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::with_description(
-            "X-Dronte-Subscriber-Hash",
+            "X-Chimely-Subscriber-Hash",
             "Optional when the environment has require_subscriber_hash = false.",
         ))),
     );
@@ -388,7 +386,7 @@ mod tests {
     #[test]
     fn exports_yaml_with_expected_identity() {
         let yaml = api_doc().to_yaml().expect("spec serializes");
-        assert!(yaml.contains("title: Dronte API"));
+        assert!(yaml.contains("title: Chimely API"));
         assert!(yaml.contains("version: 0.1.0"));
     }
 

--- a/server/src/partitions.rs
+++ b/server/src/partitions.rs
@@ -8,7 +8,7 @@
 //! partition: a missing partition is a loud insert error, never silent
 //! unprunable growth. Retention is DETACH then DROP.
 //!
-//! Exposes the `dronte_partitions_remaining{table}` gauge: the count of
+//! Exposes the `chimely_partitions_remaining{table}` gauge: the count of
 //! pre-created partitions still entirely in the future. The metrics sampler
 //! recomputes it from pg_inherits on every sample independently of this job
 //! (`remaining_at`), so a stalled job shows the gauge decaying by 1 per month
@@ -111,7 +111,7 @@ async fn run_locked(
         }
 
         let future_partitions = remaining_at(&mut *conn, table, now).await?;
-        metrics::gauge!("dronte_partitions_remaining", "table" => *table)
+        metrics::gauge!("chimely_partitions_remaining", "table" => *table)
             .set(future_partitions as f64);
     }
 

--- a/server/src/pubsub.rs
+++ b/server/src/pubsub.rs
@@ -1,5 +1,5 @@
 //! The hint plane. Redis pub/sub (fred) when `REDIS_URL` is set, Postgres
-//! LISTEN/NOTIFY otherwise (`npx dronte dev` Redis-less mode).
+//! LISTEN/NOTIFY otherwise (`npx chimely dev` Redis-less mode).
 //!
 //! Hints are refetch triggers, not transports (CLAUDE.md). Losing this plane
 //! delays hints and loses nothing. The jobs table rows survive and retry.
@@ -23,7 +23,7 @@ use tokio::sync::broadcast;
 use uuid::Uuid;
 
 /// Redis channel / Postgres NOTIFY channel carrying hint envelopes.
-const HINT_CHANNEL: &str = "dronte_hints";
+const HINT_CHANNEL: &str = "chimely_hints";
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Hint {
@@ -161,7 +161,7 @@ impl PubSub for RedisPubSub {
         let acquired: Option<String> = self
             .client
             .set(
-                format!("dronte:debounce:{key}"),
+                format!("chimely:debounce:{key}"),
                 1,
                 Some(fred::types::Expiration::PX(window.as_millis() as i64)),
                 Some(fred::types::SetOptions::NX),

--- a/server/src/ratelimit.rs
+++ b/server/src/ratelimit.rs
@@ -44,7 +44,7 @@ pub async fn enforce(
     match limiter.check(key, rate_per_sec, burst).await {
         Decision::Allowed => Ok(()),
         Decision::Limited { retry_after } => {
-            metrics::counter!("dronte_rate_limited_total").increment(1);
+            metrics::counter!("chimely_rate_limited_total").increment(1);
             Err(crate::error::ApiError::rate_limited(retry_after))
         }
     }
@@ -126,7 +126,7 @@ impl RateLimiter for RedisRateLimiter {
             .script
             .evalsha_with_reload(
                 &self.client,
-                vec![format!("dronte:rl:{key}")],
+                vec![format!("chimely:rl:{key}")],
                 vec![rate_per_sec.to_string(), burst.to_string()],
             )
             .await;
@@ -138,7 +138,7 @@ impl RateLimiter for RedisRateLimiter {
             // Fail OPEN. Redis loss may loosen limits. It must never reject
             // traffic Postgres could serve.
             Err(err) => {
-                metrics::counter!("dronte_rate_limit_errors_total").increment(1);
+                metrics::counter!("chimely_rate_limit_errors_total").increment(1);
                 tracing::warn!(error = ?err, "rate limiter unavailable; failing open");
                 Decision::Allowed
             }

--- a/server/src/telemetry.rs
+++ b/server/src/telemetry.rs
@@ -1,4 +1,4 @@
-//! Tracing + OTLP wiring. Logs are JSON by default, `DRONTE_LOG_FORMAT=text`
+//! Tracing + OTLP wiring. Logs are JSON by default, `CHIMELY_LOG_FORMAT=text`
 //! for human eyes. The OTLP trace exporter attaches only when
 //! `OTEL_EXPORTER_OTLP_ENDPOINT` is set, so local dev and CI need no collector.
 //!
@@ -15,7 +15,7 @@ use tracing_subscriber::{EnvFilter, Layer, layer::SubscriberExt, util::Subscribe
 
 pub fn init() -> anyhow::Result<()> {
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-    let json = std::env::var("DRONTE_LOG_FORMAT").as_deref() != Ok("text");
+    let json = std::env::var("CHIMELY_LOG_FORMAT").as_deref() != Ok("text");
     let fmt_layer = if json {
         tracing_subscriber::fmt::layer().json().boxed()
     } else {
@@ -31,11 +31,11 @@ pub fn init() -> anyhow::Result<()> {
             .with_batch_exporter(exporter)
             .with_resource(
                 opentelemetry_sdk::Resource::builder()
-                    .with_service_name("dronte")
+                    .with_service_name("chimely")
                     .build(),
             )
             .build();
-        let tracer = provider.tracer("dronte");
+        let tracer = provider.tracer("chimely");
         Some(tracing_opentelemetry::layer().with_tracer(tracer))
     } else {
         None

--- a/server/src/worker.rs
+++ b/server/src/worker.rs
@@ -99,13 +99,13 @@ pub async fn sweep_once(pool: &PgPool, pubsub: &dyn PubSub, cfg: &Config) -> any
         match process_one(pool, pubsub, cfg, env.environment_id).await {
             Ok(true) => {
                 processed += 1;
-                metrics::counter!("dronte_jobs_processed_total", "environment" => env.slug)
+                metrics::counter!("chimely_jobs_processed_total", "environment" => env.slug)
                     .increment(1);
             }
             Ok(false) => {}
             Err(err) => {
                 tracing::error!(error = ?err, environment = %env.environment_id, "job processing failed");
-                metrics::counter!("dronte_jobs_failed_total", "environment" => env.slug)
+                metrics::counter!("chimely_jobs_failed_total", "environment" => env.slug)
                     .increment(1);
             }
         }
@@ -142,7 +142,8 @@ pub async fn process_one(
     // Claim-to-due latency, the fairness signal: a starved environment shows
     // an unbounded wait here long before users notice late hints.
     let wait = (Utc::now() - job.run_at).num_milliseconds().max(0) as f64 / 1000.0;
-    metrics::histogram!("dronte_job_wait_seconds", "job_type" => job.job_type.clone()).record(wait);
+    metrics::histogram!("chimely_job_wait_seconds", "job_type" => job.job_type.clone())
+        .record(wait);
 
     // The span joins the trace that enqueued the job (traceparent rides in
     // the payload), so one trace covers ingest -> outbox -> worker -> hint.
@@ -302,7 +303,7 @@ async fn fail_job(
         .execute(&mut *tx)
         .await?;
         tx.commit().await?;
-        metrics::counter!("dronte_jobs_parked_total", "job_type" => row.job_type.clone())
+        metrics::counter!("chimely_jobs_parked_total", "job_type" => row.job_type.clone())
             .increment(1);
         tracing::error!(
             environment = %env, job = %id, job_type = %row.job_type,
@@ -313,7 +314,7 @@ async fn fail_job(
     }
 
     tx.commit().await?;
-    metrics::counter!("dronte_jobs_retried_total", "job_type" => row.job_type).increment(1);
+    metrics::counter!("chimely_jobs_retried_total", "job_type" => row.job_type).increment(1);
     Ok(())
 }
 
@@ -407,12 +408,12 @@ async fn process_hint(
                     reason: reason.clone(),
                 })
                 .await?;
-            metrics::histogram!("dronte_hint_publish_duration_seconds")
+            metrics::histogram!("chimely_hint_publish_duration_seconds")
                 .record(started.elapsed().as_secs_f64());
             // Enqueue-to-publish lag: the end-to-end hint latency a
             // subscriber experiences (queue wait + debounce included).
             let lag = (Utc::now() - job_created_at).num_milliseconds().max(0) as f64 / 1000.0;
-            metrics::histogram!("dronte_hint_delivery_lag_seconds").record(lag);
+            metrics::histogram!("chimely_hint_delivery_lag_seconds").record(lag);
             if let Some(sub) = target {
                 published.push(sub);
             }

--- a/server/tests/admin.rs
+++ b/server/tests/admin.rs
@@ -7,8 +7,8 @@
 
 mod support;
 
-use dronte::auth::compute_subscriber_hash;
-use dronte::ids;
+use chimely::auth::compute_subscriber_hash;
+use chimely::ids;
 use serde_json::{Value, json};
 
 fn env_typeid(app: &support::TestApp) -> String {
@@ -24,7 +24,7 @@ async fn get_status(client: &reqwest::Client, url: String) -> u16 {
 async fn post_status(client: &reqwest::Client, url: String, body: Value) -> u16 {
     client
         .post(url)
-        .header("x-dronte-admin", "1")
+        .header("x-chimely-admin", "1")
         .json(&body)
         .send()
         .await
@@ -42,9 +42,9 @@ async fn counts_status_with_secret(
     let hash = compute_subscriber_hash(secret, subscriber);
     app.client
         .get(format!("{}/v1/inbox/counts", app.base))
-        .header("X-Dronte-Environment", app.env.slug.clone())
-        .header("X-Dronte-Subscriber", subscriber)
-        .header("X-Dronte-Subscriber-Hash", hash)
+        .header("X-Chimely-Environment", app.env.slug.clone())
+        .header("X-Chimely-Subscriber", subscriber)
+        .header("X-Chimely-Subscriber-Hash", hash)
         .send()
         .await
         .expect("counts")
@@ -121,7 +121,7 @@ async fn login_success_failure_and_cookie_flags() {
     ] {
         let res = client
             .post(&login_url)
-            .header("x-dronte-admin", "1")
+            .header("x-chimely-admin", "1")
             .json(&body)
             .send()
             .await
@@ -147,7 +147,7 @@ async fn login_success_failure_and_cookie_flags() {
     // Correct login.
     let ok = client
         .post(&login_url)
-        .header("x-dronte-admin", "1")
+        .header("x-chimely-admin", "1")
         .json(
             &json!({"email": support::ADMIN_TEST_EMAIL, "password": support::ADMIN_TEST_PASSWORD}),
         )
@@ -162,7 +162,7 @@ async fn login_success_failure_and_cookie_flags() {
         .to_str()
         .unwrap()
         .to_owned();
-    assert!(set_cookie.contains("dronte_admin="));
+    assert!(set_cookie.contains("chimely_admin="));
     assert!(set_cookie.contains("HttpOnly"));
     assert!(set_cookie.contains("SameSite=Strict"));
     assert!(set_cookie.contains("Path=/admin"));
@@ -203,7 +203,7 @@ async fn logout_invalidates_the_session() {
 
     let out = client
         .post(format!("{}/admin/api/logout", app.base))
-        .header("x-dronte-admin", "1")
+        .header("x-chimely-admin", "1")
         .send()
         .await
         .unwrap();
@@ -278,7 +278,7 @@ async fn disabled_user_cannot_authenticate() {
     );
     let relogin = reqwest::Client::new()
         .post(format!("{}/admin/api/login", app.base))
-        .header("x-dronte-admin", "1")
+        .header("x-chimely-admin", "1")
         .json(&json!({"email": "v@disable.test", "password": "viewer-password-1"}))
         .send()
         .await
@@ -552,13 +552,13 @@ async fn concurrent_admin_demotion_keeps_one_admin() {
     // admin while the seed client demotes the other admin.
     let demote_seed = other_client
         .patch(format!("{}/admin/api/users/{seed_id}", app.base))
-        .header("x-dronte-admin", "1")
+        .header("x-chimely-admin", "1")
         .json(&json!({"role": "viewer"}))
         .send();
     let demote_other = app
         .client
         .patch(format!("{}/admin/api/users/{other_id}", app.base))
-        .header("x-dronte-admin", "1")
+        .header("x-chimely-admin", "1")
         .json(&json!({"role": "viewer"}))
         .send();
     let (r1, r2) = tokio::join!(demote_seed, demote_other);
@@ -608,7 +608,7 @@ async fn password_change_then_relogin() {
     // Self-service change.
     let chg = user
         .post(format!("{}/admin/api/users/{uid}/password", app.base))
-        .header("x-dronte-admin", "1")
+        .header("x-chimely-admin", "1")
         .json(&json!({"password": "new-password-456"}))
         .send()
         .await
@@ -618,7 +618,7 @@ async fn password_change_then_relogin() {
     // Old password no longer logs in, new one does.
     let old = reqwest::Client::new()
         .post(format!("{}/admin/api/login", app.base))
-        .header("x-dronte-admin", "1")
+        .header("x-chimely-admin", "1")
         .json(&json!({"email": "p@pw.test", "password": "old-password-123"}))
         .send()
         .await
@@ -695,7 +695,7 @@ async fn bootstrap_admin_is_idempotent() {
     })
     .await;
 
-    dronte::bootstrap::ensure_admin(&app.pool, &app.cfg)
+    chimely::bootstrap::ensure_admin(&app.pool, &app.cfg)
         .await
         .unwrap();
     let hash1: String =
@@ -705,7 +705,7 @@ async fn bootstrap_admin_is_idempotent() {
             .unwrap();
 
     // Second run: still one row, unchanged hash (a true no-op).
-    dronte::bootstrap::ensure_admin(&app.pool, &app.cfg)
+    chimely::bootstrap::ensure_admin(&app.pool, &app.cfg)
         .await
         .unwrap();
     let count: i64 =
@@ -736,7 +736,7 @@ async fn bootstrap_reconcile_revokes_existing_sessions() {
         cfg.admin_bootstrap_password = Some("root-password-1234".into());
     })
     .await;
-    dronte::bootstrap::ensure_admin(&app.pool, &app.cfg)
+    chimely::bootstrap::ensure_admin(&app.pool, &app.cfg)
         .await
         .unwrap();
 
@@ -750,13 +750,13 @@ async fn bootstrap_reconcile_revokes_existing_sessions() {
 
     // Simulate credential drift (e.g. a UI password change) so the next boot
     // takes the reconcile branch.
-    let drift = dronte::auth::hash_password("a-different-password").unwrap();
+    let drift = chimely::auth::hash_password("a-different-password").unwrap();
     sqlx::query("UPDATE admin_users SET password_hash = $1 WHERE email = 'root@reconcile.test'")
         .bind(drift)
         .execute(&app.pool)
         .await
         .unwrap();
-    dronte::bootstrap::ensure_admin(&app.pool, &app.cfg)
+    chimely::bootstrap::ensure_admin(&app.pool, &app.cfg)
         .await
         .unwrap();
 

--- a/server/tests/auth.rs
+++ b/server/tests/auth.rs
@@ -4,18 +4,21 @@
 
 mod support;
 
-use dronte::auth::compute_subscriber_hash;
+use chimely::auth::compute_subscriber_hash;
 use reqwest::header::{HeaderMap, HeaderValue};
 
 const SUB: &str = "usr_auth";
 
 fn headers(slug: &str, sub: &str, hash: Option<&str>) -> HeaderMap {
     let mut h = HeaderMap::new();
-    h.insert("X-Dronte-Environment", HeaderValue::from_str(slug).unwrap());
-    h.insert("X-Dronte-Subscriber", HeaderValue::from_str(sub).unwrap());
+    h.insert(
+        "X-Chimely-Environment",
+        HeaderValue::from_str(slug).unwrap(),
+    );
+    h.insert("X-Chimely-Subscriber", HeaderValue::from_str(sub).unwrap());
     if let Some(hash) = hash {
         h.insert(
-            "X-Dronte-Subscriber-Hash",
+            "X-Chimely-Subscriber-Hash",
             HeaderValue::from_str(hash).unwrap(),
         );
     }
@@ -68,7 +71,7 @@ async fn hash_is_mandatory_when_the_environment_requires_it() {
     // Missing subscriber id.
     let mut h = HeaderMap::new();
     h.insert(
-        "X-Dronte-Environment",
+        "X-Chimely-Environment",
         HeaderValue::from_str(&app.env.slug).unwrap(),
     );
     assert_eq!(get_counts_status(&app, h).await, 401);

--- a/server/tests/chaos.rs
+++ b/server/tests/chaos.rs
@@ -7,8 +7,8 @@ mod support;
 
 use std::time::Duration;
 
+use chimely::{db, jobs, partitions, worker};
 use chrono::Utc;
-use dronte::{db, jobs, partitions, worker};
 use serde_json::json;
 use support::SseStream;
 use testcontainers_modules::postgres::Postgres as PostgresImage;
@@ -473,7 +473,7 @@ async fn sustained_jobs_churn_stays_bounded_under_autovacuum() {
     .await
     .unwrap();
 
-    let cfg = dronte::config::Config {
+    let cfg = chimely::config::Config {
         database_url: url.clone(),
         redis_url: None,
         listen_addr: String::new(),
@@ -503,7 +503,7 @@ async fn sustained_jobs_churn_stays_bounded_under_autovacuum() {
         shutdown_drain_deadline: Duration::from_secs(5),
     };
     let cfg = std::sync::Arc::new(cfg);
-    let pubsub = dronte::pubsub::build(None, &pool).await.unwrap();
+    let pubsub = chimely::pubsub::build(None, &pool).await.unwrap();
 
     // Deep single-environment backlog is the worst case for the claim query.
     // One fairness slot, every worker contending on the same index head.

--- a/server/tests/metrics.rs
+++ b/server/tests/metrics.rs
@@ -5,7 +5,7 @@ mod support;
 
 use std::time::Duration;
 
-use dronte::metrics_sampler;
+use chimely::metrics_sampler;
 use serde_json::json;
 use support::SseStream;
 
@@ -31,7 +31,7 @@ async fn sampler_reports_queue_depth_dead_letters_partitions_and_zero_drift() {
          VALUES ($1, $2, 'deliver', '{}'::jsonb, 10, 10, 'boom', now())",
     )
     .bind(app.env.id)
-    .bind(dronte::ids::new_uuid())
+    .bind(chimely::ids::new_uuid())
     .execute(&app.pool)
     .await
     .unwrap();
@@ -40,18 +40,18 @@ async fn sampler_reports_queue_depth_dead_letters_partitions_and_zero_drift() {
     let body = scrape(&app).await;
 
     let depth_line = format!(
-        "dronte_queue_depth{{environment=\"{}\",job_type=\"hint\"}}",
+        "chimely_queue_depth{{environment=\"{}\",job_type=\"hint\"}}",
         app.env.slug
     );
     assert!(
         body.contains(&depth_line),
         "queue depth per env+type:\n{body}"
     );
-    assert!(body.contains("dronte_dead_letters{job_type=\"deliver\"} 1"));
-    assert!(body.contains("dronte_partitions_remaining{table=\"notifications\"} 13"));
-    assert!(body.contains("dronte_partitions_remaining{table=\"notification_status_log\"} 13"));
-    assert!(body.contains("dronte_counter_drift_unread 0"));
-    assert!(body.contains("dronte_counter_drift_unseen 0"));
+    assert!(body.contains("chimely_dead_letters{job_type=\"deliver\"} 1"));
+    assert!(body.contains("chimely_partitions_remaining{table=\"notifications\"} 13"));
+    assert!(body.contains("chimely_partitions_remaining{table=\"notification_status_log\"} 13"));
+    assert!(body.contains("chimely_counter_drift_unread 0"));
+    assert!(body.contains("chimely_counter_drift_unseen 0"));
 
     app.drain_jobs().await;
     metrics_sampler::sample(&app.pool, &app.cfg).await.unwrap();
@@ -71,26 +71,26 @@ async fn hint_latency_claim_counters_and_sse_connections_are_recorded() {
 
     let body = scrape(&app).await;
     assert!(
-        body.contains("dronte_sse_connections 1"),
+        body.contains("chimely_sse_connections 1"),
         "SSE gauge:\n{body}"
     );
     assert!(
-        body.contains("dronte_hint_publish_duration_seconds"),
+        body.contains("chimely_hint_publish_duration_seconds"),
         "publish duration histogram"
     );
     assert!(
-        body.contains("dronte_hint_delivery_lag_seconds"),
+        body.contains("chimely_hint_delivery_lag_seconds"),
         "enqueue-to-publish lag histogram"
     );
     assert!(
         body.contains(&format!(
-            "dronte_jobs_processed_total{{environment=\"{}\"}}",
+            "chimely_jobs_processed_total{{environment=\"{}\"}}",
             app.env.slug
         )),
         "claim counter per environment"
     );
     assert!(
-        body.contains("dronte_job_wait_seconds"),
+        body.contains("chimely_job_wait_seconds"),
         "fairness histogram"
     );
 }
@@ -112,7 +112,7 @@ async fn counter_drift_detects_an_artificially_poisoned_counter() {
     .await
     .unwrap();
     let mut conn = app.pool.acquire().await.unwrap();
-    dronte::jobs::enqueue_hint(&mut conn, app.env.id, &[subscriber], "read_state", &[])
+    chimely::jobs::enqueue_hint(&mut conn, app.env.id, &[subscriber], "read_state", &[])
         .await
         .unwrap();
     drop(conn);
@@ -166,5 +166,5 @@ async fn rate_limited_requests_bump_the_limit_counter() {
 
     tokio::time::sleep(Duration::from_millis(50)).await;
     let body = scrape(&app).await;
-    assert!(body.contains("dronte_rate_limited_total 1"), "{body}");
+    assert!(body.contains("chimely_rate_limited_total 1"), "{body}");
 }

--- a/server/tests/migrations.rs
+++ b/server/tests/migrations.rs
@@ -3,8 +3,8 @@
 
 mod support;
 
+use chimely::{db, ids, partitions};
 use chrono::{Datelike, Months, Utc};
-use dronte::{db, ids, partitions};
 
 #[tokio::test]
 async fn migrations_are_idempotent_and_gate_readiness() {

--- a/server/tests/quickstart.rs
+++ b/server/tests/quickstart.rs
@@ -1,6 +1,6 @@
 //! Quickstart enablers. Dev bootstrap mints an environment and API key from
 //! env-var config. Subscriber-plane CORS lets the widget run in a browser
-//! against a local Redis-less dronte.
+//! against a local Redis-less chimely.
 
 mod support;
 
@@ -11,10 +11,10 @@ async fn dev_bootstrap_seeds_an_environment_and_key_idempotently() {
     cfg.dev_environment = Some("demo".into());
     cfg.dev_api_key = Some("dev-secret-key".into());
 
-    dronte::bootstrap::run(&app.pool, &cfg)
+    chimely::bootstrap::run(&app.pool, &cfg)
         .await
         .expect("first bootstrap");
-    dronte::bootstrap::run(&app.pool, &cfg)
+    chimely::bootstrap::run(&app.pool, &cfg)
         .await
         .expect("bootstrap reruns cleanly");
 
@@ -78,7 +78,7 @@ async fn dev_bootstrap_leaves_an_existing_environment_untouched() {
     .unwrap();
     assert!(before.1, "the support environment requires hashes");
 
-    dronte::bootstrap::run(&app.pool, &cfg)
+    chimely::bootstrap::run(&app.pool, &cfg)
         .await
         .expect("bootstrap against an existing environment succeeds");
 
@@ -102,7 +102,7 @@ async fn dev_bootstrap_truncates_the_key_prefix_on_a_char_boundary() {
     // Byte 14 falls inside the two-byte é. A fixed byte slice would panic.
     cfg.dev_api_key = Some("abcdefghijklmé-secret".into());
 
-    dronte::bootstrap::run(&app.pool, &cfg)
+    chimely::bootstrap::run(&app.pool, &cfg)
         .await
         .expect("a multi-byte key must not panic the bootstrap");
 
@@ -131,7 +131,7 @@ async fn subscriber_plane_is_cors_enabled_for_the_widget() {
         .header("Access-Control-Request-Method", "GET")
         .header(
             "Access-Control-Request-Headers",
-            "x-dronte-environment,x-dronte-subscriber,if-none-match",
+            "x-chimely-environment,x-chimely-subscriber,if-none-match",
         )
         .send()
         .await
@@ -150,9 +150,9 @@ async fn subscriber_plane_is_cors_enabled_for_the_widget() {
         .unwrap_or_default()
         .to_ascii_lowercase();
     for header in [
-        "x-dronte-environment",
-        "x-dronte-subscriber",
-        "x-dronte-subscriber-hash",
+        "x-chimely-environment",
+        "x-chimely-subscriber",
+        "x-chimely-subscriber-hash",
         "if-none-match",
     ] {
         assert!(allowed_headers.contains(header), "missing {header}");
@@ -165,8 +165,8 @@ async fn subscriber_plane_is_cors_enabled_for_the_widget() {
         .client
         .get(format!("{}/v1/inbox/items", app.base))
         .header("Origin", "https://customer.example")
-        .header("X-Dronte-Environment", &app.env.slug)
-        .header("X-Dronte-Subscriber", "usr_cors")
+        .header("X-Chimely-Environment", &app.env.slug)
+        .header("X-Chimely-Subscriber", "usr_cors")
         .send()
         .await
         .unwrap();

--- a/server/tests/redteam_broadcast_gc_resurrect.rs
+++ b/server/tests/redteam_broadcast_gc_resurrect.rs
@@ -105,7 +105,7 @@ async fn mark_all_read_gc_keeps_an_above_watermark_exception() {
         .post_inbox(SUB, &format!("/v1/inbox/broadcasts/{below_id}/read"))
         .await;
     assert_eq!(res.status(), 204);
-    let below_uuid = dronte::ids::parse_typeid(dronte::ids::BROADCAST, &below_id).unwrap();
+    let below_uuid = chimely::ids::parse_typeid(chimely::ids::BROADCAST, &below_id).unwrap();
     assert!(broadcast_read_exists(&app, sub_id, below_uuid).await);
 
     // SHARE lock on `jobs` so the handler's enqueue_timeline INSERT blocks after
@@ -149,7 +149,7 @@ async fn mark_all_read_gc_keeps_an_above_watermark_exception() {
     // between its watermark UPDATE and its GC DELETE. broadcast_created_at is
     // clock_timestamp() now, strictly after the watermark W. It commits before
     // the DELETE statement starts, so it lands in the DELETE's snapshot.
-    let above_uuid = dronte::ids::new_uuid();
+    let above_uuid = chimely::ids::new_uuid();
     let above_created_at: DateTime<Utc> = sqlx::query_scalar(
         "INSERT INTO broadcasts (environment_id, id, category, created_at)
          VALUES ($1, $2, 'above', clock_timestamp())
@@ -212,7 +212,7 @@ async fn mark_all_read_gc_keeps_an_above_watermark_exception() {
     );
 
     // User-facing symptom: the above-watermark broadcast stays read in the list.
-    let above_typeid = dronte::ids::typeid(dronte::ids::BROADCAST, above_uuid);
+    let above_typeid = chimely::ids::typeid(chimely::ids::BROADCAST, above_uuid);
     let item_read = app
         .list_all_items(SUB, 50)
         .await

--- a/server/tests/redteam_contract_drift.rs
+++ b/server/tests/redteam_contract_drift.rs
@@ -5,11 +5,11 @@
 //! `GET /v1/inbox/items` returns 400 from request validation (out-of-range
 //! `limit`, malformed `cursor`) and from the query extractor (non-integer
 //! `limit`). The generated OpenAPI document must declare that 400 so it
-//! matches the handler and `@dronte/client` has a 400 branch.
+//! matches the handler and `@chimely/client` has a 400 branch.
 
 mod support;
 
-use dronte::openapi::api_doc;
+use chimely::openapi::api_doc;
 
 /// `listInboxItems` returns 400 for bad input, and the annotation declares it.
 #[tokio::test]

--- a/server/tests/redteam_contract_drift_upsert.rs
+++ b/server/tests/redteam_contract_drift_upsert.rs
@@ -5,7 +5,7 @@
 
 mod support;
 
-use dronte::openapi::api_doc;
+use chimely::openapi::api_doc;
 
 /// `upsertSubscriber` returns 400 for an over-long `subscriber_id`. The
 /// code-first utoipa document must declare it.
@@ -44,7 +44,7 @@ async fn upsert_subscriber_400_is_declared_in_the_generated_spec() {
         op.responses.responses.contains_key("400"),
         "CONTRACT DRIFT: the upsertSubscriber annotation must declare the 400 the \
          handler returns for an out-of-range subscriber_id; the generated spec declares \
-         only {declared:?}. @dronte/client is built without a 400 branch and schemathesis \
+         only {declared:?}. @chimely/client is built without a 400 branch and schemathesis \
          would report an undocumented HTTP status code.",
     );
 }

--- a/server/tests/redteam_dlq_env_scope.rs
+++ b/server/tests/redteam_dlq_env_scope.rs
@@ -37,12 +37,12 @@ async fn replay_all_replays_only_the_scoped_environment() {
     let app = support::spawn().await;
     let env_b = app.create_environment(true).await;
 
-    park_dead_letter_with_id(&app.pool, app.env.id, dronte::ids::new_uuid()).await;
-    park_dead_letter_with_id(&app.pool, env_b.id, dronte::ids::new_uuid()).await;
+    park_dead_letter_with_id(&app.pool, app.env.id, chimely::ids::new_uuid()).await;
+    park_dead_letter_with_id(&app.pool, env_b.id, chimely::ids::new_uuid()).await;
     assert_eq!(dead_letters_in(&app.pool, app.env.id).await, 1);
     assert_eq!(dead_letters_in(&app.pool, env_b.id).await, 1);
 
-    let moved = dronte::dlq::replay_all(&app.pool, Some(app.env.id))
+    let moved = chimely::dlq::replay_all(&app.pool, Some(app.env.id))
         .await
         .expect("replay env A");
     assert_eq!(moved, 1, "only env A's parked job is replayed");
@@ -66,11 +66,11 @@ async fn replay_by_id_replays_only_the_scoped_environment() {
 
     // The same job id parked in both environments is legal under the
     // (environment_id, id) PK. An id-only replay predicate replays both copies.
-    let shared = dronte::ids::new_uuid();
+    let shared = chimely::ids::new_uuid();
     park_dead_letter_with_id(&app.pool, app.env.id, shared).await;
     park_dead_letter_with_id(&app.pool, env_b.id, shared).await;
 
-    let replayed = dronte::dlq::replay(&app.pool, shared, Some(app.env.id))
+    let replayed = chimely::dlq::replay(&app.pool, shared, Some(app.env.id))
         .await
         .expect("replay env A's copy");
     assert!(replayed, "env A's copy was replayed");

--- a/server/tests/redteam_failjob_backoff_atomicity.rs
+++ b/server/tests/redteam_failjob_backoff_atomicity.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::time::Duration;
 
-use dronte::worker;
+use chimely::worker;
 
 const ROUNDS: usize = 200;
 
@@ -43,7 +43,7 @@ async fn a_failed_job_is_never_reclaimable_before_its_backoff_lands() {
 
     // 'bogus' is an unknown job type, so process_one errors and routes through
     // fail_job. max_attempts is high so the job never parks.
-    let job_id = dronte::ids::new_uuid();
+    let job_id = chimely::ids::new_uuid();
     sqlx::query(
         "INSERT INTO jobs (environment_id, id, job_type, payload, run_at,
                            attempts, max_attempts)

--- a/server/tests/shutdown.rs
+++ b/server/tests/shutdown.rs
@@ -6,7 +6,7 @@ mod support;
 
 use std::time::Duration;
 
-use dronte::worker;
+use chimely::worker;
 use serde_json::json;
 
 #[tokio::test]

--- a/server/tests/sse.rs
+++ b/server/tests/sse.rs
@@ -235,7 +235,7 @@ async fn subscriber_hash_is_scrubbed_from_access_logs() {
         .expect("install capture subscriber");
 
     let app = support::spawn().await;
-    let hash = dronte::auth::compute_subscriber_hash(&app.env.hmac_secret, SUB);
+    let hash = chimely::auth::compute_subscriber_hash(&app.env.hmac_secret, SUB);
     let mut stream = SseStream::connect(&app, SUB, None).await;
     // Force the response (and its access-log line) to materialize.
     stream.next_frame(Duration::from_secs(2)).await;

--- a/server/tests/support/mod.rs
+++ b/server/tests/support/mod.rs
@@ -13,12 +13,12 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use chimely::auth::compute_subscriber_hash;
+use chimely::config::Config;
+use chimely::pubsub::PubSub;
+use chimely::state::AppState;
+use chimely::{db, http, ids, partitions, pubsub, ratelimit, worker};
 use chrono::{DateTime, Utc};
-use dronte::auth::compute_subscriber_hash;
-use dronte::config::Config;
-use dronte::pubsub::PubSub;
-use dronte::state::AppState;
-use dronte::{db, http, ids, partitions, pubsub, ratelimit, worker};
 use reqwest::header::{HeaderMap, HeaderValue};
 use sha2::Digest as _;
 use sqlx::PgPool;
@@ -31,7 +31,7 @@ use uuid::Uuid;
 
 pub const RETENTION_MONTHS: u32 = 12;
 /// The seed admin the harness creates and logs in as by default.
-pub const ADMIN_TEST_EMAIL: &str = "admin@test.dronte";
+pub const ADMIN_TEST_EMAIL: &str = "admin@test.chimely";
 pub const ADMIN_TEST_PASSWORD: &str = "test-admin-password";
 
 pub struct TestApp {
@@ -293,7 +293,7 @@ impl TestApp {
     /// Insert an admin user directly (bypassing the API). Returns its uuid.
     pub async fn seed_admin(&self, email: &str, password: &str, role: &str) -> Uuid {
         let id = ids::new_uuid();
-        let hash = dronte::auth::hash_password(password).expect("hash password");
+        let hash = chimely::auth::hash_password(password).expect("hash password");
         sqlx::query(
             "INSERT INTO admin_users (id, email, name, role, password_hash)
              VALUES ($1, $2, $3, $4, $5)",
@@ -314,7 +314,7 @@ impl TestApp {
         let res = self
             .client
             .post(format!("{}/admin/api/login", self.base))
-            .header("x-dronte-admin", "1")
+            .header("x-chimely-admin", "1")
             .json(&serde_json::json!({ "email": email, "password": password }))
             .send()
             .await
@@ -335,7 +335,7 @@ impl TestApp {
             .expect("reqwest client");
         let res = client
             .post(format!("{}/admin/api/login", self.base))
-            .header("x-dronte-admin", "1")
+            .header("x-chimely-admin", "1")
             .json(&serde_json::json!({ "email": email, "password": password }))
             .send()
             .await
@@ -352,21 +352,21 @@ impl TestApp {
     pub fn admin_post(&self, path: &str, body: serde_json::Value) -> reqwest::RequestBuilder {
         self.client
             .post(format!("{}{path}", self.base))
-            .header("x-dronte-admin", "1")
+            .header("x-chimely-admin", "1")
             .json(&body)
     }
 
     pub fn admin_patch(&self, path: &str, body: serde_json::Value) -> reqwest::RequestBuilder {
         self.client
             .patch(format!("{}{path}", self.base))
-            .header("x-dronte-admin", "1")
+            .header("x-chimely-admin", "1")
             .json(&body)
     }
 
     pub fn admin_delete(&self, path: &str) -> reqwest::RequestBuilder {
         self.client
             .delete(format!("{}{path}", self.base))
-            .header("x-dronte-admin", "1")
+            .header("x-chimely-admin", "1")
     }
 
     pub fn subscriber_headers(&self, subscriber: &str) -> HeaderMap {
@@ -376,15 +376,15 @@ impl TestApp {
     pub fn subscriber_headers_for(&self, env: &TestEnvironment, subscriber: &str) -> HeaderMap {
         let mut headers = HeaderMap::new();
         headers.insert(
-            "X-Dronte-Environment",
+            "X-Chimely-Environment",
             HeaderValue::from_str(&env.slug).unwrap(),
         );
         headers.insert(
-            "X-Dronte-Subscriber",
+            "X-Chimely-Subscriber",
             HeaderValue::from_str(subscriber).unwrap(),
         );
         headers.insert(
-            "X-Dronte-Subscriber-Hash",
+            "X-Chimely-Subscriber-Hash",
             HeaderValue::from_str(&compute_subscriber_hash(&env.hmac_secret, subscriber)).unwrap(),
         );
         headers
@@ -636,7 +636,7 @@ impl TestApp {
     pub async fn assert_consistent(&self) {
         // Counter drift across EVERY subscriber, not a sample.
         let (unread_drift, unseen_drift) =
-            dronte::metrics_sampler::counter_drift(&self.pool, i64::MAX)
+            chimely::metrics_sampler::counter_drift(&self.pool, i64::MAX)
                 .await
                 .expect("counter drift");
         assert_eq!(

--- a/server/tests/timeline.rs
+++ b/server/tests/timeline.rs
@@ -5,8 +5,8 @@
 
 mod support;
 
+use chimely::{ids, worker};
 use chrono::Utc;
-use dronte::{ids, worker};
 use serde_json::json;
 use uuid::Uuid;
 

--- a/server/tests/tracing.rs
+++ b/server/tests/tracing.rs
@@ -39,10 +39,10 @@ async fn trace_context_rides_the_outbox_and_survives_processing() {
     let span = tracing::info_span!("ingest.test");
     async {
         let mut conn = app.pool.acquire().await.unwrap();
-        dronte::jobs::enqueue(
+        chimely::jobs::enqueue(
             &mut conn,
             app.env.id,
-            dronte::jobs::TYPE_COUNTER_REBUILD,
+            chimely::jobs::TYPE_COUNTER_REBUILD,
             json!({ "subscriber_id": subscriber_id }),
             None,
         )

--- a/server/tests/worker.rs
+++ b/server/tests/worker.rs
@@ -4,8 +4,8 @@
 
 mod support;
 
+use chimely::{jobs, worker};
 use chrono::Utc;
-use dronte::{jobs, worker};
 use serde_json::json;
 use uuid::Uuid;
 
@@ -367,7 +367,7 @@ async fn dead_letter_replay_reruns_the_job_exactly_once() {
     assert_eq!(unread, 0, "parked job applied no effects");
 
     // Replay grants a fresh attempt budget and re-enqueues NOW.
-    let replayed = dronte::dlq::replay_all(&app.pool, Some(app.env.id))
+    let replayed = chimely::dlq::replay_all(&app.pool, Some(app.env.id))
         .await
         .unwrap();
     assert_eq!(replayed, 1);


### PR DESCRIPTION
Renames the project **dronte → chimely**. Mechanical, case-aware sweep across the whole repo; the API surface is unchanged (stays at `/v1`).

## What changed
- **Server**: Rust crate/lib/binary `dronte` → `chimely`; `CHIMELY_*` env vars, `chimely_*` Prometheus metrics, `X-Chimely-*` headers, `chimely_admin` session cookie, Redis channels.
- **SDKs**: npm scope `@dronte/*` → `@chimely/*`; identifiers `ChimelyClient`/`ChimelyError`/`ChimelyProvider`/`useChimelyClient`/…
- **Domain**: example/server origin → `https://chimely.dev`.
- **Repo URL**: `that-ambuj/dronte` → `that-ambuj/chimely` in both package manifests.
- **Generated**: `docs/openapi/dronte.yaml` → `chimely.yaml` (git rename); regenerated spec + `packages/client/src/generated/api.d.ts` from the compiled binary; refreshed `Cargo.lock` and `pnpm-lock.yaml`.

## Verification
- 0 `dronte` references remain; API paths intact at `/v1`.
- `cargo fmt --check`, `cargo clippy --all-targets -D warnings` ✅
- `cargo nextest run`: 149 passed / 1 skipped ✅
- Biome lint, TS typecheck (5 projects) ✅; vitest: client 37/37, react 33/33 ✅

## Follow-ups (out of band)
- Rename the GitHub repo to `chimely` so the updated clone URLs resolve.
- Packages are pre-publish (`0.0.0`); add a changeset before publishing under the new scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)