### PR TITLE
feat(cli): add `npx chimely dev` zero-config launcher

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,32 @@
+# @chimely/cli
+
+Zero-config local launcher for [Chimely](https://github.com/dodopayments/chimely).
+
+```bash
+npx chimely dev
+```
+
+Boots a throwaway Chimely server backed by an **embedded Postgres** and **no
+Redis** (hints ride Postgres `LISTEN/NOTIFY`). It seeds a `dev` environment with
+a copy-pasteable API key and a root admin, prints a banner with the server URL
+and credentials, and discards the database on exit.
+
+## How it works
+
+`chimely` is a thin wrapper. It locates the `chimely` server binary and execs
+`chimely dev`, forwarding arguments, stdio, and signals. The binary is resolved
+in this order:
+
+1. `CHIMELY_BIN` — an explicit path to a `chimely` binary.
+2. `CARGO_TARGET_DIR/{release,debug}/chimely` — a contributor's shared target.
+3. `<repo>/server/target/{release,debug}/chimely` — a monorepo dev build.
+
+> Prebuilt per-platform binaries are not published yet. Until they are, build
+> from source with `cargo build --features dev` (inside `server/`), or point
+> `CHIMELY_BIN` at a binary. The `dev` subcommand requires a build compiled with
+> `--features dev`.
+
+## Not for production
+
+`chimely dev` is a local convenience. Run the real server (`chimely serve`) with
+your own Postgres via Docker or your platform of choice.

--- a/packages/cli/bin/chimely.mjs
+++ b/packages/cli/bin/chimely.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { resolveBinary } from '../src/resolve.mjs';
+
+// Thin launcher: find the chimely server binary and hand off to it, forwarding
+// arguments, stdio, and termination signals. `npx chimely` with no argument
+// defaults to `dev` (the zero-config local server).
+function main() {
+  let binary;
+  try {
+    binary = resolveBinary();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
+    return;
+  }
+
+  const args = process.argv.slice(2);
+  const forwarded = args.length > 0 ? args : ['dev'];
+
+  const child = spawn(binary, forwarded, { stdio: 'inherit' });
+
+  for (const signal of ['SIGINT', 'SIGTERM']) {
+    process.on(signal, () => {
+      if (child.exitCode === null) child.kill(signal);
+    });
+  }
+
+  child.on('error', (error) => {
+    process.stderr.write(`failed to launch chimely: ${error.message}\n`);
+    process.exit(1);
+  });
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(code ?? 0);
+  });
+}
+
+main();

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@chimely/cli",
+  "version": "0.0.0",
+  "description": "Zero-config local launcher for Chimely: `npx chimely dev`.",
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "chimely": "bin/chimely.mjs"
+  },
+  "files": [
+    "bin",
+    "src",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.8"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/that-ambuj/chimely.git",
+    "directory": "packages/cli"
+  }
+}

--- a/packages/cli/src/resolve.mjs
+++ b/packages/cli/src/resolve.mjs
@@ -1,0 +1,61 @@
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+/**
+ * Resolve the path to the `chimely` server binary, in priority order:
+ *   1. $CHIMELY_BIN                          explicit override
+ *   2. $CARGO_TARGET_DIR/{release,debug}     a contributor's shared cargo target
+ *   3. <repo>/server/target/{release,debug}  a monorepo dev build (walking up)
+ * Returns the first path that exists, or throws with actionable guidance.
+ *
+ * Prebuilt release binaries are not published yet; once they are, a download
+ * step slots in ahead of the monorepo lookups. `env` and `startDir` are
+ * injectable so the resolution order is unit-testable without a real tree.
+ */
+export function resolveBinary({ env = process.env, startDir = process.cwd() } = {}) {
+  const override = env.CHIMELY_BIN;
+  if (override) {
+    if (existsSync(override)) return override;
+    throw new Error(`CHIMELY_BIN is set to ${override} but no file exists there.`);
+  }
+
+  const exe = process.platform === 'win32' ? 'chimely.exe' : 'chimely';
+  const candidates = [];
+
+  if (env.CARGO_TARGET_DIR) {
+    for (const profile of ['release', 'debug']) {
+      candidates.push(join(env.CARGO_TARGET_DIR, profile, exe));
+    }
+  }
+  for (const dir of ancestors(startDir)) {
+    for (const profile of ['release', 'debug']) {
+      candidates.push(join(dir, 'server', 'target', profile, exe));
+    }
+  }
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+
+  throw new Error(
+    [
+      'Could not find the chimely server binary.',
+      '',
+      'Prebuilt binaries are not published yet. To run the dev server now:',
+      '  - build from source:  cargo build --features dev   (run inside server/), or',
+      '  - point at a binary:  CHIMELY_BIN=/path/to/chimely npx chimely dev',
+    ].join('\n'),
+  );
+}
+
+/** Yield `start` and each ancestor directory up to and including the filesystem root. */
+function* ancestors(start) {
+  let dir = resolve(start);
+  let parent = dirname(dir);
+  while (parent !== dir) {
+    yield dir;
+    dir = parent;
+    parent = dirname(dir);
+  }
+  yield dir;
+}

