### PR TITLE
chore(release): version packages 0.2.0

### DIFF
--- a/.changeset/changelog.cjs
+++ b/.changeset/changelog.cjs
@@ -1,0 +1,19 @@
+// Changelog lines without commit hashes. The default generator prefixes
+// every entry with the releasing commit, which renders as noise on npm
+// and points at the squash commit rather than the change.
+const getReleaseLine = async (changeset) => {
+  const [first, ...rest] = changeset.summary.trim().split('\n');
+  return ['- ' + first, ...rest.map((line) => '  ' + line)].join('\n');
+};
+
+const getDependencyReleaseLine = async (_changesets, dependenciesUpdated) => {
+  if (dependenciesUpdated.length === 0) {
+    return '';
+  }
+  return [
+    '- Updated dependencies:',
+    ...dependenciesUpdated.map((dep) => `  - ${dep.name}@${dep.newVersion}`),
+  ].join('\n');
+};
+
+module.exports = { getReleaseLine, getDependencyReleaseLine };

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": "./changelog.cjs",
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.changeset/dry-poems-wave.md
+++ b/.changeset/dry-poems-wave.md
@@ -1,5 +1,0 @@
----
-"@chimely/react": minor
----
-
-Popover robustness: opt-in `portal` rendering to `document.body` with fixed positioning (escapes overflow and transform ancestors), `placementOffset`, controlled `open`/`onOpenChange`, and `routerPush` for SPA navigation on same-origin action URLs. `react-dom` is now a peer dependency. markAllSeen fires on every open transition, including controlled and programmatic opens.

--- a/.changeset/eight-lions-brake.md
+++ b/.changeset/eight-lions-brake.md
@@ -1,5 +1,0 @@
----
-"@chimely/client": minor
----
-
-Archive round trip: `archive`/`unarchive` per item with optimistic removal from the active view, `archiveAll` (watermark move server-side), and `archiveRead` (asynchronous; the snapshot converges via the completion hint). `InboxItem` gains `archived` and `setFilter` accepts `'archived'`.

--- a/.changeset/four-moons-shake.md
+++ b/.changeset/four-moons-shake.md
@@ -1,5 +1,0 @@
----
-"@chimely/client": minor
----
-
-Read-state round trip and server-side views: `markUnread(item)` flips an item back to unread with the same optimistic/rollback semantics as `markRead`, and `setFilter('default' | 'unread')` switches the server-side list view, resetting pagination and refetching. The snapshot gains `filter`.

--- a/.changeset/gold-taxes-shop.md
+++ b/.changeset/gold-taxes-shop.md
@@ -1,5 +1,0 @@
----
-"@chimely/react": minor
----
-
-Read/unread toggle on row hover (tooltips via `localization.markReadAction`/`markUnreadAction`) and a header view select (Inbox / Unread, strings via `filterLabel`/`filterInbox`/`filterUnread`) wired to the server-side unread filter. New `filter` appearance slot.

--- a/.changeset/large-pears-drive.md
+++ b/.changeset/large-pears-drive.md
@@ -1,5 +1,0 @@
----
-"@chimely/react": minor
----
-
-Archive UI: row hover gains an archive/unarchive toggle, the view select gains Archived, and the header grows a more-actions menu (mark all read, archive read, archive all). New localization keys: `filterArchived`, `archiveAction`, `unarchiveAction`, `moreActions`, `archiveAllAction`, `archiveReadAction`. Mark-all-read moves from a bare header button into the menu.

--- a/.changeset/nine-jokes-repeat.md
+++ b/.changeset/nine-jokes-repeat.md
@@ -1,5 +1,0 @@
----
-"@chimely/react": minor
----
-
-Appearance depth and the new-notification pill: exported `darkTheme` variables preset, per-slot inline `appearance.styles`, `appearance.icons` overrides for the bell and gear, new `colorBadgeForeground` and `shadow` variables. Arrivals while the list is scrolled down surface as a "N new notifications" pill (text via `localization.newNotifications`) instead of yanking the viewport. The list gains a `.chimely-list-container` wrapper.

--- a/.changeset/olive-hoops-cheer.md
+++ b/.changeset/olive-hoops-cheer.md
@@ -1,5 +1,0 @@
----
-"@chimely/react": minor
----
-
-Composable components: `<InboxContent />` (the popover interior for custom popovers, drawers, and full-page inboxes), `<Bell />` (forwardRef trigger with the unseen badge), and `<Preferences />` are now exported. Granular render props `renderSubject`, `renderBody`, and `renderAvatar` replace one fragment of the default item while keeping layout and click wiring. The popover interior is now wrapped in a `.chimely-content` div (new `content` slot).

--- a/.changeset/spicy-llamas-shine.md
+++ b/.changeset/spicy-llamas-shine.md
@@ -1,5 +1,0 @@
----
-"@chimely/react": minor
----
-
-Tabs: `tabs={[{ label, icon?, filter? }]}` on `<Inbox />` and `<InboxContent />` renders a tab strip with client-side predicate filtering and per-tab unread counts over loaded pages. When a sparse tab's filtered view runs short, the list keeps fetching until the tab fills or pages run out. Infinite scroll now drains continuously while the end sentinel stays visible, instead of one page per intersection event.

--- a/.changeset/tall-berries-brush.md
+++ b/.changeset/tall-berries-brush.md
@@ -1,5 +1,0 @@
----
-"@chimely/react": minor
----
-
-Inbox popover polish: `renderFooter` render prop, a list-view header title, relative timestamps in the default item (overridable via `localization.formatTimestamp`), and a localization pass covering the bell and back-button aria-labels plus `categoryLabels` display names in the preferences panel.

--- a/.changeset/wild-pandas-argue.md
+++ b/.changeset/wild-pandas-argue.md
@@ -1,5 +1,0 @@
----
-"@chimely/client": minor
----
-
-`InboxSnapshot` gains `lastRefreshNewItemIds`: the ids the last first-page merge added that were not already loaded, with fresh array identity per merge. 304 refreshes and fetchMore leave it untouched. Powers the new-notification indicator in @chimely/react.

--- a/examples/nextjs/CHANGELOG.md
+++ b/examples/nextjs/CHANGELOG.md
@@ -1,5 +1,18 @@
 # chimely-example-nextjs
 
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies [4488eb4]
+- Updated dependencies [4488eb4]
+- Updated dependencies [4488eb4]
+- Updated dependencies [4488eb4]
+- Updated dependencies [4488eb4]
+- Updated dependencies [4488eb4]
+- Updated dependencies [4488eb4]
+  - @chimely/react@0.2.0
+
 ## 0.0.1
 
 ### Patch Changes

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chimely-example-nextjs",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "description": "Chimely 30-second quickstart: the drop-in <Inbox /> in a Next.js app.",
   "license": "MIT",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Minor Changes
 
-- 4488eb4: Archive round trip: `archive`/`unarchive` per item with optimistic removal from the active view, `archiveAll` (watermark move server-side), and `archiveRead` (asynchronous; the snapshot converges via the completion hint). `InboxItem` gains `archived` and `setFilter` accepts `'archived'`.
-- 4488eb4: Read-state round trip and server-side views: `markUnread(item)` flips an item back to unread with the same optimistic/rollback semantics as `markRead`, and `setFilter('default' | 'unread')` switches the server-side list view, resetting pagination and refetching. The snapshot gains `filter`.
-- 4488eb4: `InboxSnapshot` gains `lastRefreshNewItemIds`: the ids the last first-page merge added that were not already loaded, with fresh array identity per merge. 304 refreshes and fetchMore leave it untouched. Powers the new-notification indicator in @chimely/react.
+- Read state and views: `markUnread(item)` flips an item back to unread with the same optimistic and rollback semantics as `markRead`, and `setFilter('default' | 'unread' | 'archived')` switches the server-side list view, resetting pagination and refetching. The snapshot gains `filter`.
+- Archive: `archive` and `unarchive` per item with optimistic removal from the active view, `archiveAll`, and `archiveRead` (asynchronous, the snapshot converges on the completion hint). `InboxItem` gains `archived`.
+- `InboxSnapshot.lastRefreshNewItemIds` lists the ids the last refresh merged in. 304 refreshes and `fetchMore` leave it untouched. Powers the new-notification pill in `@chimely/react`.
 
 ## 0.1.0
 
@@ -16,7 +16,7 @@
 
 ### Patch Changes
 
-- bb1f022: Comment and JSDoc cleanup. No API, type, or behavior change.
-- 12e5a50: Regenerate client types from the documented error contract: `Error.code` is now
+- Comment and JSDoc cleanup. No API, type, or behavior change.
+- Regenerate client types from the documented error contract: `Error.code` is now
   a typed enum of the stable error codes, and the inbox stream declares its 429
   (`too_many_connections`) response. Repository URLs point at dodopayments/chimely.

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @chimely/client
 
