### PR TITLE
docs: bump version references to 0.2.0

### DIFF
--- a/docs/app/(home)/_components/hero.tsx
+++ b/docs/app/(home)/_components/hero.tsx
@@ -12,7 +12,7 @@ function Kicker() {
   return (
     <span className="inline-flex w-fit items-center gap-2.5 rounded-full border border-fd-border bg-fd-muted/50 px-3.5 py-1.5 font-mono text-[12.5px] font-medium tracking-wide text-fd-muted-foreground dark:border-white/[0.14] dark:bg-white/[0.04] dark:text-white/70">
       <span className="size-[7px] rounded-full bg-[#00D87D] shadow-[0_0_0_3px_rgba(0,216,125,0.18)] motion-safe:animate-pulse" />
-      Open source · Self-hostable · v0.1.0
+      Open source · Self-hostable · v0.2.0
     </span>
   );
 }

--- a/docs/app/(home)/_components/site-footer.tsx
+++ b/docs/app/(home)/_components/site-footer.tsx
@@ -70,7 +70,7 @@ export function SiteFooter() {
       {/* Pre-1.0 disclaimer, kept visually quiet */}
       <div className="mx-auto mt-7 max-w-[1200px] border-t border-fd-border pt-5">
         <p className="max-w-[80ch] font-mono text-[12.5px] leading-relaxed text-fd-muted-foreground/70">
-          Chimely is at v0.1.0. The HTTP API and SDK surface may still change on minor releases
+          Chimely is at v0.2.0. The HTTP API and SDK surface may still change on minor releases
           until 1.0. Pin your versions.
         </p>
       </div>

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -16,7 +16,7 @@ drop-in `<Inbox />` renders them.
 A live bell, unread counts, read state, and preferences, with nothing to build.
 
 <Callout type="warn" title="Pre-1.0">
-Chimely is at **0.1.0**. The HTTP API and the SDK surface may change on minor
+Chimely is at **0.2.0**. The HTTP API and the SDK surface may change on minor
 version bumps until 1.0.0. Pin your versions.
 </Callout>
 

--- a/docs/content/docs/sdk-reference.mdx
+++ b/docs/content/docs/sdk-reference.mdx
@@ -16,10 +16,9 @@ Two MIT packages:
 Wire types in `@chimely/client` are generated from the OpenAPI spec with
 `openapi-typescript` (`packages/client/src/generated/`) and never hand-edited.
 
-<Callout type="info" title="Pre-release">
-Both packages are at `0.0.0` and not yet on npm. Inside this monorepo they
-resolve via `workspace:*`; `npm i @chimely/react` works only after the first
-published release.
+<Callout type="info" title="Pre-1.0">
+Both packages are at `0.2.0` on npm. The SDK surface may change on minor
+version bumps until 1.0.0. Pin your versions.
 </Callout>
 
 ```bash


### PR DESCRIPTION
Updates the four version references after the 0.2.0 release: the docs index Pre-1.0 callout, the SDK reference install callout (packages are on npm now, the pre-release wording said otherwise), the homepage hero kicker, and the site footer disclaimer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPHGkeMnicLurSYQFjd2jR