### PR TITLE
feat(docs): static-export search and llms.txt

### DIFF
--- a/docs/app/api/search/route.ts
+++ b/docs/app/api/search/route.ts
@@ -3,8 +3,7 @@ import { source } from '@/lib/source';
 
 // The docs ship as a static export with no server runtime, so the default
 // server search endpoint never runs. staticGET emits the Orama index as a
-// build-time asset the client downloads. Pairs with search type "static" in
-// app/layout.tsx.
+// build-time asset. Pairs with search type "static" in app/layout.tsx.
 export const dynamic = 'force-static';
 export const revalidate = false;
 

--- a/docs/app/api/search/route.ts
+++ b/docs/app/api/search/route.ts
@@ -1,0 +1,11 @@
+import { createFromSource } from 'fumadocs-core/search/server';
+import { source } from '@/lib/source';
+
+// The docs ship as a static export with no server runtime, so the default
+// server search endpoint never runs. staticGET emits the Orama index as a
+// build-time asset the client downloads. Pairs with search type "static" in
+// app/layout.tsx.
+export const dynamic = 'force-static';
+export const revalidate = false;
+
+export const { staticGET: GET } = createFromSource(source);

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -11,7 +11,7 @@ export default function Layout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <body className="flex flex-col min-h-screen">
-        <RootProvider>{children}</RootProvider>
+        <RootProvider search={{ options: { type: 'static' } }}>{children}</RootProvider>
       </body>
     </html>
   );

--- a/docs/app/llms-full.txt/route.ts
+++ b/docs/app/llms-full.txt/route.ts
@@ -1,0 +1,15 @@
+import { getLLMText } from '@/lib/get-llm-text';
+import { source } from '@/lib/source';
+
+// Static export: prerender the concatenated corpus at build time.
+export const dynamic = 'force-static';
+export const revalidate = false;
+
+export async function GET() {
+  const pages = source.getPages();
+  const text = (await Promise.all(pages.map(getLLMText))).join('\n\n');
+
+  return new Response(text, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+}

--- a/docs/app/llms.txt/route.ts
+++ b/docs/app/llms.txt/route.ts
@@ -11,8 +11,7 @@ export function GET() {
   const parts = [helper.index()];
 
   // index() only walks the default root. The OpenAPI reference is a root:true
-  // tab parked in the fallback branch (an "API reference" folder), so append
-  // its nodes to cover every page.
+  // tab parked in the fallback branch (an "API reference" folder).
   const fallback = tree.fallback;
   if (fallback) {
     parts.push('');

--- a/docs/app/llms.txt/route.ts
+++ b/docs/app/llms.txt/route.ts
@@ -1,0 +1,25 @@
+import { llms } from 'fumadocs-core/source';
+import { source } from '@/lib/source';
+
+// Static export: prerender the index at build time.
+export const dynamic = 'force-static';
+export const revalidate = false;
+
+export function GET() {
+  const helper = llms(source);
+  const tree = source.pageTree;
+  const parts = [helper.index()];
+
+  // index() only walks the default root. The OpenAPI reference is a root:true
+  // tab parked in the fallback branch (an "API reference" folder), so append
+  // its nodes to cover every page.
+  const fallback = tree.fallback;
+  if (fallback) {
+    parts.push('');
+    for (const node of fallback.children) parts.push(helper.indexNode(node));
+  }
+
+  return new Response(parts.join('\n'), {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+}

--- a/docs/lib/get-llm-text.ts
+++ b/docs/lib/get-llm-text.ts
@@ -4,8 +4,7 @@ type SourcePage = (typeof source)['$inferPage'];
 
 // Guide pages expose getText from fumadocs-mdx (requires includeProcessedMarkdown
 // in source.config.ts). OpenAPI reference pages are virtual and carry no Markdown
-// source, so they contribute a title and description stub. Full endpoint detail
-// lives in the OpenAPI export.
+// source. Full endpoint detail lives in the OpenAPI export.
 export async function getLLMText(page: SourcePage): Promise<string> {
   const { title, description } = page.data;
   const heading = `# ${title}\nURL: ${page.url}`;

--- a/docs/lib/get-llm-text.ts
+++ b/docs/lib/get-llm-text.ts
@@ -1,0 +1,22 @@
+import type { source } from '@/lib/source';
+
+type SourcePage = (typeof source)['$inferPage'];
+
+// Guide pages expose getText from fumadocs-mdx (requires includeProcessedMarkdown
+// in source.config.ts). OpenAPI reference pages are virtual and carry no Markdown
+// source, so they contribute a title and description stub. Full endpoint detail
+// lives in the OpenAPI export.
+export async function getLLMText(page: SourcePage): Promise<string> {
+  const { title, description } = page.data;
+  const heading = `# ${title}\nURL: ${page.url}`;
+  const summary = description ? `\n\n${description}` : '';
+
+  const data = page.data as {
+    getText?: (type: 'raw' | 'processed') => Promise<string>;
+  };
+  if (typeof data.getText === 'function') {
+    const body = await data.getText('processed');
+    return `${heading}${summary}\n\n${body}`;
+  }
+  return `${heading}${summary}`;
+}

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -2,6 +2,10 @@ import { defineConfig, defineDocs } from 'fumadocs-mdx/config';
 
 export const docs = defineDocs({
   dir: 'content/docs',
+  // Exposes processed Markdown via page.data.getText('processed') for llms-full.txt.
+  docs: {
+    postprocess: { includeProcessedMarkdown: true },
+  },
 });
 
 export default defineConfig();


### PR DESCRIPTION
## Why

The docs site is a static export (`output: 'export'`, served by Cloudflare Workers Static Assets, no server runtime). Fumadocs' default search is a server route, and none existed, so search was dead. The same "no server" constraint applies to llms.txt.

## Search

- `docs/app/api/search/route.ts` (new) exports `staticGET` from `createFromSource(source)`, emitting the Orama index as a build-time asset (`out/api/search`).
- `docs/app/layout.tsx` sets `RootProvider search={{ options: { type: 'static' } }}` so the client downloads that index and searches in-browser.

## llms.txt / llms-full.txt

- `docs/app/llms.txt/route.ts` (new) — `llms(source).index()` plus the `root:true` API-reference branch that `index()` skips, so the index covers all 45 pages.
- `docs/app/llms-full.txt/route.ts` (new) — concatenates every page via `getLLMText`.
- `docs/lib/get-llm-text.ts` (new) — full processed Markdown for guides; title/URL/description stubs for the virtual OpenAPI pages.
- `docs/source.config.ts` — `includeProcessedMarkdown: true` so `page.data.getText('processed')` works.

All three routes prerender as static (`○`) in `next build`.

## Verification

- `next build` clean; `/api/search`, `/llms.txt`, `/llms-full.txt` all prerendered.
- Served the real `out/` artifact and drove Chrome: searching "broadcast" returns ranked hits across guides + API reference with snippets, and clicking one navigates to the endpoint page. No console errors.
- `llms.txt` = 5.2 KB (6 guides + full API tree); `llms-full.txt` = 42 KB (6 full guides + 39 endpoint stubs).
- Biome and `next typegen && tsc --noEmit` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMq2GMzwUawUiKszMktDBq