+## 0.2.0
+
+### Minor Changes
+
+- 4488eb4: Archive round trip: `archive`/`unarchive` per item with optimistic removal from the active view, `archiveAll` (watermark move server-side), and `archiveRead` (asynchronous; the snapshot converges via the completion hint). `InboxItem` gains `archived` and `setFilter` accepts `'archived'`.
+- 4488eb4: Read-state round trip and server-side views: `markUnread(item)` flips an item back to unread with the same optimistic/rollback semantics as `markRead`, and `setFilter('default' | 'unread')` switches the server-side list view, resetting pagination and refetching. The snapshot gains `filter`.
+- 4488eb4: `InboxSnapshot` gains `lastRefreshNewItemIds`: the ids the last first-page merge added that were not already loaded, with fresh array identity per merge. 304 refreshes and fetchMore leave it untouched. Powers the new-notification indicator in @chimely/react.
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chimely/client",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Framework-agnostic headless core for the Chimely in-app notification inbox.",
   "keywords": [
     "notifications",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -4,19 +4,18 @@
 
 ### Minor Changes
 
-- 4488eb4: Popover robustness: opt-in `portal` rendering to `document.body` with fixed positioning (escapes overflow and transform ancestors), `placementOffset`, controlled `open`/`onOpenChange`, and `routerPush` for SPA navigation on same-origin action URLs. `react-dom` is now a peer dependency. markAllSeen fires on every open transition, including controlled and programmatic opens.
-- 4488eb4: Read/unread toggle on row hover (tooltips via `localization.markReadAction`/`markUnreadAction`) and a header view select (Inbox / Unread, strings via `filterLabel`/`filterInbox`/`filterUnread`) wired to the server-side unread filter. New `filter` appearance slot.
-- 4488eb4: Archive UI: row hover gains an archive/unarchive toggle, the view select gains Archived, and the header grows a more-actions menu (mark all read, archive read, archive all). New localization keys: `filterArchived`, `archiveAction`, `unarchiveAction`, `moreActions`, `archiveAllAction`, `archiveReadAction`. Mark-all-read moves from a bare header button into the menu.
-- 4488eb4: Appearance depth and the new-notification pill: exported `darkTheme` variables preset, per-slot inline `appearance.styles`, `appearance.icons` overrides for the bell and gear, new `colorBadgeForeground` and `shadow` variables. Arrivals while the list is scrolled down surface as a "N new notifications" pill (text via `localization.newNotifications`) instead of yanking the viewport. The list gains a `.chimely-list-container` wrapper.
-- 4488eb4: Composable components: `<InboxContent />` (the popover interior for custom popovers, drawers, and full-page inboxes), `<Bell />` (forwardRef trigger with the unseen badge), and `<Preferences />` are now exported. Granular render props `renderSubject`, `renderBody`, and `renderAvatar` replace one fragment of the default item while keeping layout and click wiring. The popover interior is now wrapped in a `.chimely-content` div (new `content` slot).
-- 4488eb4: Tabs: `tabs={[{ label, icon?, filter? }]}` on `<Inbox />` and `<InboxContent />` renders a tab strip with client-side predicate filtering and per-tab unread counts over loaded pages. When a sparse tab's filtered view runs short, the list keeps fetching until the tab fills or pages run out. Infinite scroll now drains continuously while the end sentinel stays visible, instead of one page per intersection event.
-- 4488eb4: Inbox popover polish: `renderFooter` render prop, a list-view header title, relative timestamps in the default item (overridable via `localization.formatTimestamp`), and a localization pass covering the bell and back-button aria-labels plus `categoryLabels` display names in the preferences panel.
+- Composable components: `<InboxContent />`, `<Bell />`, and `<Preferences />` are exported for custom popovers, drawers, and full-page inboxes. New render props `renderSubject`, `renderBody`, and `renderAvatar` replace one fragment of the default item while keeping its layout and click wiring.
+- Tabs: `tabs={[{ label, icon?, filter? }]}` renders a tab strip with client-side filtering, per-tab unread counts, and full keyboard support. Infinite scroll now keeps fetching while the end sentinel stays visible, so sparse tabs fill themselves.
+- Popover: opt-in `portal` rendering to `document.body` (escapes overflow and transform ancestors), `placementOffset`, controlled `open`/`onOpenChange`, and `routerPush` for SPA navigation on same-origin action URLs. `react-dom` is now a peer dependency.
+- Theming: exported `darkTheme` preset, per-slot inline `appearance.styles`, `appearance.icons` overrides for the bell and gear, and new `colorBadgeForeground` and `shadow` variables.
+- New-notification pill: arrivals while the list is scrolled down surface as a pill instead of moving the viewport. Text via `localization.newNotifications`.
+- Read state: a read/unread toggle on row hover and a header view select (Inbox / Unread) backed by the server-side filter.
+- Archive: an archive/unarchive toggle on row hover, an Archived view, and a header more-actions menu with mark all read, archive read, and archive all. Mark-all-read moved from a bare header button into this menu.
+- Polish: `renderFooter`, a header title, relative timestamps by default (override with `localization.formatTimestamp`), and localization keys for every new string.
 
 ### Patch Changes
 
-- Updated dependencies [4488eb4]
-- Updated dependencies [4488eb4]
-- Updated dependencies [4488eb4]
+- Updated dependencies:
   - @chimely/client@0.2.0
 
 ## 0.1.0
@@ -27,11 +26,9 @@
 
 ### Patch Changes
 
-- bb1f022: Comment and JSDoc cleanup. No API, type, or behavior change.
-- 12e5a50: Regenerate client types from the documented error contract: `Error.code` is now
+- Comment and JSDoc cleanup. No API, type, or behavior change.
+- Regenerate client types from the documented error contract: `Error.code` is now
   a typed enum of the stable error codes, and the inbox stream declares its 429
   (`too_many_connections`) response. Repository URLs point at dodopayments/chimely.
-- Updated dependencies [bb1f022]
-- Updated dependencies [12e5a50]
-- Updated dependencies
+- Updated dependencies:
   - @chimely/client@0.1.0

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @chimely/react
 
+## 0.2.0
+
+### Minor Changes
+
+- 4488eb4: Popover robustness: opt-in `portal` rendering to `document.body` with fixed positioning (escapes overflow and transform ancestors), `placementOffset`, controlled `open`/`onOpenChange`, and `routerPush` for SPA navigation on same-origin action URLs. `react-dom` is now a peer dependency. markAllSeen fires on every open transition, including controlled and programmatic opens.
+- 4488eb4: Read/unread toggle on row hover (tooltips via `localization.markReadAction`/`markUnreadAction`) and a header view select (Inbox / Unread, strings via `filterLabel`/`filterInbox`/`filterUnread`) wired to the server-side unread filter. New `filter` appearance slot.
+- 4488eb4: Archive UI: row hover gains an archive/unarchive toggle, the view select gains Archived, and the header grows a more-actions menu (mark all read, archive read, archive all). New localization keys: `filterArchived`, `archiveAction`, `unarchiveAction`, `moreActions`, `archiveAllAction`, `archiveReadAction`. Mark-all-read moves from a bare header button into the menu.
+- 4488eb4: Appearance depth and the new-notification pill: exported `darkTheme` variables preset, per-slot inline `appearance.styles`, `appearance.icons` overrides for the bell and gear, new `colorBadgeForeground` and `shadow` variables. Arrivals while the list is scrolled down surface as a "N new notifications" pill (text via `localization.newNotifications`) instead of yanking the viewport. The list gains a `.chimely-list-container` wrapper.
+- 4488eb4: Composable components: `<InboxContent />` (the popover interior for custom popovers, drawers, and full-page inboxes), `<Bell />` (forwardRef trigger with the unseen badge), and `<Preferences />` are now exported. Granular render props `renderSubject`, `renderBody`, and `renderAvatar` replace one fragment of the default item while keeping layout and click wiring. The popover interior is now wrapped in a `.chimely-content` div (new `content` slot).
+- 4488eb4: Tabs: `tabs={[{ label, icon?, filter? }]}` on `<Inbox />` and `<InboxContent />` renders a tab strip with client-side predicate filtering and per-tab unread counts over loaded pages. When a sparse tab's filtered view runs short, the list keeps fetching until the tab fills or pages run out. Infinite scroll now drains continuously while the end sentinel stays visible, instead of one page per intersection event.
+- 4488eb4: Inbox popover polish: `renderFooter` render prop, a list-view header title, relative timestamps in the default item (overridable via `localization.formatTimestamp`), and a localization pass covering the bell and back-button aria-labels plus `categoryLabels` display names in the preferences panel.
+
+### Patch Changes
+
+- Updated dependencies [4488eb4]
+- Updated dependencies [4488eb4]
+- Updated dependencies [4488eb4]
+  - @chimely/client@0.2.0
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chimely/react",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "React bindings and the drop-in <Inbox /> component for Chimely.",
   "keywords": [
     "notifications",


### PR DESCRIPTION
Versions @chimely/client and @chimely/react 0.1.0 -> 0.2.0, consuming the ten changesets from the Novu parity stack (#40-#48, issue #34). Changelogs cover: composable components and granular render props, tabs with the ARIA keyboard pattern, popover portal and controlled open, routerPush, appearance depth with darkTheme, the new-notification pill, mark-unread with filter views, and the archive round trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPHGkeMnicLurSYQFjd2jR