### PR TITLE
chore(release): server 0.1.1

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "chimely"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "argon2",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chimely"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "AGPL-3.0-only"
 description = "In-app notification inbox infrastructure: one binary + Postgres + Redis."


### PR DESCRIPTION
## What

Bumps the server crate (`server/`) to **0.1.1** (patch) in `Cargo.toml` and `Cargo.lock`.

## Why

Cuts a server-only patch release. This is a binary/image release, independent of the SDK packages (which stay MIT and version via changesets). The OpenAPI `info.version` is deliberately left at `0.1.0` — it is the published *API contract* version, and this patch does not change the contract, so no generated artifacts need regenerating.

## Release procedure (after merge)

1. Merge this PR to `main`.
2. Create and publish a GitHub Release with tag `v0.1.1` at the merge commit.
   - `docker-publish.yml` builds and pushes the image to GAR (and moves `:latest`, since this is not a pre-release).
   - The CI `docker` job publishes the GHCR image with the `type=semver` `0.1.1` tag.
   - The SDK `release.yml` publish job also fires on the Release event, but `changeset publish` is a no-op here (no pending package version bumps).

---
*Created with [Squirrels](https://squirrels.dodopayments.tech/session/bec77359ca02effe4fb28967d16319f9)*