### PR TITLE
feat(server): include build version in /healthz

### DIFF
--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use axum::http::{HeaderName, Method, StatusCode, header};
 use axum::routing::{get, patch, post, put};
-use axum::{Router, middleware};
+use axum::{Json, Router, middleware};
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 use tower_http::cors::{Any, CorsLayer};
 use utoipa_scalar::Servable as _;
@@ -184,9 +184,9 @@ fn prometheus_handle() -> PrometheusHandle {
         .clone()
 }
 
-/// Liveness: process is up.
-async fn healthz() -> &'static str {
-    "ok"
+/// Liveness: process is up. Reports the build version for deploy verification.
+async fn healthz() -> Json<serde_json::Value> {
+    Json(serde_json::json!({ "status": "ok", "version": env!("CARGO_PKG_VERSION") }))
 }
 
 /// Readiness gates on Postgres reachable + migrations applied. Redis is the

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -184,7 +184,7 @@ fn prometheus_handle() -> PrometheusHandle {
         .clone()
 }
 
-/// Liveness: process is up. Reports the build version for deploy verification.
+/// Liveness: process is up.
 async fn healthz() -> Json<serde_json::Value> {
     Json(serde_json::json!({ "status": "ok", "version": env!("CARGO_PKG_VERSION") }))
 }

--- a/server/tests/health.rs
+++ b/server/tests/health.rs
@@ -15,7 +15,13 @@ async fn health_and_readiness_respond_on_a_fresh_deploy() {
         .await
         .unwrap();
     assert_eq!(res.status(), 200);
-    assert_eq!(res.text().await.unwrap(), "ok");
+    let health: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(health["status"], "ok");
+    assert_eq!(
+        health["version"],
+        env!("CARGO_PKG_VERSION"),
+        "healthz reports the build version"
+    );
 
     let res = app
         .client


### PR DESCRIPTION
## What

`/healthz` now returns `{"status":"ok","version":"<CARGO_PKG_VERSION>"}` instead of the plain `ok`, so a deploy can be verified (which build is live) without shelling into the container. The version is the compile-time crate version via `env!("CARGO_PKG_VERSION")`.

## Notes

- Liveness semantics unchanged: still 200 on a live process. k8s httpGet probes check the status code, not the body, so this is safe for probes.
- Not an annotated API route, so the OpenAPI spec is unaffected.

## Test

Updated `health_and_readiness_respond_on_a_fresh_deploy` (test-first) to assert `status == "ok"` and `version == env!("CARGO_PKG_VERSION")`. `cargo fmt`/`clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)