### PR TITLE
feat(react): footer, header title, relative time, localization pass

### DIFF
--- a/.changeset/tall-berries-brush.md
+++ b/.changeset/tall-berries-brush.md
@@ -1,0 +1,5 @@
+---
+"@chimely/react": minor
+---
+
+Inbox popover polish: `renderFooter` render prop, a list-view header title, relative timestamps in the default item (overridable via `localization.formatTimestamp`), and a localization pass covering the bell and back-button aria-labels plus `categoryLabels` display names in the preferences panel.

--- a/docs/content/docs/sdk-reference.mdx
+++ b/docs/content/docs/sdk-reference.mdx
@@ -47,12 +47,36 @@ uses the context client).
 | `renderItem` | `(ctx) => ReactNode` | — | Custom item renderer |
 | `renderBell` | `(ctx) => ReactNode` | — | Custom bell/badge renderer |
 | `renderEmpty` | `() => ReactNode` | — | Custom empty state |
+| `renderFooter` | `() => ReactNode` | — | Content for the popover footer (branding, links) |
 
 `appearance.variables` forwards keys as `--chimely-<key>` CSS custom
 properties (`colorPrimary`, `colorBackground`, `colorBadge`, `borderRadius`,
 `fontFamily`, …). `appearance.classNames` overrides slots: `root`, `bell`,
 `badge`, `popover`, `header`, `list`, `item`, `itemUnread`, `empty`, `footer`,
 `preferences`.
+
+### Localization
+
+Every user-visible string routes through `localization`. All fields optional;
+omitted keys keep the `en-US` defaults.
+
+| Key | Default | Notes |
+|---|---|---|
+| `emptyTitle` | `No notifications` | |
+| `emptyBody` | `You're all caught up.` | |
+| `markAllRead` | `Mark all as read` | |
+| `preferencesTitle` | `Notification preferences` | Preferences header and gear label |
+| `inboxTitle` | `Notifications` | List-view header title and dialog label |
+| `bellLabel` | `Notifications` | Bell button aria-label |
+| `backLabel` | `Back` | Preferences back button aria-label |
+| `categoryLabels` | `{}` | Display names for category keys in the preferences panel |
+| `formatTimestamp` | relative time | `(iso) => string` for item timestamps |
+| `newNotifications` | `N new notifications` | `(count) => string` |
+
+The default timestamp rendering is relative (`5 minutes ago`, via
+`Intl.RelativeTimeFormat`), falling back to the locale date past seven days.
+The absolute time stays on the `<time>` element's `dateTime` and `title`
+attributes.
 
 ## Hooks
 

