### PR TITLE
chore(release): version SDK packages to 0.1.0

### DIFF
--- a/.changeset/comment-and-lint-cleanup.md
+++ b/.changeset/comment-and-lint-cleanup.md
@@ -1,7 +1,0 @@
----
-'@chimely/client': patch
-'@chimely/react': patch
-'docs': patch
----
-
-Comment and JSDoc cleanup. No API, type, or behavior change.

--- a/.changeset/error-contract-types.md
+++ b/.changeset/error-contract-types.md
@@ -1,9 +1,0 @@
----
-'@chimely/client': patch
-'@chimely/react': patch
-'docs': patch
----
-
-Regenerate client types from the documented error contract: `Error.code` is now
-a typed enum of the stable error codes, and the inbox stream declares its 429
-(`too_many_connections`) response. Repository URLs point at dodopayments/chimely.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,10 @@
+# docs
+
+## 0.0.1
+
+### Patch Changes
+
+- bb1f022: Comment and JSDoc cleanup. No API, type, or behavior change.
+- 12e5a50: Regenerate client types from the documented error contract: `Error.code` is now
+  a typed enum of the stable error codes, and the inbox stream declares its 429
+  (`too_many_connections`) response. Repository URLs point at dodopayments/chimely.

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/examples/nextjs/CHANGELOG.md
+++ b/examples/nextjs/CHANGELOG.md
@@ -1,0 +1,10 @@
+# chimely-example-nextjs
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies [bb1f022]
+- Updated dependencies [12e5a50]
+- Updated dependencies
+  - @chimely/react@0.1.0

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chimely-example-nextjs",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "description": "Chimely 30-second quickstart: the drop-in <Inbox /> in a Next.js app.",
   "license": "MIT",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,0 +1,14 @@
+# @chimely/client
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial public release.
+
+### Patch Changes
+
+- bb1f022: Comment and JSDoc cleanup. No API, type, or behavior change.
+- 12e5a50: Regenerate client types from the documented error contract: `Error.code` is now
+  a typed enum of the stable error codes, and the inbox stream declares its 429
+  (`too_many_connections`) response. Repository URLs point at dodopayments/chimely.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chimely/client",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Framework-agnostic headless core for the Chimely in-app notification inbox.",
   "license": "MIT",
   "type": "module",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,0 +1,18 @@
+# @chimely/react
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial public release.
+
+### Patch Changes
+
+- bb1f022: Comment and JSDoc cleanup. No API, type, or behavior change.
+- 12e5a50: Regenerate client types from the documented error contract: `Error.code` is now
+  a typed enum of the stable error codes, and the inbox stream declares its 429
+  (`too_many_connections`) response. Repository URLs point at dodopayments/chimely.
+- Updated dependencies [bb1f022]
+- Updated dependencies [12e5a50]
+- Updated dependencies
+  - @chimely/client@0.1.0

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chimely/react",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "React bindings and the drop-in <Inbox /> component for Chimely.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Bumps the SDK packages to **0.1.0** for the initial public release by consuming the pending changesets locally (`changeset version`), so they align with the server and the `v0.1.0` release tag.

- `@chimely/client` 0.0.0 → **0.1.0**
- `@chimely/react` 0.0.0 → **0.1.0**
- private packages (`docs`, `examples/nextjs`) → 0.0.1 (not published)

Consumes both pending changesets plus a new `minor` "Initial public release" changeset. **Supersedes the bot "Version Packages" PR #13**, which can be closed.

After this merges, the initial release is cut by creating a GitHub Release tagged `v0.1.0` at the merge commit (publishes `@chimely/*` to npm + the server image to GAR/GHCR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
