### PR TITLE
ci: cache the GAR release docker build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -64,8 +64,7 @@ jobs:
           echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
 
       # Durable registry cache in GAR. The cargo-chef dependency layer is
-      # compiled once and reused across releases. A plain `docker build` on the
-      # ephemeral runner starts every release from a cold cache.
+      # compiled once and reused across releases.
       - name: Build and push chimely image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,19 +35,13 @@ jobs:
       - name: Extract release tag
         run: echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> "$GITHUB_ENV"
 
-      # Dockerfile at the repo root builds the single binary (admin SPA + Rust)
-      # with `.` as the context. `latest` tracks the newest stable release, so a
-      # pre-release publishes its own tag but never moves `latest`.
-      - name: Build chimely image
+      - name: Guard required repo variables
         run: |
-          [ -n "$IMAGE" ] || { echo "CHIMELY_GAR_LOCATION repo variable is unset" >&2; exit 1; }
-          docker build -t "$IMAGE:$RELEASE_TAG" .
-          if [ "$PRERELEASE" != "true" ]; then
-            docker tag "$IMAGE:$RELEASE_TAG" "$IMAGE:latest"
-          fi
+          [ -n "$IMAGE" ]  || { echo "CHIMELY_GAR_LOCATION repo variable is unset" >&2; exit 1; }
+          [ -n "$REGION" ] || { echo "REGION repo variable is unset" >&2; exit 1; }
 
+      # Auth precedes the build so the registry cache can be read from GAR.
       - name: Google Auth
-        id: auth
         uses: google-github-actions/auth@v2
         with:
           credentials_json: "${{ secrets.SERVICE_ACCOUNT_KEY }}"
@@ -56,13 +50,27 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Docker auth
-        run: |
-          [ -n "$REGION" ] || { echo "REGION repo variable is unset" >&2; exit 1; }
-          gcloud auth configure-docker "${REGION}-docker.pkg.dev"
+        run: gcloud auth configure-docker "${REGION}-docker.pkg.dev"
 
-      - name: Push chimely image to GAR
+      - uses: docker/setup-buildx-action@v3
+
+      # `latest` tracks the newest stable release, so a pre-release publishes its
+      # own tag but never moves `latest`.
+      - name: Compute image tags
+        id: tags
         run: |
-          docker push "$IMAGE:$RELEASE_TAG"
-          if [ "$PRERELEASE" != "true" ]; then
-            docker push "$IMAGE:latest"
-          fi
+          TAGS="$IMAGE:$RELEASE_TAG"
+          [ "$PRERELEASE" = "true" ] || TAGS="$TAGS,$IMAGE:latest"
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+
+      # Durable registry cache in GAR. The cargo-chef dependency layer is
+      # compiled once and reused across releases. A plain `docker build` on the
+      # ephemeral runner starts every release from a cold cache.
+      - name: Build and push chimely image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,13 @@ FROM node:24-slim AS admin
 RUN corepack enable && corepack prepare pnpm@11.5.2 --activate
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 WORKDIR /app
-# The whole workspace is needed so pnpm can resolve the committed lockfile;
-# the focused install pulls only the admin SPA's subtree.
+# `pnpm fetch` populates the store from the lockfile alone, so the dependency
+# download layer is keyed on pnpm-lock.yaml and survives any source change. The
+# offline install then links only the admin SPA's subtree out of that store.
+COPY pnpm-lock.yaml ./
+RUN pnpm fetch
 COPY . .
-RUN pnpm install --frozen-lockfile --filter chimely-admin...
+RUN pnpm install --frozen-lockfile --offline --filter chimely-admin...
 RUN pnpm --filter chimely-admin build
 
 # --- Rust build (cargo-chef: dependency layers cached independently of src) ---


### PR DESCRIPTION
## What

Two caching fixes on the Docker publish path.

**1. Cache the GAR release build (`docker-publish.yml`).** The release publish used a plain `docker build` on an ephemeral runner with no cache backend, so every release recompiled all Rust dependencies from cold (~517s in recent runs). It now builds with buildx + a durable registry cache in GAR (`type=registry,ref=$IMAGE:buildcache,mode=max`), so the cargo-chef `cook` layer is reused across releases. GCP auth moved before the build so the cache is readable from GAR.

**2. Cache admin SPA deps on the lockfile (`Dockerfile`).** The admin stage did `COPY . .` before `pnpm install`, so any repo change busted the install layer and redownloaded deps. `pnpm fetch` (keyed on `pnpm-lock.yaml` alone) now downloads deps in a layer that survives source changes; the offline install links only the admin subtree.

## Why

The release/deploy image (GAR) was the slow path with zero caching, ~2.4x the wall time of the cached GHCR build (~215s). Confirmed from the CI logs: the GHCR build already reuses the `cargo chef cook` layer; the GAR build ran it cold every release.

## Notes

- First release after merge repopulates `:buildcache` (cold once), then reused.
- Validated the `pnpm fetch` flow by building the `admin` stage locally: offline install and admin build both succeed.
- The GHCR build (`ci.yml`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)