--- a/packages/cli/test/resolve.test.mjs
+++ b/packages/cli/test/resolve.test.mjs
@@ -1,0 +1,63 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveBinary } from '../src/resolve.mjs';
+
+const exe = process.platform === 'win32' ? 'chimely.exe' : 'chimely';
+const cleanups = [];
+
+afterEach(() => {
+  while (cleanups.length > 0) cleanups.pop()();
+});
+
+function tempDir() {
+  const dir = mkdtempSync(join(tmpdir(), 'chimely-cli-'));
+  cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+function touch(path) {
+  writeFileSync(path, '');
+  return path;
+}
+
+describe('resolveBinary', () => {
+  it('prefers CHIMELY_BIN when the file exists', () => {
+    const dir = tempDir();
+    const bin = touch(join(dir, 'my-chimely'));
+    expect(resolveBinary({ env: { CHIMELY_BIN: bin }, startDir: dir })).toBe(bin);
+  });
+
+  it('throws when CHIMELY_BIN points at a missing file', () => {
+    expect(() =>
+      resolveBinary({ env: { CHIMELY_BIN: join(tempDir(), 'nope') }, startDir: tempDir() }),
+    ).toThrow(/CHIMELY_BIN/);
+  });
+
+  it('honors CARGO_TARGET_DIR', () => {
+    const dir = tempDir();
+    const target = join(dir, 'shared-target', 'debug');
+    mkdirSync(target, { recursive: true });
+    const bin = touch(join(target, exe));
+    expect(
+      resolveBinary({ env: { CARGO_TARGET_DIR: join(dir, 'shared-target') }, startDir: dir }),
+    ).toBe(bin);
+  });
+
+  it('finds a monorepo build under server/target, walking up from a nested dir', () => {
+    const dir = tempDir();
+    const target = join(dir, 'server', 'target', 'debug');
+    mkdirSync(target, { recursive: true });
+    const bin = touch(join(target, exe));
+    const nested = join(dir, 'packages', 'cli');
+    mkdirSync(nested, { recursive: true });
+    expect(resolveBinary({ env: {}, startDir: nested })).toBe(bin);
+  });
+
+  it('throws actionable guidance when nothing is found', () => {
+    expect(() => resolveBinary({ env: {}, startDir: tempDir() })).toThrow(
+      /Prebuilt binaries are not published/,
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,12 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  packages/cli:
+    devDependencies:
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.2)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0))
+
   packages/client:
     devDependencies:
       tsup:
@@ -4327,7 +4333,7 @@ snapshots:
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
@@ -4358,7 +4364,7 @@ snapshots:
 
   '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -4368,7 +4374,7 @@ snapshots:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -4407,7 +4413,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7':
+  '@babel/traverse@7.29.7(supports-color@10.2.2)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +433,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "postgresql_embedded",
  "proptest",
  "rand 0.9.4",
  "reqwest 0.12.28",
@@ -474,6 +481,16 @@ name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -573,6 +590,15 @@ name = "crc16"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-epoch"
@@ -830,6 +856,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "float-cmp"
@@ -1544,6 +1580,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,6 +1842,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -2054,6 +2149,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,6 +2165,64 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "postgresql_archive"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf41d656e8c357185ccab494989fad336a9eb16ebd689fcf4efce35a9a55726a"
+dependencies = [
+ "async-trait",
+ "flate2",
+ "futures-util",
+ "hex",
+ "regex-lite",
+ "reqwest 0.13.4",
+ "reqwest-middleware",
+ "reqwest-retry",
+ "reqwest-tracing",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tar",
+ "target-triple",
+ "tempfile",
+ "thiserror",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "postgresql_commands"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af4eb3d074b22c7f07e35ab891093c48dc1f9514a52e54b250a1ae47f311df3"
+dependencies = [
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "postgresql_embedded"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec95242c7e52d7a286f35f10cf143f5fb02255bbdd41b5b2eba05dbbcd79334"
+dependencies = [
+ "anyhow",
+ "postgresql_archive",
+ "postgresql_commands",
+ "rand 0.10.1",
+ "semver",
+ "sqlx",
+ "target-triple",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2222,6 +2381,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -2451,6 +2611,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2494,7 +2660,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
 ]
@@ -2510,24 +2676,97 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
  "web-sys",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest 0.13.4",
+ "serde",
+ "thiserror",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe2412db2af7d2268e7a5406be0431f37d9eb67ff390f35b395716f5f06c2eaa"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "getrandom 0.2.17",
+ "http",
+ "hyper",
+ "reqwest 0.13.4",
+ "reqwest-middleware",
+ "retry-policies",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "wasmtimer",
+]
+
+[[package]]
+name = "reqwest-tracing"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e5af0cd6fc3d3c8f703d597af70b6e4e62432c63157b49419fa1ffaf481702"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "getrandom 0.2.17",
+ "http",
+ "matchit",
+ "reqwest 0.13.4",
+ "reqwest-middleware",
+ "tracing",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47"
+dependencies = [
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -2586,6 +2825,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2635,6 +2883,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -2945,6 +3220,28 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -3261,6 +3558,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3407,6 +3721,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.4",
@@ -3987,6 +4302,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3996,6 +4324,20 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4016,6 +4358,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -62,6 +62,14 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
 utoipa = { version = "5.5.0", features = ["yaml", "chrono", "uuid"] }
 utoipa-scalar = { version = "0.3.0", features = ["axum"] }
 uuid = { version = "1.18.1", features = ["v7", "serde"] }
+# Embedded Postgres for `chimely dev` (feature `dev`, off by default so the
+# production binary and image never link it). rustls keeps the dependency tree
+# OpenSSL-free and permissive; theseus binaries download and cache on first run.
+postgresql_embedded = { version = "0.20.4", default-features = false, features = ["rustls", "tokio", "theseus"], optional = true }
+
+[features]
+# `chimely dev`: zero-config local launcher (embedded Postgres, Redis-less serve).
+dev = ["dep:postgresql_embedded"]
 
 [dev-dependencies]
 proptest = "1.8.0"

--- a/server/deny.toml
+++ b/server/deny.toml
@@ -7,6 +7,12 @@
 # dependency must be flagged and explicitly allowed here with a comment,
 # never waved through silently.
 
+[graph]
+# Resolve every feature so the gate also sees optional-feature deps (the `dev`
+# launcher pulls postgresql_embedded). Without this the CI `check licenses`
+# graph is default-features only and never inspects them.
+all-features = true
+
 [licenses]
 allow = [
     "MIT",
@@ -19,6 +25,9 @@ allow = [
     "BSL-1.0",
     "Unicode-3.0",
     "CDLA-Permissive-2.0",
+    # postgresql_embedded (server `dev` feature) is (Apache-2.0 OR MIT) AND
+    # PostgreSQL. The PostgreSQL license is a permissive BSD-style license.
+    "PostgreSQL",
 ]
 # Our own crate is the only copyleft code allowed in the graph.
 exceptions = [

--- a/server/src/dev.rs
+++ b/server/src/dev.rs
@@ -1,0 +1,140 @@
+//! `chimely dev`: a zero-config local launcher.
+//!
+//! Boots an ephemeral embedded Postgres (postgresql_embedded, theseus binaries
+//! cached under the user data dir on first run) and runs the normal serve path
+//! in Redis-less mode, where hints ride Postgres LISTEN/NOTIFY. It seeds a `dev`
+//! environment with a copy-pasteable API key and a root admin, prints a banner,
+//! and discards the database on exit. Compiles only under the `dev` feature.
+
+use anyhow::Context as _;
+use postgresql_embedded::{PostgreSQL, Settings};
+
+/// Ports, generated credentials, and embedded-Postgres settings, decided up
+/// front. Computed synchronously so the environment is fully exported before
+/// any runtime or telemetry thread starts.
+pub struct Plan {
+    settings: Settings,
+    pub server_addr: String,
+    pub api_key: String,
+    pub admin_email: String,
+    pub admin_password: String,
+    pub database_url: String,
+}
+
+/// Pick ports, generate credentials, and export the environment `serve()` reads.
+///
+/// Must run in `main()` before the tokio runtime and telemetry initialise: it
+/// mutates the process environment, which is only sound while single-threaded.
+pub fn plan() -> anyhow::Result<Plan> {
+    let pg_port = free_port().context("allocating a Postgres port")?;
+    let server_port = free_port().context("allocating a server port")?;
+    let server_addr = format!("127.0.0.1:{server_port}");
+    let api_key = format!("chimely_dev_{}", token());
+    let admin_email = "admin@chimely.dev".to_string();
+    let admin_password = token();
+
+    let settings = Settings {
+        host: "127.0.0.1".to_string(),
+        port: pg_port,
+        username: "postgres".to_string(),
+        password: "postgres".to_string(),
+        temporary: true,
+        // Governs each embedded-Postgres command (initdb, pg_ctl). The crate
+        // default is 5s, which initdb blows past on a cold or busy machine.
+        timeout: Some(std::time::Duration::from_secs(120)),
+        ..Settings::default()
+    };
+    let database_url = settings.url("chimely");
+
+    // SAFETY: `plan()` runs in `main()` before the tokio runtime, telemetry, or
+    // any worker thread exists, so nothing can read the environment
+    // concurrently. `serve()` consumes these via `Config::from_env()`.
+    unsafe {
+        std::env::set_var("DATABASE_URL", &database_url);
+        std::env::remove_var("REDIS_URL");
+        std::env::set_var("CHIMELY_LISTEN_ADDR", &server_addr);
+        std::env::set_var("CHIMELY_DEV_ENVIRONMENT", "dev");
+        std::env::set_var("CHIMELY_DEV_API_KEY", &api_key);
+        std::env::set_var("CHIMELY_ADMIN_EMAIL", &admin_email);
+        std::env::set_var("CHIMELY_ADMIN_PASSWORD", &admin_password);
+        std::env::set_var("CHIMELY_ADMIN_TLS_TERMINATED", "false");
+        // Snappy Ctrl-C for a local launcher: no load balancer to drain.
+        std::env::set_var("CHIMELY_SHUTDOWN_GRACE_MS", "0");
+    }
+
+    Ok(Plan {
+        settings,
+        server_addr,
+        api_key,
+        admin_email,
+        admin_password,
+        database_url,
+    })
+}
+
+/// Download (first run only), initialise, and start the embedded Postgres, then
+/// ensure the `chimely` database exists. The returned handle stops and discards
+/// the instance on `stop()` or drop.
+pub async fn start_postgres(plan: &Plan) -> anyhow::Result<PostgreSQL> {
+    let mut pg = PostgreSQL::new(plan.settings.clone());
+    eprintln!("Starting embedded Postgres (first run downloads it, then it is cached)...");
+    pg.setup()
+        .await
+        .map_err(|e| anyhow::anyhow!("embedded Postgres setup failed: {e}"))?;
+    pg.start()
+        .await
+        .map_err(|e| anyhow::anyhow!("starting embedded Postgres failed: {e}"))?;
+    let exists = pg
+        .database_exists("chimely")
+        .await
+        .map_err(|e| anyhow::anyhow!("checking for the chimely database failed: {e}"))?;
+    if !exists {
+        pg.create_database("chimely")
+            .await
+            .map_err(|e| anyhow::anyhow!("creating the chimely database failed: {e}"))?;
+    }
+    Ok(pg)
+}
+
+/// Human-facing banner: server URL, the ready-to-paste API key, and the admin
+/// login. Printed to stderr so stdout stays usable for piping.
+pub fn print_banner(plan: &Plan) {
+    let url = format!("http://{}", plan.server_addr);
+    eprintln!();
+    eprintln!("  Chimely dev server is up.");
+    eprintln!();
+    eprintln!("    API + docs   {url}");
+    eprintln!(
+        "    Admin UI     {url}/admin   ({} / {})",
+        plan.admin_email, plan.admin_password
+    );
+    eprintln!("    Environment  dev   (subscriber hashes not required)");
+    eprintln!("    API key      {}", plan.api_key);
+    eprintln!();
+    eprintln!("  Send your first notification:");
+    eprintln!();
+    eprintln!("    curl -X POST {url}/v1/notifications \\");
+    eprintln!("      -H 'Authorization: Bearer {}' \\", plan.api_key);
+    eprintln!("      -d '{{\"subscriber_id\":\"usr_1\",\"category\":\"welcome\"}}'");
+    eprintln!();
+    eprintln!("  Ephemeral Postgres, Redis-less. Ctrl-C to stop (data is discarded).");
+    eprintln!();
+}
+
+/// Bind an ephemeral port on loopback and hand back the number the OS chose.
+/// The listener is dropped immediately; a brief TOCTOU window is acceptable for
+/// a local dev launcher.
+fn free_port() -> anyhow::Result<u16> {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+    Ok(listener.local_addr()?.port())
+}
+
+/// A short random lowercase-hex token for dev credentials. Long enough to clear
+/// the admin password minimum and to be unguessable on a loopback bind.
+fn token() -> String {
+    use rand::Rng as _;
+    let mut rng = rand::rng();
+    (0..24)
+        .map(|_| char::from_digit(rng.random_range(0..16), 16).expect("nibble is < 16"))
+        .collect()
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -7,6 +7,8 @@ pub mod auth;
 pub mod bootstrap;
 pub mod config;
 pub mod db;
+#[cfg(feature = "dev")]
+pub mod dev;
 pub mod dlq;
 pub mod error;
 pub mod extract;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,9 +1,10 @@
 //! Chimely in-app notification inbox infrastructure.
 //!
-//! Single binary, three entrypoints:
+//! Single binary. Entrypoints:
 //!   `chimely serve`   (default) API plane plus workers
 //!   `chimely openapi`           print the utoipa-generated OpenAPI spec to stdout
 //!   `chimely dlq`               list and replay dead-lettered jobs
+//!   `chimely dev`               zero-config local launcher (feature `dev`)
 
 use std::sync::Arc;
 
@@ -39,8 +40,36 @@ fn main() -> anyhow::Result<()> {
                 .context("building tokio runtime")?
                 .block_on(dlq_command(args.collect()))
         }
+        Some("dev") => {
+            #[cfg(feature = "dev")]
+            {
+                // Compute config and export the environment BEFORE the runtime
+                // or telemetry start: env mutation is only sound single-threaded.
+                let plan = chimely::dev::plan()?;
+                telemetry::init()?;
+                tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .context("building tokio runtime")?
+                    .block_on(async move {
+                        let pg = chimely::dev::start_postgres(&plan).await?;
+                        chimely::dev::print_banner(&plan);
+                        let result = serve().await;
+                        let _ = pg.stop().await;
+                        result
+                    })
+            }
+            #[cfg(not(feature = "dev"))]
+            {
+                eprintln!(
+                    "`chimely dev` is only available in builds compiled with \
+                     --features dev (the npx distribution ships that build)."
+                );
+                std::process::exit(2);
+            }
+        }
         Some(other) => {
-            eprintln!("unknown subcommand: {other}\nusage: chimely [serve|openapi|dlq]");
+            eprintln!("unknown subcommand: {other}\nusage: chimely [serve|openapi|dlq|dev]");
             std::process::exit(2);
         }
     }


### PR DESCRIPTION
## What

Ships `npx chimely dev` — a zero-config local launcher — and the server support behind it.

- **`@chimely/cli`** (new npm package, MIT): a thin Node wrapper that resolves the `chimely` server binary and execs `chimely dev`, forwarding args, stdio, and signals. Resolution order: `CHIMELY_BIN` → `CARGO_TARGET_DIR/{release,debug}` → monorepo `server/target/{release,debug}` (walking up).
- **`chimely dev` subcommand** (server, feature-gated): boots a throwaway server on an **embedded Postgres** (`postgresql_embedded`, theseus binaries cached on first run) with **no Redis** — hints ride Postgres `LISTEN/NOTIFY`. Seeds a `dev` environment with a copy-pasteable API key and a root admin, prints a banner with the URL + credentials + a ready-to-run curl, and discards the database on exit.

## Why

Lowers first-run friction to a single command. This is the implementation behind the homepage's "coming soon" `npx chimely dev` callout.

## Design notes

- The `dev` feature is **off by default**, so the production binary and Docker image never link `postgresql_embedded`. `rustls` (no OpenSSL) keeps the tree permissive.
- `chimely dev` in a non-`dev` build prints guidance and exits `2`.
- Config is computed and exported to the environment **before** the tokio runtime and telemetry start (env mutation is only sound single-threaded), then the normal `serve()` path runs unchanged.
- `deny.toml`: allow the permissive **PostgreSQL** license (the `AND PostgreSQL` term on the embedded-Postgres crates) and set `[graph] all-features = true` so the CI `check licenses` gate actually inspects the `dev`-only subtree instead of skipping optional deps.

## Not yet (follow-ups)

- Prebuilt per-platform binaries aren't published, so the wrapper currently guides contributors to `cargo build --features dev`. A release pipeline + npm postinstall downloader is the next step.
- Flip the homepage "coming soon" badge once prebuilt binaries ship.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` (default **and** `--features dev`): clean.
- `cargo deny check licenses`: ok — now covering the `dev` subtree, `PostgreSQL` allow matched (no unused-allowance warning).
- `@chimely/cli` vitest: 5/5.
- End-to-end smoke: `chimely dev` up in ~6s (cached Postgres), `POST /v1/notifications` → **201**, clean `SIGINT` shutdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)