### PR TITLE
feat(docs): serve AEO markdown twins via Dualmark

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -11,6 +11,8 @@
     "typecheck": "next typegen && tsc --noEmit"
   },
   "dependencies": {
+    "@dualmark/cloudflare": "^0.10.0",
+    "@dualmark/core": "^0.10.0",
     "@paper-design/shaders-react": "0.0.76",
     "fumadocs-core": "^16.9.3",
     "fumadocs-mdx": "^15.0.11",

--- a/docs/public/index.md
+++ b/docs/public/index.md
@@ -1,0 +1,54 @@
+# Chimely
+
+> Fair-source, self-hostable in-app notification inbox infrastructure. Drop in
+> one React component, send with one API call from your backend. Open-source
+> infrastructure you run yourself.
+
+Chimely is a self-hostable **in-app notification inbox** you run yourself. It is
+the inbox primitive, not a workflow engine: you send notifications, and a
+drop-in `<Inbox />` renders them.
+
+- **One POST to notify** — your backend calls `POST /v1/notifications`.
+- **One `<Inbox />` to render** — drop the component into your frontend.
+
+A live bell, unread counts, read state, and preferences, with nothing to build.
+
+## How it works
+
+You run one Rust binary backed by Postgres (the source of truth), plus Redis
+for the real-time plane. Your backend sends notifications over a small HTTP API,
+and the `<Inbox />` widget streams updates live over SSE and stays in sync.
+Notifications update instantly without a page refresh.
+
+It self-hosts on a single node and scales to many.
+
+## What Chimely is not
+
+These are deliberate. Chimely does the inbox and nothing else:
+
+- No workflows, steps, or conditional routing.
+- No email, SMS, or push channels. In-app inbox only.
+- No server-side templating. Your payload is stored and shown as-is.
+- No digests or batching.
+
+## Architecture
+
+- One Rust binary: HTTP API, SSE hints, and background workers.
+- Postgres (>= 15) is the authoritative source of truth.
+- Redis is the real-time hint/cache plane. Redis loss may delay hints but never
+  loses data, since counters are recomputable from Postgres.
+- SSE is a hint, not a transport. Clients refetch via conditional REST (ETag)
+  on every hint, so missed hints are harmless by construction.
+
+## Get started
+
+- [Quickstart](/docs/quickstart): Run Chimely and render an inbox in about ten minutes.
+- [Self-hosting](/docs/self-hosting): Compose, configuration, health, and backups.
+- [Auth & HMAC](/docs/auth): API keys and the subscriber hash.
+- [SDK reference](/docs/sdk-reference): Inbox props, hooks, and the client.
+- [API reference](/docs/api): The full HTTP API.
+
+## License
+
+The server is AGPL-3.0 (OSI open source, copyleft). The SDKs (`@chimely/client`,
+`@chimely/react`) and examples are MIT so they can embed in customer frontends.

--- a/docs/worker.ts
+++ b/docs/worker.ts
@@ -1,0 +1,25 @@
+import { createAEOWorker } from '@dualmark/cloudflare';
+
+// Static export served by Cloudflare Workers Static Assets. The Next.js `out/`
+// directory is exposed via the ASSETS binding (see wrangler.jsonc). The
+// upstream simply forwards to the asset server. createAEOWorker runs first
+// (run_worker_first) so content negotiation and markdown twins are served
+// before the asset fallback.
+interface Env {
+  ASSETS: { fetch: (request: Request) => Promise<Response> };
+}
+
+const upstream = {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    return env.ASSETS.fetch(request);
+  },
+};
+
+export default createAEOWorker({
+  upstream,
+  // Matches next.config.mjs (no trailingSlash) and wrangler
+  // html_handling "auto-trailing-slash".
+  trailingSlash: 'never',
+  // AEO Spec §6: advertise the markdown twin on every HTML response.
+  enableLinkHeader: true,
+});

--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -1,10 +1,18 @@
 {
   "name": "chimely-docs",
   "compatibility_date": "2026-06-30",
-  // Assets-only Worker: the docs are a Next.js static export, so there is no
-  // Worker script. `main` and an ASSETS binding are intentionally omitted.
+  // The docs are a Next.js static export. worker.ts wraps the asset server
+  // with @dualmark/cloudflare's createAEOWorker() so AI agents get markdown
+  // twins and AEO headers via content negotiation.
+  "main": "./worker.ts",
   "assets": {
     "directory": "./out",
+    // Expose the static export to the Worker. worker.ts forwards to
+    // env.ASSETS for everything the AEO layer passes through.
+    "binding": "ASSETS",
+    // REQUIRED: without this the runtime serves matching assets directly and
+    // skips the Worker, so negotiation never runs and .md twins 404.
+    "run_worker_first": true,
     // Next export emits flat leaf files (docs/page.html) and folder indexes
     // (docs/index.html). auto-trailing-slash serves both and normalizes the
     // URL. Must stay in sync with next.config.mjs (no trailingSlash set).


### PR DESCRIPTION
## Summary

Makes `chimely.dev` AI-search ready (AEO). The docs site scored 0/20 on the AEO Spec v1.0 because `https://chimely.dev/index.md` returned 404 — the docs deploy was an **assets-only** Cloudflare Worker with no script, so nothing served the markdown twin.

This wraps the asset server with [`@dualmark/cloudflare`](https://dualmark.dev/docs/integrations/cloudflare-workers)'s `createAEOWorker()`, which adds content negotiation, markdown twin serving, AEO headers, and `Link rel="alternate"` injection.

## Changes

- **`docs/worker.ts`** (new): thin upstream forwarding to `env.ASSETS`, wrapped by `createAEOWorker({ trailingSlash: 'never', enableLinkHeader: true })`.
- **`docs/wrangler.jsonc`**: add `main`, an `ASSETS` binding, and `run_worker_first: true` so the Worker runs before static asset serving (without it, negotiation never runs).
- **`docs/package.json`**: add `@dualmark/cloudflare` and `@dualmark/core` (pinned `^0.10.0`).
- **`docs/public/index.md`** (new): hand-authored home page markdown twin. Next copies `public/*` into `out/`, so it lands at `out/index.md` and is served by the AEO layer (the package serves pre-built `.md`, it does not synthesize from HTML).

## Fixes failing check

- `md.fetch` (-20): `https://chimely.dev/index.md` now returns 2xx `text/markdown`. Per AEO Spec §6, a conformant server serves the twin body when the `.md` URL is requested directly.

Also satisfies §3 (negotiation), §4 (`X-Markdown-Tokens`, `X-Robots-Tag: noindex`, `Vary: Accept`, `X-AEO-Version`), and §6 (`Link` alternate header) via the package defaults.

## Deploy note

This switches the docs from an assets-only publish to a **Worker deployment** — confirm the deploy step runs `wrangler deploy` from `docs/`. Verify locally with `wrangler dev` + `curl -sI http://localhost:8787/index.md`.

## Follow-ups (not in this PR)

- `.md` twins for `/docs/*` pages.
- Root `llms.txt` (spec §6.2, RECOMMENDED).
- `docs/content/docs/index.mdx` license text still says FSL; the twin uses the settled AGPL/MIT split — reconcile separately.

---
*Created with [Squirrels](https://squirrels.dodopayments.tech/session/ca7ba79b391711320d5371fa6cc3ae34)*