### PR TITLE
feat(docs): comparison page and light-mode bands

### DIFF
--- a/docs/app/(home)/_components/closing-cta.tsx
+++ b/docs/app/(home)/_components/closing-cta.tsx
@@ -33,16 +33,17 @@ function ClosingCtas({ stacked }: { stacked?: boolean }) {
 export function ClosingCTA({ variant = 'centered' }: { variant?: 'centered' | 'inset' }) {
   return (
     <section className="relative overflow-hidden border-t border-fd-border bg-fd-background text-fd-foreground dark:bg-[#05080a] dark:text-white">
-      {/* Dark-mode art: abstract image, fluted glass (lazy, reduced-motion-safe), scrim. Hidden in light. */}
+      {/* Base: the near-black abstract image in dark mode, a soft accent glow in light. */}
       <div
         className="absolute inset-0 hidden bg-cover bg-center dark:block"
         style={{ backgroundImage: 'url(/chimely/closing-abstract.png)' }}
-      >
-        <FlutedGlassBand />
-        <div className="absolute inset-0 [background:linear-gradient(180deg,rgba(4,7,9,0.62),rgba(4,7,9,0.82))]" />
-      </div>
-      {/* Light-mode art: soft accent glow over the page background. */}
+      />
       <div className="absolute inset-0 dark:hidden [background:radial-gradient(100%_120%_at_85%_8%,rgba(18,100,255,0.08),transparent_55%)]" />
+      {/* Fluted-glass shader (lazy, reduced-motion-safe, theme-aware), renders in both themes. */}
+      <FlutedGlassBand />
+      {/* Contrast scrim so the CTA text stays legible over the shader. */}
+      <div className="absolute inset-0 hidden dark:block [background:linear-gradient(180deg,rgba(4,7,9,0.62),rgba(4,7,9,0.82))]" />
+      <div className="absolute inset-0 dark:hidden [background:linear-gradient(180deg,rgba(255,255,255,0.20),rgba(255,255,255,0.48))]" />
 
       <div className="relative mx-auto max-w-[1100px] px-6 py-[104px]">
         {variant === 'inset' ? (

--- a/docs/app/(home)/_components/closing-cta.tsx
+++ b/docs/app/(home)/_components/closing-cta.tsx
@@ -18,7 +18,7 @@ function ClosingCtas({ stacked }: { stacked?: boolean }) {
         href={links.repo}
         target="_blank"
         rel="noopener noreferrer"
-        className={`inline-flex h-[46px] items-center justify-center gap-2 rounded-xl border border-white/20 bg-white/[0.06] ${stacked ? 'px-6' : 'px-5'} text-[15px] font-semibold text-white no-underline transition-colors hover:bg-white/[0.12]`}
+        className={`inline-flex h-[46px] items-center justify-center gap-2 rounded-xl border border-fd-border bg-fd-muted/40 ${stacked ? 'px-6' : 'px-5'} text-[15px] font-semibold text-fd-foreground no-underline transition-colors hover:bg-fd-muted dark:border-white/20 dark:bg-white/[0.06] dark:text-white dark:hover:bg-white/[0.12]`}
       >
         <GitHubIcon className="size-[17px]" /> Star on GitHub
       </a>
@@ -32,23 +32,26 @@ function ClosingCtas({ stacked }: { stacked?: boolean }) {
  */
 export function ClosingCTA({ variant = 'centered' }: { variant?: 'centered' | 'inset' }) {
   return (
-    <section
-      className="relative overflow-hidden border-t border-fd-border bg-[#05080a] bg-cover bg-center text-white"
-      style={{ backgroundImage: 'url(/chimely/closing-abstract.png)' }}
-    >
-      {/* Subtle FlutedGlass over the image (lazy, reduced-motion-safe) */}
-      <FlutedGlassBand />
-      {/* Scrim for text contrast */}
-      <div className="absolute inset-0 [background:linear-gradient(180deg,rgba(4,7,9,0.62),rgba(4,7,9,0.82))]" />
+    <section className="relative overflow-hidden border-t border-fd-border bg-fd-background text-fd-foreground dark:bg-[#05080a] dark:text-white">
+      {/* Dark-mode art: abstract image, fluted glass (lazy, reduced-motion-safe), scrim. Hidden in light. */}
+      <div
+        className="absolute inset-0 hidden bg-cover bg-center dark:block"
+        style={{ backgroundImage: 'url(/chimely/closing-abstract.png)' }}
+      >
+        <FlutedGlassBand />
+        <div className="absolute inset-0 [background:linear-gradient(180deg,rgba(4,7,9,0.62),rgba(4,7,9,0.82))]" />
+      </div>
+      {/* Light-mode art: soft accent glow over the page background. */}
+      <div className="absolute inset-0 dark:hidden [background:radial-gradient(100%_120%_at_85%_8%,rgba(18,100,255,0.08),transparent_55%)]" />
 
       <div className="relative mx-auto max-w-[1100px] px-6 py-[104px]">
         {variant === 'inset' ? (
-          <div className="flex flex-wrap items-center justify-between gap-7 rounded-[22px] border border-white/[0.16] bg-[#080c0e]/50 p-11 backdrop-blur">
+          <div className="flex flex-wrap items-center justify-between gap-7 rounded-[22px] border border-fd-border bg-fd-card p-11 dark:border-white/[0.16] dark:bg-[#080c0e]/50 dark:backdrop-blur">
             <div className="min-w-[280px] flex-1">
-              <h2 className="chimely-display text-balance text-[clamp(2.25rem,4.4vw,3.125rem)] leading-[1.05] tracking-[-0.01em] text-white">
+              <h2 className="chimely-display text-balance text-[clamp(2.25rem,4.4vw,3.125rem)] leading-[1.05] tracking-[-0.01em] text-fd-foreground dark:text-white">
                 Open source. Self-hosted. <span className="italic">Yours</span>.
               </h2>
-              <p className="mt-4 max-w-[54ch] text-[17px] leading-[1.6] text-white/[0.78]">
+              <p className="mt-4 max-w-[54ch] text-[17px] leading-[1.6] text-fd-muted-foreground dark:text-white/[0.78]">
                 {BODY}
               </p>
             </div>
@@ -56,10 +59,12 @@ export function ClosingCTA({ variant = 'centered' }: { variant?: 'centered' | 'i
           </div>
         ) : (
           <div className="flex flex-col items-center gap-5 text-center">
-            <h2 className="chimely-display max-w-[16ch] text-balance text-[clamp(2.5rem,5vw,3.5rem)] leading-[1.04] tracking-[-0.01em] text-white">
+            <h2 className="chimely-display max-w-[16ch] text-balance text-[clamp(2.5rem,5vw,3.5rem)] leading-[1.04] tracking-[-0.01em] text-fd-foreground dark:text-white">
               Open source. Self-hosted. <span className="italic">Yours</span>.
             </h2>
-            <p className="max-w-[60ch] text-[18px] leading-[1.6] text-white/[0.78]">{BODY}</p>
+            <p className="max-w-[60ch] text-[18px] leading-[1.6] text-fd-muted-foreground dark:text-white/[0.78]">
+              {BODY}
+            </p>
             <ClosingCtas />
           </div>
         )}

--- a/docs/app/(home)/_components/hero.tsx
+++ b/docs/app/(home)/_components/hero.tsx
@@ -10,7 +10,7 @@ const SUBHEAD =
 
 function Kicker() {
   return (
-    <span className="inline-flex w-fit items-center gap-2.5 rounded-full border border-white/[0.14] bg-white/[0.04] px-3.5 py-1.5 font-mono text-[12.5px] font-medium tracking-wide text-white/70">
+    <span className="inline-flex w-fit items-center gap-2.5 rounded-full border border-fd-border bg-fd-muted/50 px-3.5 py-1.5 font-mono text-[12.5px] font-medium tracking-wide text-fd-muted-foreground dark:border-white/[0.14] dark:bg-white/[0.04] dark:text-white/70">
       <span className="size-[7px] rounded-full bg-[#00D87D] shadow-[0_0_0_3px_rgba(0,216,125,0.18)] motion-safe:animate-pulse" />
       Open source · Self-hostable · v0.1.0
     </span>
@@ -30,7 +30,7 @@ function Ctas() {
         href={links.repo}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex h-[46px] items-center gap-2 rounded-xl border border-white/[0.18] bg-white/[0.05] px-5 text-[15px] font-semibold text-white no-underline transition-colors hover:bg-white/10"
+        className="inline-flex h-[46px] items-center gap-2 rounded-xl border border-fd-border bg-fd-muted/40 px-5 text-[15px] font-semibold text-fd-foreground no-underline transition-colors hover:bg-fd-muted dark:border-white/[0.18] dark:bg-white/[0.05] dark:text-white dark:hover:bg-white/10"
       >
         <GitHubIcon className="size-[17px]" /> Star on GitHub
       </a>
@@ -45,7 +45,7 @@ function Ctas() {
  */
 function Headline({ className }: { className: string }) {
   return (
-    <h1 className={`chimely-display text-balance text-white ${className}`}>
+    <h1 className={`chimely-display text-balance text-fd-foreground dark:text-white ${className}`}>
       Give your app a notification <span className="italic">inbox</span>.
     </h1>
   );
@@ -53,7 +53,7 @@ function Headline({ className }: { className: string }) {
 
 function InlineCommand() {
   return (
-    <div className="inline-flex w-fit items-center gap-3 rounded-xl border border-white/[0.13] bg-black/35 py-2.5 pl-4 pr-2.5 font-mono text-sm font-medium">
+    <div className="inline-flex w-fit items-center gap-3 rounded-xl border border-white/[0.13] bg-[#0E1117] py-2.5 pl-4 pr-2.5 font-mono text-sm font-medium">
       <span className="text-[#7EE0A6]">$</span>
       <span className="whitespace-nowrap text-[#E8EAED]">npx chimely dev</span>
       <ComingSoon />
@@ -84,15 +84,17 @@ export function Hero({
   shader?: HeroShaderName;
 }) {
   return (
-    <section className="relative overflow-hidden bg-[#05080a] text-white">
-      {/* Static base gradient (shows while the shader chunk loads) */}
-      <HeroGradient />
-      {/* Animated background shader (client, ssr:false) layered on top */}
-      <HeroShader shader={shader} />
-      {/* Dark scrim so foreground text keeps contrast over the shader */}
-      <div className="absolute inset-0 [background:linear-gradient(180deg,rgba(5,8,10,0.30)_0%,rgba(5,8,10,0.40)_50%,rgba(5,8,10,0.86)_100%)]" />
-      {/* Faint technical grid */}
-      <div className="absolute inset-0 [background-image:linear-gradient(to_right,rgba(255,255,255,0.045)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.045)_1px,transparent_1px)] [background-size:46px_46px] [mask-image:radial-gradient(120%_100%_at_50%_0%,#000_35%,transparent_78%)] [-webkit-mask-image:radial-gradient(120%_100%_at_50%_0%,#000_35%,transparent_78%)]" />
+    <section className="relative overflow-hidden bg-fd-background text-fd-foreground dark:bg-[#05080a] dark:text-white">
+      {/* Dark-mode art: base gradient, animated shader, contrast scrim, grid. Hidden in light. */}
+      <div className="absolute inset-0 hidden dark:block">
+        <HeroGradient />
+        <HeroShader shader={shader} />
+        <div className="absolute inset-0 [background:linear-gradient(180deg,rgba(5,8,10,0.30)_0%,rgba(5,8,10,0.40)_50%,rgba(5,8,10,0.86)_100%)]" />
+        <div className="absolute inset-0 [background-image:linear-gradient(to_right,rgba(255,255,255,0.045)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.045)_1px,transparent_1px)] [background-size:46px_46px] [mask-image:radial-gradient(120%_100%_at_50%_0%,#000_35%,transparent_78%)] [-webkit-mask-image:radial-gradient(120%_100%_at_50%_0%,#000_35%,transparent_78%)]" />
+      </div>
+      {/* Light-mode art: soft accent glow and a faint grid over the page background. */}
+      <div className="absolute inset-0 dark:hidden [background:radial-gradient(120%_90%_at_80%_8%,rgba(18,100,255,0.10),transparent_55%),radial-gradient(110%_100%_at_4%_100%,rgba(0,79,50,0.05),transparent_60%)]" />
+      <div className="absolute inset-0 dark:hidden [background-image:linear-gradient(to_right,rgba(13,13,13,0.035)_1px,transparent_1px),linear-gradient(to_bottom,rgba(13,13,13,0.035)_1px,transparent_1px)] [background-size:46px_46px] [mask-image:radial-gradient(120%_100%_at_50%_0%,#000_30%,transparent_75%)] [-webkit-mask-image:radial-gradient(120%_100%_at_50%_0%,#000_30%,transparent_75%)]" />
 
       <div className="relative mx-auto max-w-[1200px] px-6 pb-24 pt-32 md:pt-36">
         <HeroContent layout={layout} />
@@ -108,7 +110,9 @@ function HeroContent({ layout }: { layout: HeroLayout }) {
         <div className="flex flex-col items-center gap-5 text-center lg:items-start lg:text-left">
           <Kicker />
           <Headline className="text-[clamp(2.75rem,5.4vw,4.125rem)] leading-[1.03] tracking-[-0.01em]" />
-          <p className="max-w-[54ch] text-[18px] leading-[1.62] text-white/70">{SUBHEAD}</p>
+          <p className="max-w-[54ch] text-[18px] leading-[1.62] text-fd-muted-foreground dark:text-white/70">
+            {SUBHEAD}
+          </p>
           <div className="flex flex-wrap justify-center gap-3 lg:justify-start">
             <Ctas />
           </div>
@@ -126,7 +130,9 @@ function HeroContent({ layout }: { layout: HeroLayout }) {
       <div className="flex flex-col items-start gap-6 text-left">
         <Kicker />
         <Headline className="max-w-[18ch] text-[clamp(2.875rem,5.6vw,4.375rem)] leading-[1.02] tracking-[-0.01em]" />
-        <p className="max-w-[60ch] text-[19px] leading-[1.62] text-white/70">{SUBHEAD}</p>
+        <p className="max-w-[60ch] text-[19px] leading-[1.62] text-fd-muted-foreground dark:text-white/70">
+          {SUBHEAD}
+        </p>
         <div className="flex flex-wrap justify-start gap-3">
           <Ctas />
         </div>
@@ -143,7 +149,9 @@ function HeroContent({ layout }: { layout: HeroLayout }) {
       <div className="flex flex-col items-center gap-6 text-center">
         <Kicker />
         <Headline className="max-w-[15ch] text-[clamp(3rem,7vw,5.5rem)] leading-[1] tracking-[-0.01em]" />
-        <p className="max-w-[60ch] text-[19px] leading-[1.62] text-white/70">{SUBHEAD}</p>
+        <p className="max-w-[60ch] text-[19px] leading-[1.62] text-fd-muted-foreground dark:text-white/70">
+          {SUBHEAD}
+        </p>
         <div className="mt-0.5 flex flex-wrap justify-center gap-3">
           <Ctas />
         </div>
@@ -157,7 +165,9 @@ function HeroContent({ layout }: { layout: HeroLayout }) {
     <div className="flex flex-col items-center gap-6 text-center">
       <Kicker />
       <Headline className="max-w-[14ch] text-[clamp(2.875rem,6vw,4.75rem)] leading-[1.02] tracking-[-0.01em]" />
-      <p className="max-w-[62ch] text-[19px] leading-[1.62] text-white/70">{SUBHEAD}</p>
+      <p className="max-w-[62ch] text-[19px] leading-[1.62] text-fd-muted-foreground dark:text-white/70">
+        {SUBHEAD}
+      </p>
       <div className="mt-0.5 flex flex-wrap justify-center gap-3">
         <Ctas />
       </div>

--- a/docs/app/(home)/_components/hero.tsx
+++ b/docs/app/(home)/_components/hero.tsx
@@ -85,15 +85,20 @@ export function Hero({
 }) {
   return (
     <section className="relative overflow-hidden bg-fd-background text-fd-foreground dark:bg-[#05080a] dark:text-white">
-      {/* Dark-mode art: base gradient, animated shader, contrast scrim, grid. Hidden in light. */}
+      {/* Static base shown while the shader chunk loads. Split by theme via CSS. */}
       <div className="absolute inset-0 hidden dark:block">
         <HeroGradient />
-        <HeroShader shader={shader} />
+      </div>
+      <div className="absolute inset-0 dark:hidden [background:radial-gradient(120%_90%_at_80%_8%,rgba(18,100,255,0.10),transparent_55%),radial-gradient(110%_100%_at_4%_100%,rgba(0,79,50,0.05),transparent_60%)]" />
+      {/* Animated shader, theme-aware palette, so it renders in both themes. */}
+      <HeroShader shader={shader} />
+      {/* Dark-mode contrast scrim and grid over the shader. */}
+      <div className="absolute inset-0 hidden dark:block">
         <div className="absolute inset-0 [background:linear-gradient(180deg,rgba(5,8,10,0.30)_0%,rgba(5,8,10,0.40)_50%,rgba(5,8,10,0.86)_100%)]" />
         <div className="absolute inset-0 [background-image:linear-gradient(to_right,rgba(255,255,255,0.045)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.045)_1px,transparent_1px)] [background-size:46px_46px] [mask-image:radial-gradient(120%_100%_at_50%_0%,#000_35%,transparent_78%)] [-webkit-mask-image:radial-gradient(120%_100%_at_50%_0%,#000_35%,transparent_78%)]" />
       </div>
-      {/* Light-mode art: soft accent glow and a faint grid over the page background. */}
-      <div className="absolute inset-0 dark:hidden [background:radial-gradient(120%_90%_at_80%_8%,rgba(18,100,255,0.10),transparent_55%),radial-gradient(110%_100%_at_4%_100%,rgba(0,79,50,0.05),transparent_60%)]" />
+      {/* Light-mode veil and grid so dark text stays legible over the shader. */}
+      <div className="absolute inset-0 dark:hidden [background:linear-gradient(180deg,rgba(255,255,255,0.14)_0%,rgba(255,255,255,0.30)_48%,rgba(255,255,255,0.66)_100%)]" />
       <div className="absolute inset-0 dark:hidden [background-image:linear-gradient(to_right,rgba(13,13,13,0.035)_1px,transparent_1px),linear-gradient(to_bottom,rgba(13,13,13,0.035)_1px,transparent_1px)] [background-size:46px_46px] [mask-image:radial-gradient(120%_100%_at_50%_0%,#000_30%,transparent_75%)] [-webkit-mask-image:radial-gradient(120%_100%_at_50%_0%,#000_30%,transparent_75%)]" />
 
       <div className="relative mx-auto max-w-[1200px] px-6 pb-24 pt-32 md:pt-36">

--- a/docs/app/(home)/_components/icons.tsx
+++ b/docs/app/(home)/_components/icons.tsx
@@ -77,6 +77,21 @@ export const XIcon = (props: IconProps) => (
   </Stroke>
 );
 
+export const MinusIcon = (props: IconProps) => (
+  <Stroke strokeWidth={2.2} {...props}>
+    <path d="M5 12h14" />
+  </Stroke>
+);
+
+export const GitCompareIcon = (props: IconProps) => (
+  <Stroke {...props}>
+    <circle cx="18" cy="18" r="3" />
+    <circle cx="6" cy="6" r="3" />
+    <path d="M13 6h3a2 2 0 0 1 2 2v7" />
+    <path d="M11 18H8a2 2 0 0 1-2-2V9" />
+  </Stroke>
+);
+
 // Feature icons
 export const BellIcon = (props: IconProps) => (
   <Stroke {...props}>

--- a/docs/app/(home)/_components/shaders/fluted-glass-band.tsx
+++ b/docs/app/(home)/_components/shaders/fluted-glass-band.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import dynamic from 'next/dynamic';
+import { useTheme } from 'next-themes';
 import { useEffect, useRef, useState } from 'react';
 
 /**
@@ -8,16 +9,26 @@ import { useEffect, useRef, useState } from 'react';
  * under the browser's WebGL-context cap. Client-only (ssr: false) and mounted
  * lazily: it only initializes once the closing band nears the viewport. Under
  * prefers-reduced-motion it never mounts. In both cases the parent section's own
- * background image remains as the on-brand fallback, so contrast is preserved.
+ * background remains as the on-brand fallback, so contrast is preserved.
+ *
+ * Theme-aware: the dark variant refracts the near-black closing-abstract image,
+ * the light variant is a flat frosted-glass texture (no dark image) so the band
+ * still renders in light mode.
  */
 const FlutedGlass = dynamic(
   () => import('@paper-design/shaders-react').then((m) => m.FlutedGlass),
   { ssr: false },
 );
 
+const FILL = { position: 'absolute', inset: 0, width: '100%', height: '100%' } as const;
+
 export function FlutedGlassBand() {
   const ref = useRef<HTMLDivElement>(null);
   const [show, setShow] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const { resolvedTheme } = useTheme();
+
+  useEffect(() => setMounted(true), []);
 
   useEffect(() => {
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
@@ -36,30 +47,53 @@ export function FlutedGlassBand() {
     return () => io.disconnect();
   }, []);
 
+  const light = mounted && resolvedTheme === 'light';
+
   return (
     <div ref={ref} aria-hidden className="absolute inset-0">
-      {show && (
-        <FlutedGlass
-          image="/chimely/closing-abstract.png"
-          colorBack="#00000000"
-          colorShadow="#000000"
-          colorHighlight="#ffffff"
-          size={0.5}
-          shadows={0.25}
-          highlights={0.1}
-          shape="lines"
-          angle={0}
-          distortionShape="prism"
-          distortion={0.5}
-          shift={0}
-          stretch={0}
-          blur={0}
-          edges={0.25}
-          margin={0}
-          fit="cover"
-          style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }}
-        />
-      )}
+      {show &&
+        (light ? (
+          <FlutedGlass
+            colorBack="#e9f0fb"
+            colorShadow="#7f9dc6"
+            colorHighlight="#ffffff"
+            size={0.5}
+            shadows={0.3}
+            highlights={0.2}
+            shape="lines"
+            angle={0}
+            distortionShape="prism"
+            distortion={0.5}
+            shift={0}
+            stretch={0}
+            blur={0}
+            edges={0.25}
+            margin={0}
+            fit="cover"
+            style={FILL}
+          />
+        ) : (
+          <FlutedGlass
+            image="/chimely/closing-abstract.png"
+            colorBack="#00000000"
+            colorShadow="#000000"
+            colorHighlight="#ffffff"
+            size={0.5}
+            shadows={0.25}
+            highlights={0.1}
+            shape="lines"
+            angle={0}
+            distortionShape="prism"
+            distortion={0.5}
+            shift={0}
+            stretch={0}
+            blur={0}
+            edges={0.25}
+            margin={0}
+            fit="cover"
+            style={FILL}
+          />
+        ))}
     </div>
   );
 }

--- a/docs/app/(home)/_components/shaders/hero-shader.tsx
+++ b/docs/app/(home)/_components/shaders/hero-shader.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import dynamic from 'next/dynamic';
+import { useTheme } from 'next-themes';
 import { useEffect, useState } from 'react';
 
 /**
@@ -9,6 +10,11 @@ import { useEffect, useState } from 'react';
  * during SSR/hydration. This is the eager, above-the-fold shader. Keep the page
  * total at two shader instances (this + the closing FlutedGlass) to stay under
  * the browser WebGL-context cap.
+ *
+ * `HeroShader` resolves the theme and renders one of two self-contained
+ * variants: `DarkShader` (the near-black brand palette) or `LightShader` (a soft
+ * blue-on-white palette). Keeping them separate means the dark path is never
+ * touched when the light path changes.
  */
 const FILL = { position: 'absolute', inset: 0, width: '100%', height: '100%' } as const;
 
@@ -31,6 +37,10 @@ export type HeroShaderName = 'panels' | 'mesh' | 'dots' | 'warp';
 
 export function HeroShader({ shader = 'panels' }: { shader?: HeroShaderName }) {
   const [reduced, setReduced] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const { resolvedTheme } = useTheme();
+
+  useEffect(() => setMounted(true), []);
 
   useEffect(() => {
     const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
@@ -40,9 +50,20 @@ export function HeroShader({ shader = 'panels' }: { shader?: HeroShaderName }) {
     return () => mq.removeEventListener('change', update);
   }, []);
 
-  // Honor reduced motion: static on-brand gradient instead of the animated shader.
-  if (reduced) return <HeroGradient />;
+  // Render nothing until the theme resolves on the client, so light mode never
+  // flashes the dark palette. The static base gradient covers this window.
+  if (!mounted) return null;
 
+  const light = resolvedTheme === 'light';
+
+  // Honor reduced motion: static on-brand gradient instead of the animated shader.
+  if (reduced) return <HeroGradient light={light} />;
+
+  return light ? <LightShader shader={shader} /> : <DarkShader shader={shader} />;
+}
+
+/** Near-black brand palette. This is the original hero shader, unchanged. */
+function DarkShader({ shader }: { shader: HeroShaderName }) {
   if (shader === 'mesh') {
     return (
       <MeshGradient
@@ -68,7 +89,6 @@ export function HeroShader({ shader = 'panels' }: { shader?: HeroShaderName }) {
   if (shader === 'warp') {
     return <Warp colors={['#04070a', '#004F32', '#1264FF']} speed={0.5} scale={1} style={FILL} />;
   }
-  // panels (default), the brief's ColorPanels preset
   return (
     <ColorPanels
       colors={['#1467ff']}
@@ -92,18 +112,69 @@ export function HeroShader({ shader = 'panels' }: { shader?: HeroShaderName }) {
   );
 }
 
+/** Soft blue-on-white palette, mirroring `DarkShader` for light mode. */
+function LightShader({ shader }: { shader: HeroShaderName }) {
+  if (shader === 'mesh') {
+    return (
+      <MeshGradient
+        colors={['#ffffff', '#e6efff', '#c7dbff', '#7aa5f5']}
+        distortion={1}
+        swirl={0.65}
+        speed={0.4}
+        style={FILL}
+      />
+    );
+  }
+  if (shader === 'dots') {
+    return (
+      <DotOrbit
+        colors={['#1264FF', '#3b82f6', '#7aa5f5']}
+        colorBack="#ffffff"
+        scale={0.4}
+        speed={0.8}
+        style={FILL}
+      />
+    );
+  }
+  if (shader === 'warp') {
+    return <Warp colors={['#ffffff', '#dff0e8', '#9cc0ff']} speed={0.5} scale={1} style={FILL} />;
+  }
+  return (
+    <ColorPanels
+      colors={['#1467ff']}
+      colorBack="#ffffff"
+      density={2.21}
+      angle1={-1}
+      angle2={-1}
+      length={0.56}
+      edges
+      blur={0.15}
+      fadeIn={0}
+      fadeOut={1}
+      gradient={0}
+      speed={2}
+      scale={2.32}
+      rotation={360}
+      offsetX={0.38}
+      offsetY={0.6}
+      style={FILL}
+    />
+  );
+}
+
 /**
  * Static on-brand gradient. Rendered as the base layer beneath the shader (so the
  * hero looks right while the shader chunk loads) and as the reduced-motion fallback.
  */
-export function HeroGradient() {
+export function HeroGradient({ light = false }: { light?: boolean }) {
   return (
     <div
       aria-hidden
       className="absolute inset-0"
       style={{
-        background:
-          'radial-gradient(120% 90% at 80% 14%, rgba(18,100,255,0.40), transparent 58%), radial-gradient(110% 105% at 8% 96%, rgba(0,79,50,0.55), transparent 60%), radial-gradient(90% 80% at 52% 48%, rgba(8,92,82,0.18), transparent 72%), #04070a',
+        background: light
+          ? 'radial-gradient(120% 90% at 80% 14%, rgba(18,100,255,0.14), transparent 58%), radial-gradient(110% 105% at 8% 96%, rgba(0,79,50,0.05), transparent 60%), #ffffff'
+          : 'radial-gradient(120% 90% at 80% 14%, rgba(18,100,255,0.40), transparent 58%), radial-gradient(110% 105% at 8% 96%, rgba(0,79,50,0.55), transparent 60%), radial-gradient(90% 80% at 52% 48%, rgba(8,92,82,0.18), transparent 72%), #04070a',
       }}
     />
   );

--- a/docs/app/(home)/comparison/page.tsx
+++ b/docs/app/(home)/comparison/page.tsx
@@ -1,0 +1,289 @@
+import type { Metadata } from 'next';
+import { ArrowRight, CheckIcon, GitCompareIcon, GitHubIcon, MinusIcon } from '../_components/icons';
+import { links } from '../_components/links';
+import { FlutedGlassBand } from '../_components/shaders/fluted-glass-band';
+import { SiteFooter } from '../_components/site-footer';
+import { SiteHeader } from '../_components/site-header';
+import { geistMono, instrumentSerif } from '../fonts';
+
+export const metadata: Metadata = {
+  title: 'Chimely vs Novu',
+  description:
+    'How Chimely, the in-app notification inbox, compares to Novu, the multi-channel notification platform.',
+};
+
+// Chimely-column claims are verified against server/ and packages/. Novu-column
+// entries reflect Novu's public positioning and are hedged in the footnote.
+const rows: { feature: string; chimely: string; novu: string }[] = [
+  {
+    feature: 'Core model',
+    chimely: 'In-app notification inbox',
+    novu: 'Multi-channel workflow engine',
+  },
+  {
+    feature: 'Channels',
+    chimely: 'In-app inbox, web-push later',
+    novu: 'Email, SMS, push, chat, in-app',
+  },
+  {
+    feature: 'Send a notification',
+    chimely: 'One POST /v1/notifications',
+    novu: 'Trigger a workflow of steps',
+  },
+  {
+    feature: 'Larger fan-out',
+    chimely: 'One broadcast, fanned out on read',
+    novu: 'Topics and subscribers',
+  },
+  {
+    feature: 'Templates',
+    chimely: 'None, render in your own UI',
+    novu: 'Server-side template editor',
+  },
+  { feature: 'Data stores', chimely: 'Postgres, Redis optional', novu: 'MongoDB and Redis' },
+  { feature: 'Deployment', chimely: 'A single Rust binary', novu: 'Several coordinated services' },
+  {
+    feature: 'Real-time',
+    chimely: 'SSE, with REST as the source of truth',
+    novu: 'WebSocket (socket.io)',
+  },
+  {
+    feature: 'React UI',
+    chimely: 'Drop-in <Inbox /> plus headless hooks',
+    novu: '<Inbox /> notification center',
+  },
+  {
+    feature: 'Multi-tenancy',
+    chimely: 'Run another instance',
+    novu: 'Orgs and environments built in',
+  },
+  {
+    feature: 'Delivery safety',
+    chimely: 'Transactional outbox, at-least-once, idempotency keys',
+    novu: 'Workflow execution engine',
+  },
+  { feature: 'Managed cloud', chimely: 'None, self-host only', novu: 'Novu Cloud available' },
+  { feature: 'License', chimely: 'AGPL-3.0 server, MIT SDKs', novu: 'MIT, open-source core' },
+];
+
+function CompareHero() {
+  return (
+    <section className="relative overflow-hidden border-b border-fd-border bg-fd-background text-fd-foreground dark:bg-[#05080a] dark:text-white">
+      {/* Dark-mode art: accent glow, faint grid, contrast scrim. Hidden in light. */}
+      <div className="absolute inset-0 hidden dark:block">
+        <div className="absolute inset-0 [background:radial-gradient(120%_90%_at_82%_6%,rgba(18,100,255,0.34),transparent_56%),radial-gradient(105%_105%_at_4%_100%,rgba(0,79,50,0.44),transparent_60%),#04070a]" />
+        <div className="absolute inset-0 [background-image:linear-gradient(to_right,rgba(255,255,255,0.045)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.045)_1px,transparent_1px)] [background-size:46px_46px] [mask-image:radial-gradient(120%_100%_at_50%_0%,#000_30%,transparent_76%)] [-webkit-mask-image:radial-gradient(120%_100%_at_50%_0%,#000_30%,transparent_76%)]" />
+        <div className="absolute inset-0 [background:linear-gradient(180deg,rgba(5,8,10,0.24)_0%,rgba(5,8,10,0.42)_52%,rgba(5,8,10,0.86)_100%)]" />
+      </div>
+      {/* Light-mode art: soft accent glow and a faint grid over the page background. */}
+      <div className="absolute inset-0 dark:hidden [background:radial-gradient(120%_90%_at_82%_6%,rgba(18,100,255,0.10),transparent_56%),radial-gradient(105%_105%_at_4%_100%,rgba(0,79,50,0.05),transparent_60%)]" />
+      <div className="absolute inset-0 dark:hidden [background-image:linear-gradient(to_right,rgba(13,13,13,0.035)_1px,transparent_1px),linear-gradient(to_bottom,rgba(13,13,13,0.035)_1px,transparent_1px)] [background-size:46px_46px] [mask-image:radial-gradient(120%_100%_at_50%_0%,#000_30%,transparent_76%)] [-webkit-mask-image:radial-gradient(120%_100%_at_50%_0%,#000_30%,transparent_76%)]" />
+
+      <div className="relative mx-auto flex max-w-[920px] flex-col items-center gap-5 px-6 pb-[66px] pt-[140px] text-center">
+        <span className="inline-flex items-center gap-2.5 rounded-full border border-fd-border bg-fd-muted/50 px-3.5 py-1.5 font-mono text-[12.5px] font-medium tracking-wide text-fd-muted-foreground dark:border-white/[0.14] dark:bg-white/[0.04] dark:text-white/70">
+          <GitCompareIcon className="size-3.5" />
+          Comparison
+        </span>
+        <h1 className="chimely-display text-balance text-[clamp(3rem,8vw,5.375rem)] leading-[1.0] tracking-[-0.01em] text-fd-foreground dark:text-white">
+          Chimely <span className="italic text-fd-muted-foreground dark:text-white/60">vs</span>{' '}
+          Novu
+        </h1>
+        <p className="max-w-[64ch] text-[19px] leading-[1.62] text-fd-muted-foreground dark:text-white/[0.74]">
+          Both are open-source notification tools, but they solve different-sized problems. Novu is
+          a multi-channel workflow platform. Chimely is just the in-app inbox: one binary, one
+          Postgres, one{' '}
+          <span className="font-mono text-[0.9em] text-fd-foreground dark:text-white">POST</span>.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+function FeatureMatrix() {
+  return (
+    <section className="bg-fd-background px-6 py-[88px]">
+      <div className="mx-auto max-w-[1000px]">
+        <span className="inline-flex items-center gap-2 rounded-full border border-[#1264FF]/30 bg-[#1264FF]/10 px-3 py-[5px] font-mono text-xs font-medium uppercase tracking-wider text-[#1264FF]">
+          Feature by feature
+        </span>
+        <h2 className="mt-3.5 text-balance chimely-display text-[clamp(2rem,4vw,3rem)] leading-[1.05] tracking-[-0.005em] text-fd-foreground">
+          Where they <span className="italic text-[#1264FF]">actually</span> differ
+        </h2>
+
+        <div className="mt-[34px] overflow-x-auto">
+          <table className="w-full min-w-[660px] border-separate border-spacing-0 text-left">
+            <thead>
+              <tr>
+                <th className="w-[32%] px-[18px] pb-3.5 align-bottom" />
+                <th className="w-[34%] rounded-t-xl border-b-2 border-[#1264FF] bg-[#1264FF]/[0.07] px-[18px] py-3.5 align-bottom">
+                  <span className="inline-flex items-center gap-2 text-[16px] font-semibold text-fd-foreground">
+                    <span className="size-2 rounded-full bg-[#1264FF] shadow-[0_0_0_3px_rgba(18,100,255,0.22)]" />
+                    Chimely
+                  </span>
+                </th>
+                <th className="w-[34%] px-[18px] pb-3.5 align-bottom text-[16px] font-semibold text-fd-muted-foreground">
+                  Novu
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, i) => {
+                const last = i === rows.length - 1;
+                return (
+                  <tr key={row.feature}>
+                    <td className="border-b border-fd-border px-[18px] py-[15px] align-top text-[14.5px] font-medium leading-[1.5] text-fd-muted-foreground">
+                      {row.feature}
+                    </td>
+                    <td
+                      className={`bg-[#1264FF]/[0.06] px-[18px] py-[15px] align-top text-[14.5px] font-medium leading-[1.5] text-fd-foreground ${
+                        last ? 'rounded-b-xl' : 'border-b border-fd-border'
+                      }`}
+                    >
+                      {row.chimely}
+                    </td>
+                    <td className="border-b border-fd-border px-[18px] py-[15px] align-top text-[14.5px] leading-[1.5] text-fd-muted-foreground">
+                      {row.novu}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        <p className="mt-5 max-w-[82ch] font-mono text-[12.5px] leading-[1.6] text-fd-muted-foreground/80">
+          Reflects each project&apos;s public positioning as of July 2026. Both are actively
+          developed and details change. Chimely optimizes for a small in-app inbox, Novu for
+          multi-channel orchestration.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+const chimelyFits = [
+  'You need an in-app inbox (the bell, the badge, the list) and not much else.',
+  'You already run Postgres and want one more binary, not one more datastore.',
+  'You would rather render notifications in your own components.',
+  'You want to self-host with the fewest moving parts, per-tenant by instance.',
+];
+
+const novuFits = [
+  'You need to orchestrate email, SMS, push and in-app from one place.',
+  'You want a visual workflow editor and managed, server-side templates.',
+  'A hosted cloud option matters, alongside self-hosting.',
+  'Multiple teams share one messaging platform with orgs and environments.',
+];
+
+function WhichFits() {
+  return (
+    <section className="border-t border-fd-border bg-fd-muted/30 px-6 py-[88px]">
+      <div className="mx-auto max-w-[1000px]">
+        <h2 className="text-balance text-center chimely-display text-[clamp(2rem,4vw,3rem)] leading-[1.05] tracking-[-0.005em] text-fd-foreground">
+          Which one <span className="italic text-[#1264FF]">fits</span> your problem?
+        </h2>
+        <div className="mt-10 grid gap-[18px] text-left [grid-template-columns:repeat(auto-fit,minmax(280px,1fr))]">
+          <div className="rounded-[18px] border border-[#1264FF] bg-[#1264FF]/[0.06] p-7">
+            <div className="flex items-center gap-2.5 text-[18px] font-semibold text-fd-foreground">
+              <span className="size-2.5 rounded-full bg-[#1264FF] shadow-[0_0_0_3px_rgba(18,100,255,0.22)]" />
+              Reach for Chimely when
+            </div>
+            <ul className="mt-[18px] flex flex-col gap-3">
+              {chimelyFits.map((item) => (
+                <li
+                  key={item}
+                  className="flex items-start gap-[11px] text-[15px] leading-[1.55] text-fd-muted-foreground"
+                >
+                  <CheckIcon className="mt-[3px] size-4 shrink-0 text-[#1264FF]" />
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="rounded-[18px] border border-fd-border bg-fd-card p-7">
+            <div className="flex items-center gap-2.5 text-[18px] font-semibold text-fd-foreground">
+              <span className="size-2.5 rounded-full bg-fd-muted-foreground/60" />
+              Reach for Novu when
+            </div>
+            <ul className="mt-[18px] flex flex-col gap-3">
+              {novuFits.map((item) => (
+                <li
+                  key={item}
+                  className="flex items-start gap-[11px] text-[15px] leading-[1.55] text-fd-muted-foreground"
+                >
+                  <MinusIcon className="mt-[3px] size-4 shrink-0 text-fd-muted-foreground/70" />
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CompareClosing() {
+  return (
+    <section className="relative overflow-hidden border-t border-fd-border bg-fd-background text-fd-foreground dark:bg-[#05080a] dark:text-white">
+      {/* Dark-mode art: abstract image, fluted glass, contrast scrim. Hidden in light. */}
+      <div
+        className="absolute inset-0 hidden bg-cover bg-center dark:block"
+        style={{ backgroundImage: 'url(/chimely/closing-abstract.png)' }}
+      >
+        <FlutedGlassBand />
+        <div className="absolute inset-0 [background:linear-gradient(180deg,rgba(4,7,9,0.64),rgba(4,7,9,0.84))]" />
+      </div>
+      {/* Light-mode art: soft accent glow over the page background. */}
+      <div className="absolute inset-0 dark:hidden [background:radial-gradient(100%_120%_at_85%_8%,rgba(18,100,255,0.08),transparent_55%)]" />
+
+      <div className="relative mx-auto flex max-w-[1000px] flex-col items-center gap-5 px-6 py-24 text-center">
+        <h2 className="chimely-display max-w-[18ch] text-balance text-[clamp(2.5rem,5vw,3.625rem)] leading-[1.02] tracking-[-0.01em] text-fd-foreground dark:text-white">
+          Just need the <span className="italic">inbox</span>?
+        </h2>
+        <p className="max-w-[60ch] text-[18px] leading-[1.6] text-fd-muted-foreground dark:text-white/[0.78]">
+          Chimely is the in-app inbox, unbundled from the platform. One binary, one Postgres, one{' '}
+          <span className="font-mono text-[0.9em] text-fd-foreground dark:text-white">POST</span>,
+          self-hosted and yours.
+        </p>
+        <div className="mt-1 flex flex-wrap justify-center gap-3">
+          <a
+            href={links.docs}
+            className="inline-flex h-[46px] items-center gap-2 rounded-xl bg-[#1264FF] px-[22px] text-[15px] font-semibold text-white no-underline shadow-[0_10px_30px_-10px_rgba(18,100,255,0.7)] transition-colors hover:bg-[#0b53e0]"
+          >
+            Get started <ArrowRight className="size-4" />
+          </a>
+          <a
+            href={links.repo}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex h-[46px] items-center gap-2 rounded-xl border border-fd-border bg-fd-muted/40 px-5 text-[15px] font-semibold text-fd-foreground no-underline transition-colors hover:bg-fd-muted dark:border-white/20 dark:bg-white/[0.06] dark:text-white dark:hover:bg-white/[0.12]"
+          >
+            <GitHubIcon className="size-[17px]" /> Star on GitHub
+          </a>
+          <a
+            href="/"
+            className="inline-flex h-[46px] items-center gap-1.5 rounded-xl px-4 text-[15px] font-semibold text-fd-muted-foreground no-underline transition-colors hover:text-fd-foreground dark:text-white/[0.82] dark:hover:text-white"
+          >
+            <ArrowRight className="size-4 rotate-180" /> Back to overview
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default function ComparisonPage() {
+  return (
+    <main
+      className={`${geistMono.variable} ${instrumentSerif.variable} chimely-home bg-fd-background text-fd-foreground`}
+    >
+      <SiteHeader />
+      <CompareHero />
+      <FeatureMatrix />
+      <WhichFits />
+      <CompareClosing />
+      <SiteFooter />
+    </main>
+  );
+}

--- a/docs/app/(home)/comparison/page.tsx
+++ b/docs/app/(home)/comparison/page.tsx
@@ -226,16 +226,17 @@ function WhichFits() {
 function CompareClosing() {
   return (
     <section className="relative overflow-hidden border-t border-fd-border bg-fd-background text-fd-foreground dark:bg-[#05080a] dark:text-white">
-      {/* Dark-mode art: abstract image, fluted glass, contrast scrim. Hidden in light. */}
+      {/* Base: the near-black abstract image in dark mode, a soft accent glow in light. */}
       <div
         className="absolute inset-0 hidden bg-cover bg-center dark:block"
         style={{ backgroundImage: 'url(/chimely/closing-abstract.png)' }}
-      >
-        <FlutedGlassBand />
-        <div className="absolute inset-0 [background:linear-gradient(180deg,rgba(4,7,9,0.64),rgba(4,7,9,0.84))]" />
-      </div>
-      {/* Light-mode art: soft accent glow over the page background. */}
+      />
       <div className="absolute inset-0 dark:hidden [background:radial-gradient(100%_120%_at_85%_8%,rgba(18,100,255,0.08),transparent_55%)]" />
+      {/* Fluted-glass shader (lazy, reduced-motion-safe, theme-aware), renders in both themes. */}
+      <FlutedGlassBand />
+      {/* Contrast scrim so the CTA text stays legible over the shader. */}
+      <div className="absolute inset-0 hidden dark:block [background:linear-gradient(180deg,rgba(4,7,9,0.64),rgba(4,7,9,0.84))]" />
+      <div className="absolute inset-0 dark:hidden [background:linear-gradient(180deg,rgba(255,255,255,0.20),rgba(255,255,255,0.48))]" />
 
       <div className="relative mx-auto flex max-w-[1000px] flex-col items-center gap-5 px-6 py-24 text-center">
         <h2 className="chimely-display max-w-[18ch] text-balance text-[clamp(2.5rem,5vw,3.625rem)] leading-[1.02] tracking-[-0.01em] text-fd-foreground dark:text-white">


### PR DESCRIPTION
## What

Two docs-site changes:

**1. Adds the `/comparison` page (`feat`)** — fixes the dead homepage
"Chimely vs Novu →" link, which pointed at `/comparison` with no route
behind it (404). Built from the `Chimely vs Novu.dc.html` design and
ported to the repo idiom (Tailwind + Fumadocs `fd-*` tokens, shared
`SiteHeader`/`SiteFooter`/`FlutedGlassBand`, `next/font`). Every
Chimely-column claim in the feature matrix is verified against `server/`
and `packages/` (routes, the 100-recipient cap + `/v1/broadcasts`,
`ALLOWED_CHANNELS=["in_app"]`, Redis-optional LISTEN/NOTIFY, SSE
`/v1/inbox/stream`, the exported hooks, transactional outbox +
idempotency keys, `environment_id` isolation, AGPL/MIT). Em-dashes
stripped from the copy.

**2. Light-mode hero + closing bands (`fix`)** — those two shader bands
were hardcoded dark in both themes, so light mode showed jarring black
bands. The dark art (WebGL shader, fluted glass, gradients, grid) is now
gated behind the class-based `dark:` variant, with a soft light
treatment in light mode. Dark mode is unchanged; code panels stay dark
by convention. Applied to the home page and the new comparison page.

## Verification

- `tsc --noEmit` ✓, `biome ci` ✓
- Static export build ✓ (`out/comparison.html` prerenders, 52/52 pages)
- Verified visually in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
