### PR TITLE
ci: add GAR docker publish + npm provenance on release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,10 +1,10 @@
 # Docker image publish to Google Artifact Registry (GAR), the dodo deploy plane.
 #
 # Mirrors the dodo-discord-bot publish workflow: publishing a GitHub Release
-# builds the image, tags it with the release tag and `latest`, and pushes both
-# to GAR. This is the internal-deploy image. The public fair-source image is
-# built and pushed to GHCR by the `docker` job in ci.yml. The two are
-# independent and target different registries.
+# builds the image, tags it with the release tag, and pushes it to GAR. This is
+# the internal-deploy image. The public fair-source image is built and pushed
+# to GHCR by the `docker` job in ci.yml. The two are independent and target
+# different registries.
 #
 # Prerequisites (repo settings, one-time, human):
 #   - secrets.SERVICE_ACCOUNT_KEY: JSON key for a GCP service account with
@@ -28,6 +28,7 @@ jobs:
     env:
       IMAGE: ${{ vars.CHIMELY_GAR_LOCATION }}
       REGION: ${{ vars.REGION }}
+      PRERELEASE: ${{ github.event.release.prerelease }}
     steps:
       - uses: actions/checkout@v4
 
@@ -35,11 +36,15 @@ jobs:
         run: echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> "$GITHUB_ENV"
 
       # Dockerfile at the repo root builds the single binary (admin SPA + Rust)
-      # with `.` as the context.
+      # with `.` as the context. `latest` tracks the newest stable release, so a
+      # pre-release publishes its own tag but never moves `latest`.
       - name: Build chimely image
         run: |
+          [ -n "$IMAGE" ] || { echo "CHIMELY_GAR_LOCATION repo variable is unset" >&2; exit 1; }
           docker build -t "$IMAGE:$RELEASE_TAG" .
-          docker tag "$IMAGE:$RELEASE_TAG" "$IMAGE:latest"
+          if [ "$PRERELEASE" != "true" ]; then
+            docker tag "$IMAGE:$RELEASE_TAG" "$IMAGE:latest"
+          fi
 
       - name: Google Auth
         id: auth
@@ -51,9 +56,13 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Docker auth
-        run: gcloud auth configure-docker "${REGION}-docker.pkg.dev"
+        run: |
+          [ -n "$REGION" ] || { echo "REGION repo variable is unset" >&2; exit 1; }
+          gcloud auth configure-docker "${REGION}-docker.pkg.dev"
 
       - name: Push chimely image to GAR
         run: |
           docker push "$IMAGE:$RELEASE_TAG"
