### PR TITLE
feat(docs): homepage typography refresh + Geist Mono fix

### DIFF
--- a/docs/app/(home)/_components/architecture.tsx
+++ b/docs/app/(home)/_components/architecture.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 
-/** Thin flow arrow — points right on desktop, down on mobile. */
+/** Thin flow arrow, points right on desktop, down on mobile. */
 function FlowArrow() {
   return (
     <svg
@@ -24,7 +24,7 @@ function Connector({ label }: { label?: string }) {
   return (
     <div className="flex shrink-0 flex-col items-center gap-1.5 text-fd-muted-foreground">
       {label ? (
-        <span className="whitespace-nowrap rounded-md bg-[#1264FF]/10 px-2 py-1 font-mono text-[11px] text-[#1264FF]">
+        <span className="whitespace-nowrap rounded-md bg-[#1264FF]/[0.12] px-2 py-1 font-mono text-[11px] font-medium text-[#1264FF]">
           {label}
         </span>
       ) : null}
@@ -37,7 +37,7 @@ function Node({ title, sub, accent }: { title: ReactNode; sub: string; accent?: 
   return (
     <div
       className={
-        'w-full max-w-[260px] rounded-2xl border px-4 py-4 text-center lg:w-auto lg:max-w-[180px] lg:flex-1 ' +
+        'w-full max-w-[260px] rounded-[14px] border px-4 py-4 text-center lg:w-auto lg:max-w-[180px] lg:flex-1 ' +
         (accent
           ? 'border-[#1264FF] bg-[#1264FF]/[0.09] shadow-[0_12px_36px_-18px_rgba(18,100,255,0.7)]'
           : 'border-fd-border bg-fd-card')
@@ -53,8 +53,8 @@ export function Architecture() {
   return (
     <section className="border-t border-fd-border bg-fd-muted/30 px-6 py-24">
       <div className="mx-auto max-w-[1200px]">
-        <h2 className="text-[40px] font-semibold leading-[1.1] tracking-[-0.03em] text-fd-foreground">
-          One service in your stack.
+        <h2 className="chimely-display text-[clamp(2rem,4vw,2.875rem)] leading-[1.08] tracking-[-0.005em] text-fd-foreground">
+          <span className="italic text-[#1264FF]">One</span> service in your stack.
         </h2>
         <p className="mt-4 max-w-[74ch] text-[17px] leading-[1.62] text-fd-muted-foreground">
           Your backend decides what to send and when. Chimely makes it durable, real-time, and
@@ -62,7 +62,7 @@ export function Architecture() {
           for small single-node deployments.
         </p>
 
-        <div className="mt-12 flex flex-col items-center justify-center gap-3 lg:flex-row">
+        <div className="mt-[46px] flex flex-col items-center justify-center gap-2.5 lg:flex-row">
           <Node title="Your backend" sub="decides what & when" />
           <Connector label="POST /v1/notifications" />
           <Node title="Chimely" sub="API + workers" accent />

--- a/docs/app/(home)/_components/closing-cta.tsx
+++ b/docs/app/(home)/_components/closing-cta.tsx
@@ -10,7 +10,7 @@ function ClosingCtas({ stacked }: { stacked?: boolean }) {
     <div className={stacked ? 'flex flex-col gap-3' : 'flex flex-wrap justify-center gap-3'}>
       <a
         href={links.docs}
-        className="inline-flex h-[46px] items-center justify-center gap-2 rounded-xl bg-[#1264FF] px-[22px] text-[15px] font-semibold text-white no-underline shadow-[0_10px_30px_-10px_rgba(18,100,255,0.7)] transition-colors hover:bg-[#0b53e0]"
+        className={`inline-flex h-[46px] items-center justify-center gap-2 rounded-xl bg-[#1264FF] ${stacked ? 'px-6' : 'px-[22px]'} text-[15px] font-semibold text-white no-underline shadow-[0_10px_30px_-10px_rgba(18,100,255,0.7)] transition-colors hover:bg-[#0b53e0]`}
       >
         Get started <ArrowRight className="size-4" />
       </a>
@@ -18,7 +18,7 @@ function ClosingCtas({ stacked }: { stacked?: boolean }) {
         href={links.repo}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex h-[46px] items-center justify-center gap-2 rounded-xl border border-white/20 bg-white/[0.06] px-5 text-[15px] font-semibold text-white no-underline transition-colors hover:bg-white/[0.12]"
+        className={`inline-flex h-[46px] items-center justify-center gap-2 rounded-xl border border-white/20 bg-white/[0.06] ${stacked ? 'px-6' : 'px-5'} text-[15px] font-semibold text-white no-underline transition-colors hover:bg-white/[0.12]`}
       >
         <GitHubIcon className="size-[17px]" /> Star on GitHub
       </a>
@@ -27,7 +27,7 @@ function ClosingCtas({ stacked }: { stacked?: boolean }) {
 }
 
 /**
- * Closing CTA — the page's second shader band (FlutedGlass over a generated
+ * Closing CTA. The page's second shader band (FlutedGlass over a generated
  * abstract image). `variant` selects "centered" or a bordered "inset" panel.
  */
 export function ClosingCTA({ variant = 'centered' }: { variant?: 'centered' | 'inset' }) {
@@ -43,10 +43,10 @@ export function ClosingCTA({ variant = 'centered' }: { variant?: 'centered' | 'i
 
       <div className="relative mx-auto max-w-[1100px] px-6 py-[104px]">
         {variant === 'inset' ? (
-          <div className="flex flex-wrap items-center justify-between gap-7 rounded-[22px] border border-white/[0.16] bg-[#080c0e]/50 p-11 backdrop-blur-md">
+          <div className="flex flex-wrap items-center justify-between gap-7 rounded-[22px] border border-white/[0.16] bg-[#080c0e]/50 p-11 backdrop-blur">
             <div className="min-w-[280px] flex-1">
-              <h2 className="text-balance text-[42px] font-semibold leading-[1.08] tracking-[-0.035em] text-white">
-                Open source. Self-hosted. Yours.
+              <h2 className="chimely-display text-balance text-[clamp(2.25rem,4.4vw,3.125rem)] leading-[1.05] tracking-[-0.01em] text-white">
+                Open source. Self-hosted. <span className="italic">Yours</span>.
               </h2>
               <p className="mt-4 max-w-[54ch] text-[17px] leading-[1.6] text-white/[0.78]">
                 {BODY}
@@ -56,8 +56,8 @@ export function ClosingCTA({ variant = 'centered' }: { variant?: 'centered' | 'i
           </div>
         ) : (
           <div className="flex flex-col items-center gap-5 text-center">
-            <h2 className="max-w-[16ch] text-balance text-[48px] font-semibold leading-[1.07] tracking-[-0.035em] text-white">
-              Open source. Self-hosted. Yours.
+            <h2 className="chimely-display max-w-[16ch] text-balance text-[clamp(2.5rem,5vw,3.5rem)] leading-[1.04] tracking-[-0.01em] text-white">
+              Open source. Self-hosted. <span className="italic">Yours</span>.
             </h2>
             <p className="max-w-[60ch] text-[18px] leading-[1.6] text-white/[0.78]">{BODY}</p>
             <ClosingCtas />

--- a/docs/app/(home)/_components/code-block.tsx
+++ b/docs/app/(home)/_components/code-block.tsx
@@ -13,17 +13,31 @@ export function CodeBlock({
   lang = 'bash',
   code,
   copyLabel,
+  badge,
+  dot,
+  elevated,
   children,
 }: {
   lang?: string;
   code: string;
   copyLabel: string;
+  badge?: ReactNode;
+  dot?: boolean;
+  elevated?: boolean;
   children: ReactNode;
 }) {
   return (
-    <div className="chimely-code overflow-hidden rounded-2xl border border-white/10 shadow-[0_14px_40px_-20px_rgba(0,0,0,0.8)]">
+    <div
+      className={`chimely-code overflow-hidden rounded-[14px] border border-white/10${
+        elevated ? ' shadow-[0_14px_40px_-20px_rgba(0,0,0,0.8)]' : ''
+      }`}
+    >
       <div className="flex items-center justify-between border-b border-white/[0.06] bg-[#0E1117] px-3.5 py-2">
-        <span className="font-mono text-xs tracking-tight text-zinc-500">{lang}</span>
+        <span className="inline-flex items-center gap-2">
+          {dot ? <span className="size-[7px] shrink-0 rounded-full bg-[#1264FF]" /> : null}
+          <span className="font-mono text-xs font-medium text-[#8B949E]">{lang}</span>
+          {badge}
+        </span>
         <CopyButton text={code} label={copyLabel} />
       </div>
       {/* whitespace-pre + overflow-x-auto => code scrolls horizontally, never wraps */}

--- a/docs/app/(home)/_components/code-proof.tsx
+++ b/docs/app/(home)/_components/code-proof.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { CodeBlock } from './code-block';
 
-// Syntax token colors (neutral palette — deliberately distinct from the brand
+// Syntax token colors (neutral palette, deliberately distinct from the brand
 // semantic colors, which are reserved for state).
 const C = {
   str: '#7EE0A6',
@@ -36,7 +36,7 @@ export function CodeProof() {
   return (
     <div className="flex w-full min-w-0 flex-col gap-4">
       <div className="grid w-full min-w-0 gap-3.5 [grid-template-columns:repeat(auto-fit,minmax(290px,1fr))]">
-        <CodeBlock lang="Server · bash" code={CURL} copyLabel="Copy server snippet">
+        <CodeBlock lang="Server · bash" code={CURL} copyLabel="Copy server snippet" dot elevated>
           <Line>
             <T c={C.fn}>curl</T> <T c={C.punct}>-X</T> POST{' '}
             <T c={C.str}>https://your-app.com/v1/notifications</T> <T c={C.punct}>\</T>
@@ -81,7 +81,7 @@ export function CodeProof() {
           </Line>
         </CodeBlock>
 
-        <CodeBlock lang="Client · tsx" code={INBOX} copyLabel="Copy client snippet">
+        <CodeBlock lang="Client · tsx" code={INBOX} copyLabel="Copy client snippet" dot elevated>
           <Line>
             <T c={C.kw}>import</T> <T c={C.punct}>{'{'}</T> Inbox <T c={C.punct}>{'}'}</T>{' '}
             <T c={C.kw}>from</T> <T c={C.str}>&quot;@chimely/react&quot;</T>

--- a/docs/app/(home)/_components/coming-soon.tsx
+++ b/docs/app/(home)/_components/coming-soon.tsx
@@ -1,0 +1,10 @@
+/** Amber "Coming soon" pill. Marks surfaces that are not shipped yet: the
+ *  `npx chimely dev` CLI (hero inline command + quickstart). Amber #E5C07B is a
+ *  neutral "pending" hue, deliberately not one of the brand state colors. */
+export function ComingSoon() {
+  return (
+    <span className="inline-flex items-center rounded-full border border-[#E5C07B]/30 bg-[#E5C07B]/[0.12] px-2 py-0.5 font-mono text-[10px] font-semibold uppercase leading-none tracking-[0.07em] text-[#E5C07B]">
+      Coming soon
+    </span>
+  );
+}

--- a/docs/app/(home)/_components/comparison.tsx
+++ b/docs/app/(home)/_components/comparison.tsx
@@ -12,14 +12,14 @@ export function Comparison() {
   return (
     <section className="border-t border-fd-border bg-fd-background px-6 py-24">
       <div className="mx-auto max-w-[1000px] text-center">
-        <h2 className="text-[40px] font-semibold leading-[1.1] tracking-[-0.03em] text-fd-foreground">
-          Simpler than a notification platform.
+        <h2 className="chimely-display text-[clamp(2rem,4vw,2.875rem)] leading-[1.08] tracking-[-0.005em] text-fd-foreground">
+          <span className="italic text-[#1264FF]">Simpler</span> than a notification platform.
         </h2>
         <p className="mx-auto mt-4 max-w-[74ch] text-[17px] leading-[1.62] text-fd-muted-foreground">
-          Most notification tools model a workflow engine that happens to have an inbox channel —
+          Most notification tools model a workflow engine that happens to have an inbox channel:
           Mongo, several services, and a step-based mental model to learn. Chimely models the inbox
           itself: one binary, one Postgres, one POST. Multi-tenancy is solved the way Plausible
-          solves it — run another instance.
+          solves it. Run another instance.
         </p>
 
         <div className="my-10 grid gap-4 text-left [grid-template-columns:repeat(auto-fit,minmax(260px,1fr))]">

--- a/docs/app/(home)/_components/feature-grid.tsx
+++ b/docs/app/(home)/_components/feature-grid.tsx
@@ -6,7 +6,7 @@ const Mono = ({ children, accent }: { children: ReactNode; accent?: boolean }) =
     className={
       accent
         ? 'font-mono text-[0.88em] text-[#1264FF]'
-        : 'rounded bg-fd-foreground/[0.07] px-1.5 py-px font-mono text-[0.9em] text-fd-foreground'
+        : 'font-mono text-[0.9em] text-fd-foreground'
     }
   >
     {children}
@@ -65,7 +65,7 @@ const features: Feature[] = [
     id: 'small',
     icon: <ScopeIcon className="size-[19px]" />,
     title: 'Deliberately small',
-    body: 'No workflow engine, no server-side templates, no email or SMS. Web-push lands later as another transport for the same notification — not a migration.',
+    body: 'No workflow engine, no server-side templates, no email or SMS. Web-push lands later as another transport for the same notification, not a migration.',
   },
 ];
 
@@ -73,14 +73,16 @@ export function FeatureGrid() {
   return (
     <section className="border-t border-fd-border bg-fd-background px-6 py-24">
       <div className="mx-auto max-w-[1200px]">
-        <h2 className="max-w-[20ch] text-balance text-[40px] font-semibold leading-[1.1] tracking-[-0.03em] text-fd-foreground">
-          Everything an inbox needs. Nothing it doesn&apos;t.
+        <h2 className="chimely-display max-w-[20ch] text-balance text-[clamp(2rem,4vw,2.875rem)] leading-[1.08] tracking-[-0.005em] text-fd-foreground">
+          {'Everything an inbox needs. '}
+          <span className="italic text-[#1264FF]">Nothing</span>
+          {" it doesn't."}
         </h2>
         <div className="mt-12 grid gap-[18px] [grid-template-columns:repeat(auto-fit,minmax(300px,1fr))]">
           {features.map((feature) => (
             <div
               key={feature.id}
-              className="flex flex-col gap-3.5 rounded-2xl border border-fd-border bg-fd-card p-6"
+              className="flex flex-col gap-3.5 rounded-2xl border border-fd-border bg-fd-card px-6 py-[26px]"
             >
               <div className="grid size-[38px] place-items-center rounded-[10px] bg-[#1264FF]/[0.14] text-[#1264FF]">
                 {feature.icon}

--- a/docs/app/(home)/_components/hero.tsx
+++ b/docs/app/(home)/_components/hero.tsx
@@ -1,15 +1,16 @@
 import { CodeProof } from './code-proof';
+import { ComingSoon } from './coming-soon';
 import { CopyButton } from './copy-button';
-import { ArrowRight, ArrowUpRight, GitHubIcon } from './icons';
+import { ArrowRight, GitHubIcon } from './icons';
 import { links } from './links';
 import { HeroGradient, HeroShader, type HeroShaderName } from './shaders/hero-shader';
 
 const SUBHEAD =
-  'The bell, the unread badge, the dropdown list — drop them into your React app with one component, and send notifications from your backend with one API call. Open-source infrastructure you run yourself: a single Rust binary, Postgres, and Redis. No workflow engine, no templates — just the inbox.';
+  'Drop in one React component, send with one API call from your backend. Open-source infrastructure you run yourself.';
 
 function Kicker() {
   return (
-    <span className="inline-flex w-fit items-center gap-2.5 rounded-full border border-white/[0.14] bg-white/[0.04] px-3.5 py-1.5 font-mono text-[12.5px] tracking-wide text-white/70">
+    <span className="inline-flex w-fit items-center gap-2.5 rounded-full border border-white/[0.14] bg-white/[0.04] px-3.5 py-1.5 font-mono text-[12.5px] font-medium tracking-wide text-white/70">
       <span className="size-[7px] rounded-full bg-[#00D87D] shadow-[0_0_0_3px_rgba(0,216,125,0.18)] motion-safe:animate-pulse" />
       Open source · Self-hostable · v0.1.0
     </span>
@@ -33,23 +34,29 @@ function Ctas() {
       >
         <GitHubIcon className="size-[17px]" /> Star on GitHub
       </a>
-      <a
-        href={links.demo}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="inline-flex h-[46px] items-center gap-1.5 rounded-xl px-3.5 text-[15px] font-semibold text-white/80 no-underline transition-colors hover:text-white"
-      >
-        Live demo <ArrowUpRight className="size-[15px]" />
-      </a>
     </>
+  );
+}
+
+/**
+ * The hero headline. Instrument Serif display face with the emphasized word in
+ * true italic (same white as the rest, accent italics are reserved for the
+ * section H2s). `className` carries the per-treatment size / leading / width.
+ */
+function Headline({ className }: { className: string }) {
+  return (
+    <h1 className={`chimely-display text-balance text-white ${className}`}>
+      Give your app a notification <span className="italic">inbox</span>.
+    </h1>
   );
 }
 
 function InlineCommand() {
   return (
-    <div className="inline-flex w-fit items-center gap-3 rounded-xl border border-white/[0.13] bg-black/35 py-2.5 pl-4 pr-2.5 font-mono text-sm">
+    <div className="inline-flex w-fit items-center gap-3 rounded-xl border border-white/[0.13] bg-black/35 py-2.5 pl-4 pr-2.5 font-mono text-sm font-medium">
       <span className="text-[#7EE0A6]">$</span>
       <span className="whitespace-nowrap text-[#E8EAED]">npx chimely dev</span>
+      <ComingSoon />
       <CopyButton
         text="npx chimely dev"
         label="Copy install command"
@@ -100,9 +107,7 @@ function HeroContent({ layout }: { layout: HeroLayout }) {
       <div className="grid grid-cols-1 items-center gap-12 lg:grid-cols-2 lg:gap-[52px]">
         <div className="flex flex-col items-center gap-5 text-center lg:items-start lg:text-left">
           <Kicker />
-          <h1 className="text-balance text-[clamp(2.1rem,5vw,3.5rem)] font-semibold leading-[1.05] tracking-[-0.035em] text-white">
-            Give your app a notification inbox.
-          </h1>
+          <Headline className="text-[clamp(2.75rem,5.4vw,4.125rem)] leading-[1.03] tracking-[-0.01em]" />
           <p className="max-w-[54ch] text-[18px] leading-[1.62] text-white/70">{SUBHEAD}</p>
           <div className="flex flex-wrap justify-center gap-3 lg:justify-start">
             <Ctas />
@@ -120,9 +125,7 @@ function HeroContent({ layout }: { layout: HeroLayout }) {
     return (
       <div className="flex flex-col items-start gap-6 text-left">
         <Kicker />
-        <h1 className="max-w-[18ch] text-balance text-[clamp(2.3rem,5.4vw,3.75rem)] font-semibold leading-[1.04] tracking-[-0.035em] text-white">
-          Give your app a notification inbox.
-        </h1>
+        <Headline className="max-w-[18ch] text-[clamp(2.875rem,5.6vw,4.375rem)] leading-[1.02] tracking-[-0.01em]" />
         <p className="max-w-[60ch] text-[19px] leading-[1.62] text-white/70">{SUBHEAD}</p>
         <div className="flex flex-wrap justify-start gap-3">
           <Ctas />
@@ -139,9 +142,7 @@ function HeroContent({ layout }: { layout: HeroLayout }) {
     return (
       <div className="flex flex-col items-center gap-6 text-center">
         <Kicker />
-        <h1 className="max-w-[15ch] text-balance text-[clamp(2.7rem,7vw,4.6rem)] font-semibold leading-[1.02] tracking-[-0.04em] text-white">
-          Give your app a notification inbox.
-        </h1>
+        <Headline className="max-w-[15ch] text-[clamp(3rem,7vw,5.5rem)] leading-[1] tracking-[-0.01em]" />
         <p className="max-w-[60ch] text-[19px] leading-[1.62] text-white/70">{SUBHEAD}</p>
         <div className="mt-0.5 flex flex-wrap justify-center gap-3">
           <Ctas />
@@ -155,9 +156,7 @@ function HeroContent({ layout }: { layout: HeroLayout }) {
   return (
     <div className="flex flex-col items-center gap-6 text-center">
       <Kicker />
-      <h1 className="max-w-[14ch] text-balance text-[clamp(2.45rem,6vw,4rem)] font-semibold leading-[1.04] tracking-[-0.035em] text-white">
-        Give your app a notification inbox.
-      </h1>
+      <Headline className="max-w-[14ch] text-[clamp(2.875rem,6vw,4.75rem)] leading-[1.02] tracking-[-0.01em]" />
       <p className="max-w-[62ch] text-[19px] leading-[1.62] text-white/70">{SUBHEAD}</p>
       <div className="mt-0.5 flex flex-wrap justify-center gap-3">
         <Ctas />

--- a/docs/app/(home)/_components/links.ts
+++ b/docs/app/(home)/_components/links.ts
@@ -7,7 +7,6 @@ export const links = {
   quickstart: '/docs/quickstart',
   comparison: '/comparison',
   repo: 'https://github.com/dodopayments/chimely',
-  demo: 'https://demo.chimely.dev',
   dodo: 'https://dodopayments.com',
   twitter: 'https://x.com/dodopayments',
 } as const;

--- a/docs/app/(home)/_components/quickstart.tsx
+++ b/docs/app/(home)/_components/quickstart.tsx
@@ -1,4 +1,5 @@
 import { CodeBlock } from './code-block';
+import { ComingSoon } from './coming-soon';
 import { ArrowRight } from './icons';
 import { links } from './links';
 
@@ -6,13 +7,18 @@ export function Quickstart() {
   return (
     <section className="border-t border-fd-border bg-fd-muted/30 px-6 py-24">
       <div className="mx-auto max-w-[1000px]">
-        <h2 className="text-[40px] font-semibold leading-[1.1] tracking-[-0.03em] text-fd-foreground">
-          Up and running in two commands.
+        <h2 className="chimely-display text-[clamp(2rem,4vw,2.875rem)] leading-[1.08] tracking-[-0.005em] text-fd-foreground">
+          Up and running in <span className="italic text-[#1264FF]">two</span> commands.
         </h2>
 
         <div className="mt-11 grid gap-[18px] [grid-template-columns:repeat(auto-fit,minmax(310px,1fr))]">
           <div className="flex flex-col gap-3.5">
-            <CodeBlock lang="bash" code="npx chimely dev" copyLabel="Copy npx command">
+            <CodeBlock
+              lang="bash"
+              code="npx chimely dev"
+              copyLabel="Copy npx command"
+              badge={<ComingSoon />}
+            >
               <span className="text-[#7EE0A6]">$</span> npx chimely dev
             </CodeBlock>
             <p className="text-sm leading-relaxed text-fd-muted-foreground">

--- a/docs/app/(home)/_components/shaders/fluted-glass-band.tsx
+++ b/docs/app/(home)/_components/shaders/fluted-glass-band.tsx
@@ -4,7 +4,7 @@ import dynamic from 'next/dynamic';
 import { useEffect, useRef, useState } from 'react';
 
 /**
- * Second (and final) shader on the page — keep the total at two instances to stay
+ * Second (and final) shader on the page. Keep the total at two instances to stay
  * under the browser's WebGL-context cap. Client-only (ssr: false) and mounted
  * lazily: it only initializes once the closing band nears the viewport. Under
  * prefers-reduced-motion it never mounts. In both cases the parent section's own

--- a/docs/app/(home)/_components/shaders/hero-shader.tsx
+++ b/docs/app/(home)/_components/shaders/hero-shader.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react';
 /**
  * Hero background shaders (@paper-design/shaders-react, pinned 0.0.76).
  * WebGL/canvas + client-only: each is loaded with ssr:false so it never runs
- * during SSR/hydration. This is the eager, above-the-fold shader — keep the page
+ * during SSR/hydration. This is the eager, above-the-fold shader. Keep the page
  * total at two shader instances (this + the closing FlutedGlass) to stay under
  * the browser WebGL-context cap.
  */
@@ -68,7 +68,7 @@ export function HeroShader({ shader = 'panels' }: { shader?: HeroShaderName }) {
   if (shader === 'warp') {
     return <Warp colors={['#04070a', '#004F32', '#1264FF']} speed={0.5} scale={1} style={FILL} />;
   }
-  // panels (default) — the brief's ColorPanels preset
+  // panels (default), the brief's ColorPanels preset
   return (
     <ColorPanels
       colors={['#1467ff']}

--- a/docs/app/(home)/_components/site-footer.tsx
+++ b/docs/app/(home)/_components/site-footer.tsx
@@ -67,10 +67,10 @@ export function SiteFooter() {
         </nav>
       </div>
 
-      {/* Pre-1.0 disclaimer — kept visually quiet */}
+      {/* Pre-1.0 disclaimer, kept visually quiet */}
       <div className="mx-auto mt-7 max-w-[1200px] border-t border-fd-border pt-5">
         <p className="max-w-[80ch] font-mono text-[12.5px] leading-relaxed text-fd-muted-foreground/70">
-          Chimely is at v0.1.0 — the HTTP API and SDK surface may still change on minor releases
+          Chimely is at v0.1.0. The HTTP API and SDK surface may still change on minor releases
           until 1.0. Pin your versions.
         </p>
       </div>

--- a/docs/app/(home)/_components/site-header.tsx
+++ b/docs/app/(home)/_components/site-header.tsx
@@ -20,7 +20,7 @@ export function SiteHeader() {
   return (
     <header className="sticky top-0 z-50 border-b border-fd-border bg-fd-background/75 backdrop-blur-md">
       <div className="mx-auto flex h-[60px] max-w-[1200px] items-center justify-between gap-3.5 px-5">
-        {/* Org-namespaced wordmark — Dodo Payments logo + breadcrumb */}
+        {/* Org-namespaced wordmark: Dodo Payments logo + breadcrumb */}
         <div className="flex min-w-0 items-center gap-2 whitespace-nowrap">
           <a
             href={links.dodo}
@@ -29,7 +29,7 @@ export function SiteHeader() {
             aria-label="Dodo Payments"
             className="flex items-center gap-2 no-underline transition-opacity hover:opacity-80"
           >
-            {/* Authentic Dodo Payments mark — see public/chimely/logo-dodo.svg */}
+            {/* Authentic Dodo Payments mark, see public/chimely/logo-dodo.svg */}
             {/* biome-ignore lint/performance/noImgElement: inline SVG brand mark; next/image adds no value and keeps the home route framework-portable */}
             <img
               src="/chimely/logo-dodo.svg"
@@ -38,9 +38,6 @@ export function SiteHeader() {
               height={22}
               className="block size-[22px]"
             />
-            <span className="text-[15px] font-semibold tracking-tight text-fd-muted-foreground">
-              Dodo Payments
-            </span>
           </a>
           <span className="text-[15px] text-fd-muted-foreground/60">/</span>
           <a href={links.docs} className="no-underline transition-opacity hover:opacity-80">

--- a/docs/app/(home)/fonts.ts
+++ b/docs/app/(home)/fonts.ts
@@ -1,13 +1,29 @@
-import { Geist_Mono } from 'next/font/google';
+import { Geist_Mono, Instrument_Serif } from 'next/font/google';
 
 /**
  * Geist Mono powers all monospace / code on the home page. `home.css` maps
- * Tailwind's `--font-mono` to this `--font-geist-mono` variable, and the
- * variable class is applied on the page's <main> (see page.tsx).
+ * Tailwind's `--font-mono` to this `--font-geist-mono` variable inside the
+ * `.chimely-home` scope, and both the variable class and `.chimely-home` sit
+ * on the page's <main> (see page.tsx) so the mapping resolves in the same
+ * scope where the variable is defined.
  */
 export const geistMono = Geist_Mono({
   subsets: ['latin'],
   weight: ['400', '500', '600'],
   variable: '--font-geist-mono',
+  display: 'swap',
+});
+
+/**
+ * Instrument Serif is the display face for every headline (hero + section
+ * H2s + closing). Loaded at 400 with a real italic so the emphasized word in
+ * each heading renders in the true italic, not a synthesized slant. `home.css`
+ * consumes `--font-instrument-serif` in the `.chimely-display` utility.
+ */
+export const instrumentSerif = Instrument_Serif({
+  subsets: ['latin'],
+  weight: '400',
+  style: ['normal', 'italic'],
+  variable: '--font-instrument-serif',
   display: 'swap',
 });

--- a/docs/app/(home)/home.css
+++ b/docs/app/(home)/home.css
@@ -1,5 +1,5 @@
 /*
- * Chimely home page — brand additions on top of Fumadocs' theme.
+ * Chimely home page. Brand additions on top of Fumadocs' theme.
  *
  * Fumadocs (fumadocs-ui) already provides the light + dark `fd-*` design tokens
  * (--color-fd-background, --color-fd-foreground, --color-fd-muted-foreground,
@@ -15,8 +15,23 @@
   --chimely-accent: #1264ff;
   --chimely-accent-hover: #0b53e0;
   --chimely-accent-deep: #004f32;
-  /* Route Tailwind's monospace utilities to Geist Mono (loaded in fonts.ts). */
+}
+
+/*
+ * The next/font variables (--font-geist-mono, --font-instrument-serif) are only
+ * defined on <main> via the font `variable` classes, so the --font-mono mapping
+ * has to live in the same scope. Declaring it at :root would resolve
+ * var(--font-geist-mono) against a scope where it is undefined, invalidating the
+ * whole value (fallbacks included) and dropping code back to the inherited font.
+ */
+.chimely-home {
   --font-mono: var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+/* Display face for every headline. Real italic ships in the font (see fonts.ts). */
+.chimely-display {
+  font-family: var(--font-instrument-serif), Georgia, "Times New Roman", serif;
+  font-weight: 400;
 }
 
 /* Code panels stay dark in both light and dark themes. */

--- a/docs/app/(home)/layout.tsx
+++ b/docs/app/(home)/layout.tsx
@@ -6,7 +6,7 @@ import './home.css';
  *
  * The standard Fumadocs <RootProvider> (in your root `app/layout.tsx`) already
  * supplies the theme (next-themes) and the ⌘K search context that the page's
- * header uses — nothing extra is needed here.
+ * header uses. Nothing extra is needed here.
  *
  * This page renders its own <SiteHeader>, so we intentionally do NOT mount
  * Fumadocs' <HomeLayout> nav. If you'd rather use Fumadocs' shared nav/footer,

--- a/docs/app/(home)/page.tsx
+++ b/docs/app/(home)/page.tsx
@@ -6,11 +6,13 @@ import { Hero } from './_components/hero';
 import { Quickstart } from './_components/quickstart';
 import { SiteFooter } from './_components/site-footer';
 import { SiteHeader } from './_components/site-header';
-import { geistMono } from './fonts';
+import { geistMono, instrumentSerif } from './fonts';
 
 export default function HomePage() {
   return (
-    <main className={`${geistMono.variable} bg-fd-background text-fd-foreground`}>
+    <main
+      className={`${geistMono.variable} ${instrumentSerif.variable} chimely-home bg-fd-background text-fd-foreground`}
+    >
       <SiteHeader />
 
       {/*


### PR DESCRIPTION
Refreshes the docs homepage (`docs/app/(home)`) to the updated Claude Design (`Chimely Home.dc.html`), plus fixes and review feedback from this session.

## Highlights
- **Instrument Serif display headings** with an italic emphasis word — hero *inbox*, and *Nothing* / *One* / *Simpler* / *two* (accent) / *Yours* — loaded via `next/font`, applied through a `.chimely-display` utility.
- **Fix: code was not rendering in Geist Mono.** `--font-mono` was mapped at `:root`, but the `next/font` variable is only defined on `<main>`, so `var(--font-geist-mono)` resolved out of scope and invalidated the whole value (fallbacks included) — code fell back to the inherited sans font. Moved the mapping into a `.chimely-home` scope on `<main>`. Verified in-browser (`getComputedStyle` on a code element now reports Geist Mono).
- **Shorter hero subtitle**; **removed the Live demo link** (no demo deployment yet).
- **No em-dashes** in copy or comments.
- **"Coming soon" badges** on `npx chimely dev` (hero + quickstart).
- **Logo-only header wordmark** (matches the design and footer) plus minor fidelity tweaks (code-panel status dots, plain inline mono, exact radii/padding/blur), from a section-by-section audit against the design file.

## Verification
- `biome check` and `tsc --noEmit` clean.
- Walked the full page in the dev server (hero → footer), light default theme.

## Notes
- Treatments kept as the current `Hero layout="left" shader="mesh"` + `ClosingCTA variant="inset"`.
- Not included: the closing `FlutedGlass` shader logs a benign, transient `WebGL 1281` on mount (an image-decode race inside `@paper-design/shaders@0.0.76`, not our asset/code) — left as-is pending a decision on whether to keep the shader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
