### PR TITLE
feat(docs): serve markdown twins to AI agents

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -11,6 +11,7 @@
     "typecheck": "next typegen && tsc --noEmit"
   },
   "dependencies": {
+    "@dualmark/cloudflare": "^0.10.0",
     "@paper-design/shaders-react": "0.0.76",
     "fumadocs-core": "^16.9.3",
     "fumadocs-mdx": "^15.0.11",

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && node scripts/generate-md-twins.mjs",
     "start": "next start",
     "postinstall": "fumadocs-mdx",
     "typecheck": "next typegen && tsc --noEmit"

--- a/docs/scripts/generate-md-twins.mjs
+++ b/docs/scripts/generate-md-twins.mjs
@@ -1,0 +1,116 @@
+// Generates Dualmark markdown twins into the static export (out/).
+//
+// The @dualmark/cloudflare adapter does not convert HTML at the edge. On an AI
+// request it fetches toMarkdownPath(path) from the ASSETS binding and serves it
+// verbatim, so the twin files must exist in out/ next to their .html pages.
+// Path mapping mirrors @dualmark/core toMarkdownPath: /docs/quickstart ->
+// out/docs/quickstart.md, /docs -> out/docs.md, / -> out/index.md.
+
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  readdirSync,
+  existsSync,
+} from 'node:fs';
+import { join, dirname, relative, sep, posix } from 'node:path';
+
+const CONTENT_DIR = 'content/docs';
+const OUT_DIR = 'out';
+const DOCS_BASE = '/docs';
+
+if (!existsSync(OUT_DIR)) {
+  throw new Error(`${OUT_DIR}/ not found. Run "next build" before this script.`);
+}
+
+// @dualmark/core toMarkdownPath, replicated so the twin path matches what the
+// Worker requests.
+function toMarkdownPath(pathname) {
+  if (pathname.endsWith('.md')) return pathname;
+  const trimmed = pathname.replace(/\/+$/, '');
+  if (trimmed === '') return '/index.md';
+  return `${trimmed}.md`;
+}
+
+function readMeta() {
+  const src = readFileSync('app/layout.tsx', 'utf8');
+  const title = src.match(/title:\s*['"](.+?)['"]/)?.[1] ?? 'Docs';
+  const description = src.match(/description:\s*['"](.+?)['"]/)?.[1] ?? '';
+  return { title, description };
+}
+
+function parseFrontmatter(src) {
+  if (!src.startsWith('---')) return { data: {}, body: src };
+  const end = src.indexOf('\n---', 3);
+  if (end === -1) return { data: {}, body: src };
+  const data = {};
+  for (const line of src.slice(3, end).trim().split('\n')) {
+    const m = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (m) data[m[1]] = m[2].replace(/^['"]|['"]$/g, '').trim();
+  }
+  return { data, body: src.slice(end + 4).replace(/^\s*\n/, '') };
+}
+
+// MDX ESM statements are not valid markdown. JSX components are left inline.
+function stripMdx(body) {
+  return body
+    .split('\n')
+    .filter((l) => !/^\s*import\s.+from\s/.test(l) && !/^\s*export\s/.test(l))
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function collectMdx(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...collectMdx(full));
+    else if (entry.name.endsWith('.mdx')) files.push(full);
+  }
+  return files;
+}
+
+function routeFor(file) {
+  const noExt = relative(CONTENT_DIR, file).replace(/\.mdx$/, '');
+  const segs = noExt.split(sep).filter((s) => s !== 'index');
+  return posix.join(DOCS_BASE, ...segs);
+}
+
+function write(twinPath, content) {
+  const fsPath = join(OUT_DIR, twinPath);
+  mkdirSync(dirname(fsPath), { recursive: true });
+  writeFileSync(fsPath, content.endsWith('\n') ? content : `${content}\n`);
+  return twinPath;
+}
+
+const meta = readMeta();
+const pages = [];
+
+for (const file of collectMdx(CONTENT_DIR)) {
+  const route = routeFor(file);
+  const { data, body } = parseFrontmatter(readFileSync(file, 'utf8'));
+  const title = data.title ?? route.split('/').pop();
+  let md = `# ${title}\n\n`;
+  if (data.description) md += `> ${data.description}\n\n`;
+  md += stripMdx(body);
+  const twin = write(toMarkdownPath(route), md);
+  pages.push({ route, title, description: data.description ?? '', twin });
+}
+
+pages.sort((a, b) => a.route.localeCompare(b.route));
+
+// Homepage twin (/ -> /index.md). The root is a React page with no markdown
+// source, so compose an overview plus links to every doc twin.
+const links = pages
+  .map((p) => `- [${p.title}](${toMarkdownPath(p.route)})${p.description ? `: ${p.description}` : ''}`)
+  .join('\n');
+const home = `# ${meta.title}\n\n> ${meta.description}\n\n## Documentation\n\n${links}\n`;
+write('/index.md', home);
+
+// llms.txt and llms-full.txt are owned by the Fumadocs route handlers under
+// app/, so this script does not write them.
+
+console.log(`Generated ${pages.length + 1} markdown twins in ${OUT_DIR}/`);
+for (const p of pages) console.log(`  ${p.route}  ->  ${p.twin}`);
+console.log('  /            ->  /index.md');

--- a/docs/scripts/generate-md-twins.mjs
+++ b/docs/scripts/generate-md-twins.mjs
@@ -6,14 +6,8 @@
 // Path mapping mirrors @dualmark/core toMarkdownPath: /docs/quickstart ->
 // out/docs/quickstart.md, /docs -> out/docs.md, / -> out/index.md.
 
-import {
-  readFileSync,
-  writeFileSync,
-  mkdirSync,
-  readdirSync,
-  existsSync,
-} from 'node:fs';
-import { join, dirname, relative, sep, posix } from 'node:path';
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, posix, relative, sep } from 'node:path';
 
 const CONTENT_DIR = 'content/docs';
 const OUT_DIR = 'out';
@@ -103,7 +97,9 @@ pages.sort((a, b) => a.route.localeCompare(b.route));
 // Homepage twin (/ -> /index.md). The root is a React page with no markdown
 // source, so compose an overview plus links to every doc twin.
 const links = pages
-  .map((p) => `- [${p.title}](${toMarkdownPath(p.route)})${p.description ? `: ${p.description}` : ''}`)
+  .map(
+    (p) => `- [${p.title}](${toMarkdownPath(p.route)})${p.description ? `: ${p.description}` : ''}`,
+  )
   .join('\n');
 const home = `# ${meta.title}\n\n> ${meta.description}\n\n## Documentation\n\n${links}\n`;
 write('/index.md', home);

--- a/docs/worker/index.ts
+++ b/docs/worker/index.ts
@@ -1,19 +1,11 @@
-import { createAEOWorker } from '@dualmark/cloudflare';
-
-// The docs are a Next.js static export served by the Cloudflare Static Assets
-// binding. Dualmark runs first (wrangler.jsonc run_worker_first), inspects the
-// request, and serves markdown twins to AI agents. Everything else falls
-// through to the static assets unchanged.
-interface Env {
-  ASSETS: { fetch: (request: Request) => Promise<Response> };
-}
+import { createAEOWorker, type MinimalEnv } from '@dualmark/cloudflare';
 
 const upstream = {
-  fetch: (request: Request, env: Env) => env.ASSETS.fetch(request),
+  fetch: (request: Request, env: MinimalEnv) => env.ASSETS.fetch(request),
 };
 
-// trailingSlash mirrors next.config.mjs (no trailingSlash) and the wrangler
-// html_handling "auto-trailing-slash" normalization.
+// Mirrors next.config.mjs (no trailingSlash) and wrangler html_handling
+// "auto-trailing-slash". The three must agree or a bot hits a 301 loop.
 export default createAEOWorker({
   upstream,
   trailingSlash: 'never',

--- a/docs/worker/index.ts
+++ b/docs/worker/index.ts
@@ -1,0 +1,20 @@
+import { createAEOWorker } from '@dualmark/cloudflare';
+
+// The docs are a Next.js static export served by the Cloudflare Static Assets
+// binding. Dualmark runs first (wrangler.jsonc run_worker_first), inspects the
+// request, and serves markdown twins to AI agents. Everything else falls
+// through to the static assets unchanged.
+interface Env {
+  ASSETS: { fetch: (request: Request) => Promise<Response> };
+}
+
+const upstream = {
+  fetch: (request: Request, env: Env) => env.ASSETS.fetch(request),
+};
+
+// trailingSlash mirrors next.config.mjs (no trailingSlash) and the wrangler
+// html_handling "auto-trailing-slash" normalization.
+export default createAEOWorker({
+  upstream,
+  trailingSlash: 'never',
+});

--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -1,10 +1,18 @@
 {
   "name": "chimely-docs",
   "compatibility_date": "2026-06-30",
-  // Assets-only Worker: the docs are a Next.js static export, so there is no
-  // Worker script. `main` and an ASSETS binding are intentionally omitted.
+  // Dualmark AEO Worker in front of the Next.js static export. createAEOWorker
+  // (worker/index.ts) serves markdown twins to AI agents and passes human
+  // traffic through to the ASSETS binding.
+  "main": "worker/index.ts",
   "assets": {
     "directory": "./out",
+    // The Worker reads static files through this binding (env.ASSETS.fetch()).
+    "binding": "ASSETS",
+    // Run the Worker before static-asset serving. Without this Cloudflare
+    // answers HTML pages directly from ./out and Dualmark never sees the
+    // request, so content negotiation cannot happen.
+    "run_worker_first": true,
     // Next export emits flat leaf files (docs/page.html) and folder indexes
     // (docs/index.html). auto-trailing-slash serves both and normalizes the
     // URL. Must stay in sync with next.config.mjs (no trailingSlash set).

--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -1,17 +1,12 @@
 {
   "name": "chimely-docs",
   "compatibility_date": "2026-06-30",
-  // Dualmark AEO Worker in front of the Next.js static export. createAEOWorker
-  // (worker/index.ts) serves markdown twins to AI agents and passes human
-  // traffic through to the ASSETS binding.
   "main": "worker/index.ts",
   "assets": {
     "directory": "./out",
-    // The Worker reads static files through this binding (env.ASSETS.fetch()).
     "binding": "ASSETS",
-    // Run the Worker before static-asset serving. Without this Cloudflare
-    // answers HTML pages directly from ./out and Dualmark never sees the
-    // request, so content negotiation cannot happen.
+    // Without this, static assets serve before the Worker runs and content
+    // negotiation never happens.
     "run_worker_first": true,
     // Next export emits flat leaf files (docs/page.html) and folder indexes
     // (docs/index.html). auto-trailing-slash serves both and normalizes the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
 
   docs:
     dependencies:
+      '@dualmark/cloudflare':
+        specifier: ^0.10.0
+        version: 0.10.0
       '@paper-design/shaders-react':
         specifier: 0.0.76
         version: 0.0.76(@types/react@19.2.17)(react@19.2.7)
@@ -494,6 +497,14 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dualmark/cloudflare@0.10.0':
+    resolution: {integrity: sha512-/+Q8C0n/CX0qCooyXzlACuwEFAsaqk2VrlMLsCZZoJSQQVgZif31Nxt9wUeFHdWZWbRaf4nkAwrYjpdNbgofPA==}
+    engines: {node: '>=22.12.0'}
+
+  '@dualmark/core@0.10.0':
+    resolution: {integrity: sha512-2BC3mnJe20dOjeeqZr+u7ndjCcG0CLW8G807f2Ah7XoQAgND01n48Qocy3R9VHEnKSJYNGfdbPQVUJJy0r/fvQ==}
+    engines: {node: '>=22.12.0'}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -4327,7 +4338,7 @@ snapshots:
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
@@ -4358,7 +4369,7 @@ snapshots:
 
   '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -4368,7 +4379,7 @@ snapshots:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -4407,7 +4418,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7':
+  '@babel/traverse@7.29.7(supports-color@10.2.2)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -4629,6 +4640,12 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@dualmark/cloudflare@0.10.0':
+    dependencies:
+      '@dualmark/core': 0.10.0
+
+  '@dualmark/core@0.10.0': {}
 
   '@emnapi/core@1.10.0':
     dependencies:


### PR DESCRIPTION
## What

Make the docs AI-search ready (AEO) with [Dualmark](https://dualmark.dev/): serve clean markdown twins to AI agents alongside HTML for humans, picked by HTTP content negotiation. Same URLs.

## How

- **`docs/worker/index.ts`**: `createAEOWorker` from `@dualmark/cloudflare` wrapping an upstream that serves the Next.js static export through the `ASSETS` binding.
- **`docs/wrangler.jsonc`**: assets-only Worker → Worker + assets. Added `main`, `assets.binding: "ASSETS"`, and `run_worker_first: true` (required: otherwise Cloudflare serves the HTML asset directly and the Worker never sees the request).
- **`docs/scripts/generate-md-twins.mjs`** + `build` script: **the adapter does not convert HTML at the edge** — on an AI request it fetches the pre-built `toMarkdownPath(path)` asset (`/` → `/index.md`, `/docs/quickstart` → `/docs/quickstart.md`). So we generate a `.md` twin per docs page plus `/index.md` into `out/` at build time. Without this every markdown path 404s and the AEO `md.fetch` check fails.
- `llms.txt` / `llms-full.txt` / static search are the Fumadocs route handlers (from #32); the twin generator leaves them alone.
- Added `@dualmark/cloudflare@^0.10.0`.

## Verification

- `wrangler dev` end-to-end: `/index.md`, `/docs/*.md`, `Accept: text/markdown`, and AI-bot user-agents all return `200 text/markdown`; browsers still get HTML with a `Link: rel="alternate"; type="text/markdown"` twin header. `md.fetch` passes.
- `pnpm typecheck` passes; `wrangler deploy --dry-run` validates the config.

## Deploy notes

- The Cloudflare Workers build command must invoke the `build` npm script (`pnpm build`), which now chains the twin generator after `next build`. A bare `next build` would deploy without twins.
- Known gap: OpenAPI operation pages under `/docs/api/**` do not get twins yet (they are not static MDX). Follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