-          docker push "$IMAGE:latest"
+          if [ "$PRERELEASE" != "true" ]; then
+            docker push "$IMAGE:latest"
+          fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,59 @@
+# Docker image publish to Google Artifact Registry (GAR), the dodo deploy plane.
+#
+# Mirrors the dodo-discord-bot publish workflow: publishing a GitHub Release
+# builds the image, tags it with the release tag and `latest`, and pushes both
+# to GAR. This is the internal-deploy image. The public fair-source image is
+# built and pushed to GHCR by the `docker` job in ci.yml. The two are
+# independent and target different registries.
+#
+# Prerequisites (repo settings, one-time, human):
+#   - secrets.SERVICE_ACCOUNT_KEY: JSON key for a GCP service account with
+#     Artifact Registry write access on the target repository.
+#   - vars.REGION: GAR region host prefix, e.g. `us-central1`.
+#   - vars.CHIMELY_GAR_LOCATION: full image path without a tag, e.g.
+#     `us-central1-docker.pkg.dev/PROJECT/REPO/chimely`.
+name: Docker Publish
+
+on:
+  release:
+    types: [published]
+
+concurrency: docker-publish-${{ github.ref }}
+
+jobs:
+  docker_build_and_push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      IMAGE: ${{ vars.CHIMELY_GAR_LOCATION }}
+      REGION: ${{ vars.REGION }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract release tag
+        run: echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> "$GITHUB_ENV"
+
+      # Dockerfile at the repo root builds the single binary (admin SPA + Rust)
+      # with `.` as the context.
+      - name: Build chimely image
+        run: |
+          docker build -t "$IMAGE:$RELEASE_TAG" .
+          docker tag "$IMAGE:$RELEASE_TAG" "$IMAGE:latest"
+
+      - name: Google Auth
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: "${{ secrets.SERVICE_ACCOUNT_KEY }}"
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Docker auth
+        run: gcloud auth configure-docker "${REGION}-docker.pkg.dev"
+
+      - name: Push chimely image to GAR
+        run: |
+          docker push "$IMAGE:$RELEASE_TAG"
+          docker push "$IMAGE:latest"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,18 @@ jobs:
       # The publish path must never outrun the gates.
       - run: pnpm typecheck
       - run: pnpm test
+      # npm rejects provenance from a private source repo (the publish 422s).
+      # chimely is private now and public-bound, so gate provenance on live
+      # visibility: off while private, on with no edit once the repo is public.
+      - name: Determine repo visibility (gates provenance)
+        id: vis
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          case "$(gh repo view "$GITHUB_REPOSITORY" --json visibility --jq .visibility)" in
+            PUBLIC) echo "provenance=true" >> "$GITHUB_OUTPUT" ;;
+            *)      echo "provenance=false" >> "$GITHUB_OUTPUT" ;;
+          esac
       - name: Publish to npm
         uses: changesets/action@v1
         with:
@@ -82,6 +94,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          # Provenance attestation on npm. Aborts the publish unless each
-          # package declares a `repository` field (both do).
-          NPM_CONFIG_PROVENANCE: "true"
+          NPM_CONFIG_PROVENANCE: ${{ steps.vis.outputs.provenance }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # OIDC token for npm provenance (NPM_CONFIG_PROVENANCE on the publish step).
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -80,3 +82,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Provenance attestation on npm. Aborts the publish unless each
+          # package declares a `repository` field (both do).
+          NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
## What

Adds the dodo-standard publish path on `release: published`, modeled on the
sibling repos:

- **`docker-publish.yml`** (new) — builds the image and pushes it to **Google
  Artifact Registry** with the release tag + `latest`. Modeled on
  `dodo-discord-bot`.
- **`release.yml`** (edit) — the existing changesets npm publish now emits
  **provenance**, but **only when the source repo is public** (npm 422s
  provenance from a private repo). A visibility step gates it, so it is off
  today and auto-enables when chimely flips public — no future edit. This is
  the monorepo-safe equivalent of `dodo-migrate`'s `npm publish --provenance`.

## Why this shape

chimely already publishes npm (changesets) and a **public** image to **GHCR**
(the `docker` job in `ci.yml`). Those are correct for the fair-source
distribution, so this PR is **additive and non-destructive**:

- GHCR stays the public image (untouched).
- GAR is the new internal-deploy image, on release only.
- npm publishing stays changesets-driven (two packages, `@chimely/client` +
  `@chimely/react`); duplicating `dodo-migrate`'s single-package
  version-from-tag workflow would break monorepo versioning, so provenance is
  added to the existing publish instead.

## Required repo settings (one-time, human)

Variables (already set):
- `vars.REGION` = `asia-south1`
- `vars.CHIMELY_GAR_LOCATION` = `asia-south1-docker.pkg.dev/dodopayments/dodo-backend/chimely`

Secrets:
- `secrets.SERVICE_ACCOUNT_KEY` — GCP service-account JSON with Artifact
  Registry write (set).
- `secrets.NPM_TOKEN` — npm Automation/granular token with publish on the
  `@chimely` scope. Required for auth (tokenless OIDC trusted publishing can't
  bootstrap a not-yet-published package, and also needs a public repo).

npm provenance needs no extra secret (GitHub OIDC), and is gated off until the
repo is public.

## Notes
- Both workflow files pass `actionlint`.
- `run:` steps reference values via `env:` blocks (no untrusted interpolation).