### PR TITLE
fix(admin): admin login in dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,10 @@ services:
       # and an API key. Never set these in production.
       CHIMELY_DEV_ENVIRONMENT: demo
       CHIMELY_DEV_API_KEY: dev-secret-key
+      # Dev-only root admin so the dashboard at /admin is loggable out of the
+      # box. Password must be at least 12 characters. Never set in production.
+      CHIMELY_ADMIN_EMAIL: admin@example.com
+      CHIMELY_ADMIN_PASSWORD: chimely-dev-admin
     ports:
       - "8080:8080"
 

--- a/server/admin/src/lib/api.ts
+++ b/server/admin/src/lib/api.ts
@@ -34,7 +34,10 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     },
   });
 
-  if (res.status === 401) {
+  // A 401 on a session-gated request means the session is gone, so route back
+  // to login. The login request has no session yet, so its 401 is a credential
+  // rejection and must surface the server message instead of "Session expired".
+  if (res.status === 401 && path !== '/login') {
     window.dispatchEvent(new CustomEvent('chimely-admin-unauthorized'));
     throw new ApiRequestError({ status: 401, code: 'unauthorized', message: 'Session expired' });
   }

--- a/server/src/bootstrap.rs
+++ b/server/src/bootstrap.rs
@@ -100,6 +100,17 @@ pub async fn ensure_admin(pool: &PgPool, cfg: &Config) -> anyhow::Result<()> {
         return Ok(());
     };
     let email = email.trim().to_lowercase();
+    // Env vars commonly carry a trailing newline (heredocs, `.env` files,
+    // `export VAR=$(...)`). The login form never sends surrounding whitespace,
+    // so trim the password the way the email is trimmed. Otherwise the hashed
+    // credential and the typed one differ and every login 401s.
+    let trimmed = password.trim();
+    if trimmed.len() != password.len() {
+        tracing::warn!(
+            "CHIMELY_ADMIN_PASSWORD had surrounding whitespace, using the trimmed value"
+        );
+    }
+    let password = trimmed;
     if password.chars().count() < crate::auth::MIN_PASSWORD_LEN {
         anyhow::bail!("CHIMELY_ADMIN_PASSWORD must be at least 12 characters");
     }

--- a/server/tests/admin.rs
+++ b/server/tests/admin.rs
@@ -727,6 +727,29 @@ async fn bootstrap_admin_is_idempotent() {
         .await;
 }
 
+/// The CHIMELY_ADMIN_* bootstrap credentials authenticate through the real
+/// login endpoint. A trailing newline in the env password (heredocs, `.env`
+/// files, `export VAR=$(...)`) is trimmed at boot the way the email is, so the
+/// operator signs in with the clean value instead of hitting a phantom 401.
+#[tokio::test]
+async fn bootstrap_admin_credentials_authenticate() {
+    let app = support::spawn_configured(false, |cfg| {
+        cfg.admin_bootstrap_email = Some("root@auth.test".into());
+        cfg.admin_bootstrap_password = Some("root-password-1234\n".into());
+    })
+    .await;
+
+    chimely::bootstrap::ensure_admin(&app.pool, &app.cfg)
+        .await
+        .unwrap();
+
+    // login_client asserts a 200. The clean password authenticates even though
+    // the configured env value carried a trailing newline.
+    let _ = app
+        .login_client("root@auth.test", "root-password-1234")
+        .await;
+}
+
 /// Rotating the bootstrap credential (reconcile branch) revokes sessions that
 /// predate the rotation, so a restart recovers from a compromise.
 #[tokio::test]


### PR DESCRIPTION
Fixes admin login failing in dev with a 401 (network tab: `invalid email or password`) while the UI showed `Session expired`.

## Root causes and fixes

1. **Backend — the real 401.** `bootstrap::ensure_admin` trimmed the email but hashed `CHIMELY_ADMIN_PASSWORD` raw. A trailing newline in the env value (heredocs, `.env` files, `export VAR=$(...)`) made the stored hash disagree with the value typed at login, so every admin login 401'd. Now the password is trimmed the way the email is, with a `warn!` when whitespace is stripped.

2. **Frontend — the wrong message.** `api.ts` mapped *every* 401 to a hardcoded `Session expired` and fired the global unauthorized event before reading the body, so a failed login hid the server's real message. The login request is now exempt (it has no session yet, so its 401 is a credential rejection).

3. **Dev-ex — no admin to log in as.** The local `docker-compose.yml` seeded a demo env + API key but no admin, so `ensure_admin` was a no-op and `/admin` had no account. Added a dev-only root admin (`admin@example.com` / `chimely-dev-admin`).

## Tests

- New `bootstrap_admin_credentials_authenticate` (test-first): a `CHIMELY_ADMIN_PASSWORD` with a trailing newline authenticates through the real login endpoint with the clean value. Failed before the trim, passes after.
- Existing bootstrap tests still pass; `cargo fmt`/`clippy` clean; admin SPA `tsc --noEmit` clean; `docker compose config` valid.

Note: the admin SPA has no unit-test harness, so the `api.ts` change is covered by typecheck + reasoning only. Happy to add a vitest harness + a regression test in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)