--- a/packages/react/src/Inbox.tsx
+++ b/packages/react/src/Inbox.tsx
@@ -328,7 +328,7 @@ function InboxView<TPayload>(props: InboxProps<TPayload>): ReactNode {
           ref={popoverRef}
           className={cls('popover')}
           role="dialog"
-          aria-label={strings.inboxTitle}
+          aria-label={showPreferences ? strings.preferencesTitle : strings.inboxTitle}
         >
           <div className={cls('header')}>
             {showPreferences ? (

--- a/packages/react/src/Inbox.tsx
+++ b/packages/react/src/Inbox.tsx
@@ -9,6 +9,7 @@ import type { InboxLocalization } from './localization';
 import { mergeLocalization } from './localization';
 import { isSafeActionUrl, navigation } from './navigation';
 import { ensureStyles } from './styles';
+import { useNow } from './time';
 
 /** Named slots for classNames overrides. This union only ever widens. */
 export type InboxSlot =
@@ -88,6 +89,7 @@ export interface InboxProps<TPayload = WellKnownPayload> {
   renderItem?: (ctx: { item: InboxItem<TPayload>; markRead: () => Promise<void> }) => ReactNode;
   renderBell?: (ctx: { unseenCount: number; open: boolean }) => ReactNode;
   renderEmpty?: () => ReactNode;
+  renderFooter?: () => ReactNode;
 }
 
 export function Inbox<TPayload = WellKnownPayload>(props: InboxProps<TPayload>): ReactNode {
@@ -170,6 +172,9 @@ function InboxView<TPayload>(props: InboxProps<TPayload>): ReactNode {
   useEffect(() => {
     ensureStyles();
   }, []);
+
+  // Minute tick keeps relative timestamps current while the list is visible.
+  useNow(open && !showPreferences ? 60_000 : null);
 
   useEffect(() => {
     if (!open) {
@@ -303,7 +308,7 @@ function InboxView<TPayload>(props: InboxProps<TPayload>): ReactNode {
         ref={bellRef}
         type="button"
         className={cls('bell')}
-        aria-label="Notifications"
+        aria-label={strings.bellLabel}
         aria-expanded={open}
         onClick={handleBellClick}
       >
@@ -319,14 +324,19 @@ function InboxView<TPayload>(props: InboxProps<TPayload>): ReactNode {
         )}
       </button>
       {open && (
-        <div ref={popoverRef} className={cls('popover')} role="dialog" aria-label="Notifications">
+        <div
+          ref={popoverRef}
+          className={cls('popover')}
+          role="dialog"
+          aria-label={strings.inboxTitle}
+        >
           <div className={cls('header')}>
             {showPreferences ? (
               <>
                 <button
                   type="button"
                   className="chimely-header-action"
-                  aria-label="Back"
+                  aria-label={strings.backLabel}
                   onClick={() => setShowPreferences(false)}
                 >
                   ←
@@ -335,26 +345,29 @@ function InboxView<TPayload>(props: InboxProps<TPayload>): ReactNode {
               </>
             ) : (
               <>
-                <button
-                  type="button"
-                  className="chimely-header-action"
-                  onClick={() => {
-                    void markAllRead();
-                  }}
-                >
-                  {strings.markAllRead}
-                </button>
-                {props.preferencesPanel !== false && (
+                <span className="chimely-header-title">{strings.inboxTitle}</span>
+                <div className="chimely-header-actions">
                   <button
                     type="button"
                     className="chimely-header-action"
-                    aria-label={strings.preferencesTitle}
-                    title={strings.preferencesTitle}
-                    onClick={() => setShowPreferences(true)}
+                    onClick={() => {
+                      void markAllRead();
+                    }}
                   >
-                    <GearIcon />
+                    {strings.markAllRead}
                   </button>
-                )}
+                  {props.preferencesPanel !== false && (
+                    <button
+                      type="button"
+                      className="chimely-header-action"
+                      aria-label={strings.preferencesTitle}
+                      title={strings.preferencesTitle}
+                      onClick={() => setShowPreferences(true)}
+                    >
+                      <GearIcon />
+                    </button>
+                  )}
+                </div>
               </>
             )}
           </div>
@@ -362,7 +375,7 @@ function InboxView<TPayload>(props: InboxProps<TPayload>): ReactNode {
             <div className={cls('preferences')}>
               {categories.map((category) => (
                 <label key={category} className="chimely-preference">
-                  <span>{category}</span>
+                  <span>{strings.categoryLabels[category] ?? category}</span>
                   <input
                     type="checkbox"
                     checked={isEnabled(category)}
@@ -400,6 +413,7 @@ function InboxView<TPayload>(props: InboxProps<TPayload>): ReactNode {
                       <DefaultItem
                         item={item}
                         className={item.read ? cls('item') : `${cls('item')} ${cls('itemUnread')}`}
+                        formatTimestamp={strings.formatTimestamp}
                         onClick={() => handleItemClick(item)}
                       />
                     )}
@@ -409,7 +423,9 @@ function InboxView<TPayload>(props: InboxProps<TPayload>): ReactNode {
               <li ref={sentinelRef} className="chimely-sentinel" aria-hidden="true" />
             </ul>
           )}
-          <div className={cls('footer')} aria-busy={isLoading} />
+          <div className={cls('footer')} aria-busy={isLoading}>
+            {props.renderFooter?.()}
+          </div>
         </div>
       )}
     </div>
@@ -419,9 +435,10 @@ function InboxView<TPayload>(props: InboxProps<TPayload>): ReactNode {
 function DefaultItem<TPayload>(props: {
   item: InboxItem<TPayload>;
   className: string;
+  formatTimestamp: (iso: string) => string;
   onClick: () => void;
 }): ReactNode {
-  const { item, className, onClick } = props;
+  const { item, className, formatTimestamp, onClick } = props;
   const payload = item.payload as Partial<WellKnownPayload>;
   return (
     <button type="button" className={className} onClick={onClick}>
@@ -436,8 +453,12 @@ function DefaultItem<TPayload>(props: {
           // Plain text by construction. React escaping keeps it that way.
           <span className="chimely-item-body">{payload.body}</span>
         )}
-        <time className="chimely-item-time" dateTime={item.occurredAt}>
-          {new Date(item.occurredAt).toLocaleString()}
+        <time
+          className="chimely-item-time"
+          dateTime={item.occurredAt}
+          title={new Date(item.occurredAt).toLocaleString()}
+        >
+          {formatTimestamp(item.occurredAt)}
         </time>
       </span>
       {!item.read && <span className="chimely-item-dot" aria-hidden="true" />}

--- a/packages/react/src/inbox.test.tsx
+++ b/packages/react/src/inbox.test.tsx
@@ -248,6 +248,94 @@ describe('item click behavior', () => {
   });
 });
 
+describe('header title and footer', () => {
+  test('renders the default header title and renderFooter content', async () => {
+    const stub = createStubServer();
+    stub.addNotification();
+    await renderInbox(stub, {
+      renderFooter: () => <span data-testid="footer-brand">Acme</span>,
+    });
+    fireEvent.click(bell());
+    expect(document.querySelector('.chimely-header-title')?.textContent).toBe('Notifications');
+    expect(screen.getByTestId('footer-brand').closest('.chimely-footer')).not.toBeNull();
+  });
+
+  test('inboxTitle overrides the header title and the dialog label', async () => {
+    const stub = createStubServer();
+    await renderInbox(stub, { localization: { inboxTitle: 'Meldungen' } });
+    fireEvent.click(bell());
+    expect(screen.getByRole('dialog', { name: 'Meldungen' })).toBeDefined();
+    expect(document.querySelector('.chimely-header-title')?.textContent).toBe('Meldungen');
+  });
+});
+
+describe('localized labels', () => {
+  test('bellLabel and backLabel drive the aria labels', async () => {
+    const stub = createStubServer();
+    stub.addNotification({ category: 'billing.alerts' });
+    await renderInbox(stub, {
+      localization: { bellLabel: 'Meine Glocke', backLabel: 'Zurueck' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Meine Glocke' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Notification preferences' }));
+    expect(screen.getByRole('button', { name: 'Zurueck' })).toBeDefined();
+  });
+
+  test('categoryLabels rename preference rows, unknown keys fall back', async () => {
+    const stub = createStubServer();
+    stub.addNotification({ category: 'billing.alerts' });
+    stub.addNotification({ category: 'security.alerts' });
+    await renderInbox(stub, {
+      localization: { categoryLabels: { 'billing.alerts': 'Billing' } },
+    });
+    fireEvent.click(bell());
+    fireEvent.click(screen.getByRole('button', { name: 'Notification preferences' }));
+    expect(screen.getByText('Billing')).toBeDefined();
+    expect(screen.queryByText('billing.alerts')).toBeNull();
+    expect(screen.getByText('security.alerts')).toBeDefined();
+  });
+});
+
+describe('timestamps', () => {
+  test('recent items read as relative time with absolute dateTime and title', async () => {
+    const stub = createStubServer();
+    stub.addNotification({
+      payload: { title: 'fresh' },
+      occurred_at: new Date(Date.now() - 30_000).toISOString(),
+    });
+    const { client } = await renderInbox(stub);
+    fireEvent.click(bell());
+
+    const time = document.querySelector('.chimely-item-time') as HTMLTimeElement;
+    const occurredAt = client.getSnapshot().items[0]?.occurredAt as string;
+    expect(time.textContent).toBe('now');
+    expect(time.getAttribute('datetime')).toBe(occurredAt);
+    expect(time.getAttribute('title')).toBe(new Date(occurredAt).toLocaleString());
+  });
+
+  test('old items fall back to the locale date', async () => {
+    const stub = createStubServer();
+    stub.addNotification({ payload: { title: 'ancient' } });
+    const { client } = await renderInbox(stub);
+    fireEvent.click(bell());
+
+    const occurredAt = client.getSnapshot().items[0]?.occurredAt as string;
+    expect(document.querySelector('.chimely-item-time')?.textContent).toBe(
+      new Date(occurredAt).toLocaleDateString(),
+    );
+  });
+
+  test('formatTimestamp override wins', async () => {
+    const stub = createStubServer();
+    stub.addNotification();
+    await renderInbox(stub, {
+      localization: { formatTimestamp: (iso) => `ts:${iso}` },
+    });
+    fireEvent.click(bell());
+    expect(document.querySelector('.chimely-item-time')?.textContent).toMatch(/^ts:/);
+  });
+});
+
 describe('header actions', () => {
   test('mark all read uses the localized label and hits read-all', async () => {
     const stub = createStubServer();

--- a/packages/react/src/inbox.test.tsx
+++ b/packages/react/src/inbox.test.tsx
@@ -267,6 +267,17 @@ describe('header title and footer', () => {
     expect(screen.getByRole('dialog', { name: 'Meldungen' })).toBeDefined();
     expect(document.querySelector('.chimely-header-title')?.textContent).toBe('Meldungen');
   });
+
+  test('dialog label follows the preferences panel', async () => {
+    const stub = createStubServer();
+    stub.addNotification({ category: 'billing.alerts' });
+    await renderInbox(stub);
+    fireEvent.click(bell());
+    fireEvent.click(screen.getByRole('button', { name: 'Notification preferences' }));
+    expect(screen.getByRole('dialog', { name: 'Notification preferences' })).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(screen.getByRole('dialog', { name: 'Notifications' })).toBeDefined();
+  });
 });
 
 describe('localized labels', () => {

--- a/packages/react/src/localization.test.ts
+++ b/packages/react/src/localization.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest';
+import type { InboxLocalization } from './localization';
+import { DEFAULT_LOCALIZATION, mergeLocalization } from './localization';
+
+describe('mergeLocalization', () => {
+  test('no overrides yields a copy of the defaults', () => {
+    const merged = mergeLocalization();
+    expect(merged).toEqual(DEFAULT_LOCALIZATION);
+    expect(merged).not.toBe(DEFAULT_LOCALIZATION);
+  });
+
+  test('string overrides win, unspecified keys keep defaults', () => {
+    const merged = mergeLocalization({ inboxTitle: 'Meldungen' });
+    expect(merged.inboxTitle).toBe('Meldungen');
+    expect(merged.markAllRead).toBe(DEFAULT_LOCALIZATION.markAllRead);
+    expect(merged.bellLabel).toBe('Notifications');
+  });
+
+  test('function overrides win', () => {
+    const formatTimestamp = (iso: string) => `ts:${iso}`;
+    const newNotifications = (count: number) => `${count}!`;
+    const merged = mergeLocalization({ formatTimestamp, newNotifications });
+    expect(merged.formatTimestamp('x')).toBe('ts:x');
+    expect(merged.newNotifications(3)).toBe('3!');
+  });
+
+  test('categoryLabels replaces the whole map', () => {
+    const merged = mergeLocalization({ categoryLabels: { 'billing.alerts': 'Billing' } });
+    expect(merged.categoryLabels).toEqual({ 'billing.alerts': 'Billing' });
+  });
+
+  test('explicit undefined values keep defaults', () => {
+    const merged = mergeLocalization({ emptyTitle: undefined });
+    expect(merged.emptyTitle).toBe(DEFAULT_LOCALIZATION.emptyTitle);
+  });
+
+  test('keys outside the contract are dropped', () => {
+    const merged = mergeLocalization({ bogus: 'x' } as Partial<InboxLocalization>);
+    expect('bogus' in merged).toBe(false);
+  });
+
+  test('default newNotifications pluralizes', () => {
+    expect(DEFAULT_LOCALIZATION.newNotifications(1)).toBe('1 new notification');
+    expect(DEFAULT_LOCALIZATION.newNotifications(4)).toBe('4 new notifications');
+  });
+});

--- a/packages/react/src/localization.ts
+++ b/packages/react/src/localization.ts
@@ -1,31 +1,62 @@
+import { formatRelativeTime } from './time';
+
 /**
  * No index signature so typos fail to type-check.
- * New strings are added as optional fields to keep minor versions non-breaking.
+ * New fields are added as optional to keep minor versions non-breaking.
+ * DEFAULT_LOCALIZATION supplies a value for every field, so merged results
+ * are fully populated.
  */
 export interface InboxLocalization {
   emptyTitle: string;
   emptyBody: string;
   markAllRead: string;
   preferencesTitle: string;
+  /** List-view header title. Also labels the popover dialog. */
+  inboxTitle?: string;
+  /** Bell button aria-label. */
+  bellLabel?: string;
+  /** Preferences back button aria-label. */
+  backLabel?: string;
+  /** New-notification indicator text. */
+  newNotifications?: (count: number) => string;
+  /**
+   * Display names for category keys in the preferences panel.
+   * Merged by whole-map replacement, not per key.
+   */
+  categoryLabels?: Record<string, string>;
+  /** Timestamp text in the default item rendering. Defaults to relative time. */
+  formatTimestamp?: (iso: string) => string;
 }
 
-export const DEFAULT_LOCALIZATION: InboxLocalization = {
+export const DEFAULT_LOCALIZATION: Required<InboxLocalization> = {
   emptyTitle: 'No notifications',
   emptyBody: "You're all caught up.",
   markAllRead: 'Mark all as read',
   preferencesTitle: 'Notification preferences',
+  inboxTitle: 'Notifications',
+  bellLabel: 'Notifications',
+  backLabel: 'Back',
+  newNotifications: (count) => (count === 1 ? '1 new notification' : `${count} new notifications`),
+  categoryLabels: {},
+  formatTimestamp: (iso) => formatRelativeTime(iso),
 };
 
-export function mergeLocalization(overrides?: Partial<InboxLocalization>): InboxLocalization {
+export function mergeLocalization(
+  overrides?: Partial<InboxLocalization>,
+): Required<InboxLocalization> {
   const merged = { ...DEFAULT_LOCALIZATION };
   if (!overrides) {
     return merged;
   }
-  for (const key of Object.keys(DEFAULT_LOCALIZATION) as Array<keyof InboxLocalization>) {
+  const apply = <K extends keyof InboxLocalization>(key: K): void => {
     const value = overrides[key];
     if (value !== undefined) {
-      merged[key] = value;
+      // The undefined check narrows the value, which the indexed write cannot see.
+      merged[key] = value as Required<InboxLocalization>[K];
     }
+  };
+  for (const key of Object.keys(DEFAULT_LOCALIZATION) as Array<keyof InboxLocalization>) {
+    apply(key);
   }
   return merged;
 }

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -69,6 +69,12 @@ export const INBOX_CSS = `
 .chimely-header-title {
   font-weight: 600;
 }
+.chimely-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+}
 .chimely-header-action {
   border: none;
   background: transparent;
@@ -166,6 +172,9 @@ export const INBOX_CSS = `
   flex: none;
   border-top: 1px solid var(--chimely-colorMuted, #f3f4f6);
   min-height: 4px;
+}
+.chimely-footer:not(:empty) {
+  padding: 8px 14px;
 }
 .chimely-preferences {
   flex: 1;

--- a/packages/react/src/time.test.ts
+++ b/packages/react/src/time.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'vitest';
+import { formatRelativeTime } from './time';
+
+const NOW = Date.parse('2026-07-02T12:00:00Z');
+
+function at(offsetSeconds: number): string {
+  return new Date(NOW + offsetSeconds * 1000).toISOString();
+}
+
+function relative(value: number, unit: Intl.RelativeTimeFormatUnit): string {
+  return new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' }).format(value, unit);
+}
+
+describe('formatRelativeTime', () => {
+  test('under a minute reads as now, in both directions', () => {
+    expect(formatRelativeTime(at(-30), NOW)).toBe('now');
+    expect(formatRelativeTime(at(30), NOW)).toBe('now');
+    expect(formatRelativeTime(at(-59), NOW)).toBe('now');
+  });
+
+  test('minutes', () => {
+    expect(formatRelativeTime(at(-60), NOW)).toBe(relative(-1, 'minute'));
+    expect(formatRelativeTime(at(-5 * 60), NOW)).toBe(relative(-5, 'minute'));
+    expect(formatRelativeTime(at(5 * 60), NOW)).toBe(relative(5, 'minute'));
+  });
+
+  test('hours', () => {
+    expect(formatRelativeTime(at(-3 * 3600), NOW)).toBe(relative(-3, 'hour'));
+    expect(formatRelativeTime(at(-90 * 60), NOW)).toBe(relative(-1, 'hour'));
+  });
+
+  test('days up to a week', () => {
+    expect(formatRelativeTime(at(-2 * 86400), NOW)).toBe(relative(-2, 'day'));
+    expect(formatRelativeTime(at(-6 * 86400), NOW)).toBe(relative(-6, 'day'));
+  });
+
+  test('past a week falls back to the locale date', () => {
+    const iso = at(-10 * 86400);
+    expect(formatRelativeTime(iso, NOW)).toBe(new Date(iso).toLocaleDateString());
+  });
+
+  test('invalid input is returned verbatim', () => {
+    expect(formatRelativeTime('not-a-date', NOW)).toBe('not-a-date');
+  });
+});

--- a/packages/react/src/time.ts
+++ b/packages/react/src/time.ts
@@ -1,10 +1,9 @@
 import { useEffect, useState } from 'react';
 
-let relativeFormatter: Intl.RelativeTimeFormat | undefined;
-
+// Constructed per call so the resolved locale tracks the runtime default,
+// matching the toLocaleDateString fallback below.
 function formatter(): Intl.RelativeTimeFormat {
-  relativeFormatter ??= new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
-  return relativeFormatter;
+  return new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
 }
 
 const MINUTE = 60;
@@ -41,7 +40,7 @@ export function formatRelativeTime(iso: string, nowMs?: number): string {
 
 /**
  * Re-renders the caller on an interval so relative timestamps stay current.
- * Pass null to pause. Returns the current epoch milliseconds.
+ * Pass null to pause. Returns the epoch milliseconds of the last tick.
  */
 export function useNow(intervalMs: number | null): number {
   const [now, setNow] = useState(() => Date.now());
@@ -49,7 +48,6 @@ export function useNow(intervalMs: number | null): number {
     if (intervalMs === null) {
       return undefined;
     }
-    setNow(Date.now());
     const timer = setInterval(() => {
       setNow(Date.now());
     }, intervalMs);

--- a/packages/react/src/time.ts
+++ b/packages/react/src/time.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+
+let relativeFormatter: Intl.RelativeTimeFormat | undefined;
+
+function formatter(): Intl.RelativeTimeFormat {
+  relativeFormatter ??= new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+  return relativeFormatter;
+}
+
+const MINUTE = 60;
+const HOUR = 3600;
+const DAY = 86400;
+const WEEK = 7 * DAY;
+
+/**
+ * Relative form of an RFC 3339 timestamp: "now" under a minute, then
+ * minutes/hours/days via Intl.RelativeTimeFormat, then the locale date past
+ * seven days. Invalid input is returned verbatim.
+ */
+export function formatRelativeTime(iso: string, nowMs?: number): string {
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) {
+    return iso;
+  }
+  const deltaSeconds = Math.round((then - (nowMs ?? Date.now())) / 1000);
+  const magnitude = Math.abs(deltaSeconds);
+  if (magnitude < MINUTE) {
+    return 'now';
+  }
+  if (magnitude < HOUR) {
+    return formatter().format(Math.trunc(deltaSeconds / MINUTE), 'minute');
+  }
+  if (magnitude < DAY) {
+    return formatter().format(Math.trunc(deltaSeconds / HOUR), 'hour');
+  }
+  if (magnitude < WEEK) {
+    return formatter().format(Math.trunc(deltaSeconds / DAY), 'day');
+  }
+  return new Date(then).toLocaleDateString();
+}
+
+/**
+ * Re-renders the caller on an interval so relative timestamps stay current.
+ * Pass null to pause. Returns the current epoch milliseconds.
+ */
+export function useNow(intervalMs: number | null): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (intervalMs === null) {
+      return undefined;
+    }
+    setNow(Date.now());
+    const timer = setInterval(() => {
+      setNow(Date.now());
+    }, intervalMs);
+    return () => {
+      clearInterval(timer);
+    };
+  }, [intervalMs]);
+  return now;
+}


### PR DESCRIPTION
Part of #34 (items 1.4, 1.5, 1.6, 1.11).

- `renderFooter?: () => ReactNode`: the popover footer can now carry content (branding strips); styled only when non-empty.
- List-view header gets a title (`localization.inboxTitle`, default "Notifications"), with mark-all-read and the gear grouped right.
- Default item timestamps are relative (`Intl.RelativeTimeFormat`, date fallback past 7 days), absolute time kept on `dateTime`/`title`; a minute tick keeps open popovers current. Overridable via `localization.formatTimestamp`.
- Localization pass: `bellLabel`/`backLabel` aria-labels, `categoryLabels` display names in the preferences panel, `newNotifications` string (consumed by the upcoming indicator), merge reworked for non-string fields. `DEFAULT_LOCALIZATION` now satisfies `Required<InboxLocalization>`.

Compat notes: header actions are now wrapped in `.chimely-header-actions` (direct-child selectors against the header change) and default timestamp text changes from `toLocaleString()` to relative form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPHGkeMnicLurSYQFjd2jR