### PR TITLE
build(docs): host on Cloudflare Workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ out/
 docs/.source/
 docs/next-env.d.ts
 
+# Cloudflare Wrangler (local dev/runtime state)
+.wrangler/
+
 # Env & editor
 .env
 .env.*

--- a/docs/app/page.tsx
+++ b/docs/app/page.tsx
@@ -1,5 +1,17 @@
-import { redirect } from 'next/navigation';
+'use client';
 
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+// The site root forwards to the docs. In production the edge redirect in
+// public/_redirects issues a real 302 before any asset is served. `next dev`
+// does not read _redirects, and `redirect()` from next/navigation is
+// unsupported under output: 'export', so this client shell keeps the same
+// behavior for local development.
 export default function HomePage() {
-  redirect('/docs');
+  const router = useRouter();
+  useEffect(() => {
+    router.replace('/docs');
+  }, [router]);
+  return null;
 }

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -3,6 +3,14 @@ import { createMDX } from 'fumadocs-mdx/next';
 /** @type {import('next').NextConfig} */
 const config = {
   reactStrictMode: true,
+  // Static export: the docs site has no server runtime (every route is
+  // prerendered), so it ships as static assets served by Cloudflare Workers
+  // Static Assets. Pairs with html_handling "auto-trailing-slash" in
+  // wrangler.jsonc.
+  output: 'export',
+  // next/image optimization needs a server; static export requires the
+  // unoptimized loader. The docs use no <Image> today, this keeps it safe.
+  images: { unoptimized: true },
 };
 
 const withMDX = createMDX();

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -1,0 +1,8 @@
+# Cloudflare Workers Static Assets redirect rules.
+# Next.js copies public/ into the static export (out/), so this ships at
+# out/_redirects and is honored by the asset router. Redirect rules run
+# before asset matching.
+#
+# The site root forwards to the docs entry point. 302 (temporary) keeps the
+# root free to become a landing page later without a cached 301 in the way.
+/  /docs  302

--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -1,0 +1,19 @@
+{
+  "name": "chimely-docs",
+  "compatibility_date": "2026-06-30",
+  // Assets-only Worker: the docs are a Next.js static export, so there is no
+  // Worker script. `main` and an ASSETS binding are intentionally omitted.
+  "assets": {
+    "directory": "./out",
+    // Next export emits flat leaf files (docs/page.html) and folder indexes
+    // (docs/index.html). auto-trailing-slash serves both and normalizes the
+    // URL. Must stay in sync with next.config.mjs (no trailingSlash set).
+    "html_handling": "auto-trailing-slash",
+    // Serve out/404.html with a real 404 status for unmatched paths. Never
+    // "single-page-application" here, that would answer 404s with 200.
+    "not_found_handling": "404-page"
+  }
+  // Custom domain: bind docs.chimely.dev in the Cloudflare dashboard
+  // (Workers > chimely-docs > Settings > Domains & Routes), or add a
+  // "routes" entry here once the zone is known.
+}


### PR DESCRIPTION
## What

Migrate the Fumadocs docs site hosting from **Vercel → Cloudflare Workers Static Assets**.

The docs are fully static (every route is prerendered: `generateStaticParams` on the only dynamic route, OpenAPI via `fumadocs-openapi` `staticSource`, no API routes / middleware / server actions). So instead of OpenNext SSR, the site ships as a **Next.js static export** (`output: 'export'`) served by an **assets-only Worker** — cheaper, faster, zero cold starts, no runtime compat risk.

## Changes (5 files, no dependency changes)

- **`docs/next.config.mjs`** — `output: 'export'` + `images: { unoptimized: true }`.
- **`docs/app/page.tsx`** — the root `/` used `redirect('/docs')`, which is unsupported under static export (it bakes a broken `__next_error__` page into `index.html`). Replaced with a client redirect shell so `next dev` keeps working; production redirects at the edge (below).
- **`docs/public/_redirects`** — `/  /docs  302`. Copied into `out/` by Next; the Workers asset router honors it **before** asset matching, so the root is a real edge 302.
- **`docs/wrangler.jsonc`** — assets-only config: `directory: ./out`, `html_handling: auto-trailing-slash` (matches Next's flat-file export), `not_found_handling: 404-page` (serves `out/404.html` with a real 404).
- **`.gitignore`** — ignore `.wrangler/`.

No CI workflow and no `wrangler` dependency added — deployment is wired through **Cloudflare's native git integration** (per your call).

## Deploy setup (Cloudflare dashboard, one-time)

Connect this repo in **Workers & Pages → Create → Workers → Connect to Git**, then:

| Setting | Value |
|---|---|
| Root directory | `docs` |
| Build command | `pnpm install --frozen-lockfile && pnpm --filter docs build` |
| Deploy command | `npx wrangler deploy` |

Cloudflare reads `docs/wrangler.jsonc` and uploads `docs/out`. Bind the custom domain under **Settings → Domains & Routes** (placeholder `docs.chimely.dev` noted in the config).

> Remember to disconnect the existing Vercel project / repoint DNS once the Worker is live. (No Vercel config existed in-repo — it was dashboard-managed.)

## Verification

Built the static export and exercised the **real Workers runtime** via `wrangler dev`:

- `/` → **302** → `/docs`
- `/docs` → **200** (title "Overview")
- `/docs/quickstart` → **200**
- deep `/docs/api/admin/adminMe` → **200**
- `/docs/quickstart.html` → **307** normalized → `/docs/quickstart`
- unknown path → **404** serving `404.html`
- `/_redirects` not exposed as an asset → **404**

`tsc --noEmit` and `biome check` pass on the changed files.