### PR TITLE
feat(server): redirect / to the admin dashboard

### DIFF
--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -4,6 +4,7 @@
 use std::time::Duration;
 
 use axum::http::{HeaderName, Method, StatusCode, header};
+use axum::response::Redirect;
 use axum::routing::{get, patch, post, put};
 use axum::{Router, middleware};
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
@@ -81,6 +82,10 @@ pub fn router(state: AppState) -> Router {
         // served from this binary. Explicit API routes are matched before the
         // SPA wildcard fallback.
         .merge(admin_plane())
+        // The server root is a convenience redirect to the embedded admin
+        // dashboard. Temporary so the mapping stays reversible and no browser
+        // caches / -> /admin permanently.
+        .route("/", get(|| async { Redirect::temporary("/admin") }))
         // Operational plane
         .route("/healthz", get(healthz))
         .route("/readyz", get(readyz))

--- a/server/tests/admin.rs
+++ b/server/tests/admin.rs
@@ -1327,6 +1327,9 @@ async fn status_browser_lists_notifications_and_their_timeline() {
 /// The binary serves the app at /admin; the marketing site is hosted elsewhere.
 /// Temporary (307), not permanent, so the mapping stays reversible and no
 /// operator's browser caches / -> /admin forever.
+///
+/// The redirect is GET-only. axum get(...) registers GET (and auto HEAD) and
+/// answers other verbs with 405, so a POST to / never redirects.
 #[tokio::test]
 async fn root_redirects_to_the_admin_dashboard() {
     let app = support::spawn().await;
@@ -1346,5 +1349,14 @@ async fn root_redirects_to_the_admin_dashboard() {
             .and_then(|v| v.to_str().ok()),
         Some("/admin"),
         "root redirects to the admin dashboard",
+    );
+
+    // Only GET redirects. get(...) answers non-GET verbs with 405, so a POST
+    // to / returns Method Not Allowed and carries no Location.
+    let res = client.post(format!("{}/", app.base)).send().await.unwrap();
+    assert_eq!(res.status(), 405, "POST / is not a redirect");
+    assert!(
+        res.headers().get(reqwest::header::LOCATION).is_none(),
+        "non-GET root does not redirect",
     );
 }

--- a/server/tests/admin.rs
+++ b/server/tests/admin.rs
@@ -1318,3 +1318,33 @@ async fn status_browser_lists_notifications_and_their_timeline() {
         .unwrap();
     assert!(filtered["items"].as_array().unwrap().is_empty());
 }
+
+// =============================================================================
+// Root path
+// =============================================================================
+
+/// The server root is a convenience redirect to the embedded admin dashboard.
+/// The binary serves the app at /admin; the marketing site is hosted elsewhere.
+/// Temporary (307), not permanent, so the mapping stays reversible and no
+/// operator's browser caches / -> /admin forever.
+#[tokio::test]
+async fn root_redirects_to_the_admin_dashboard() {
+    let app = support::spawn().await;
+    // reqwest follows redirects by default. A non-following client makes the
+    // 3xx itself observable.
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+
+    let res = client.get(format!("{}/", app.base)).send().await.unwrap();
+
+    assert_eq!(res.status(), 307, "GET / is a temporary redirect");
+    assert_eq!(
+        res.headers()
+            .get(reqwest::header::LOCATION)
+            .and_then(|v| v.to_str().ok()),
+        Some("/admin"),
+        "root redirects to the admin dashboard",
+    );
+}


### PR DESCRIPTION
## What

`GET /` returned a 404 (the app is served at `/admin`; nothing was mounted at the root). Redirect the server root to `/admin` so operators land on the embedded admin dashboard.

## Why 307 (temporary)

Not a permanent redirect: the `/` → `/admin` mapping stays reversible and no operator's browser caches it forever. The root is hit rarely, so the extra hop costs nothing, and the marketing homepage is a separate host that could plausibly own `/` later.

## Test

`root_redirects_to_the_admin_dashboard` asserts `GET /` returns `307` with `Location: /admin` (built test-first). Not an annotated API route, so the OpenAPI spec is unaffected.

Verified: new test + full `admin` binary (25/25) pass, `cargo fmt --check` and `clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)