### PR TITLE
fix(server): init telemetry inside the tokio runtime

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -23,22 +23,16 @@ fn main() -> anyhow::Result<()> {
             print!("{yaml}");
             Ok(())
         }
-        Some("serve") | None => {
-            telemetry::init()?;
-            tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .build()
-                .context("building tokio runtime")?
-                .block_on(serve())
-        }
-        Some("dlq") => {
-            telemetry::init()?;
-            tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .build()
-                .context("building tokio runtime")?
-                .block_on(dlq_command(args.collect()))
-        }
+        Some("serve") | None => tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .context("building tokio runtime")?
+            .block_on(serve()),
+        Some("dlq") => tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .context("building tokio runtime")?
+            .block_on(dlq_command(args.collect())),
         Some(other) => {
             eprintln!("unknown subcommand: {other}\nusage: chimely [serve|openapi|dlq]");
             std::process::exit(2);
@@ -47,6 +41,9 @@ fn main() -> anyhow::Result<()> {
 }
 
 async fn serve() -> anyhow::Result<()> {
+    // The OTLP exporter builds a tonic/hyper client that needs a running
+    // reactor, so telemetry init happens on the runtime, not before it.
+    telemetry::init()?;
     let cfg = Arc::new(config::Config::from_env()?);
 
     let pool = db::connect(&cfg.database_url)
@@ -157,6 +154,7 @@ async fn serve() -> anyhow::Result<()> {
 }
 
 async fn dlq_command(args: Vec<String>) -> anyhow::Result<()> {
+    telemetry::init()?;
     let cfg = config::Config::from_env()?;
     let pool = db::connect(&cfg.database_url)
         .await


### PR DESCRIPTION
## Summary

Fixes a startup panic that crash-loops the server whenever OTLP tracing is enabled:

```
thread 'main' panicked at hyper-util-0.1.20/src/rt/tokio.rs:115:9:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
```

`telemetry::init()` was called in `main()` **before** the Tokio runtime was built. When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, `init()` builds a tonic OTLP span exporter whose hyper-util transport requires a running reactor, so `serve`/`dlq` panicked on boot.

This only surfaced in deployments that configure an OTLP collector (e.g. Kubernetes); local dev and CI leave the endpoint unset, so the exporter branch was skipped and the bug stayed hidden.

## Change

- Move `telemetry::init()?` out of `main()` and into the async `serve()` and `dlq_command()` bodies, so the exporter is constructed on the runtime.
- `chimely openapi` stays runtime-free and telemetry-free, as intended.

## Testing

- `cargo build`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`

---
*Created with [Squirrels](https://squirrels.dodopayments.tech/session/e0304a91c5967a6503041b1002408ffc)*