### PR TITLE
docs: clone-free quickstart and audit fixes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@
 #
 # Mirrors the dodo-discord-bot publish workflow: publishing a GitHub Release
 # builds the image, tags it with the release tag, and pushes it to GAR. This is
-# the internal-deploy image. The public fair-source image is built and pushed
+# the internal-deploy image. The public open-source image is built and pushed
 # to GHCR by the `docker` job in ci.yml. The two are independent and target
 # different registries.
 #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Chimely
 
-Fair-source, self-hostable in-app notification inbox infrastructure: one Rust
+Open-source, self-hostable in-app notification inbox infrastructure: one Rust
 binary + Postgres (source of truth) + Redis (real-time plane), a small HTTP
 API, and a drop-in `<Inbox />`.
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     restart: unless-stopped
 
   chimely:
-    image: ghcr.io/dodopayments/chimely:${CHIMELY_VERSION:-0.1.0}
+    image: ghcr.io/dodopayments/chimely:${CHIMELY_VERSION:-0.2.0}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,14 @@
-# Local all-in-one Chimely: builds the binary from this checkout, with Postgres
-# and Redis. For production use deploy/docker-compose.yml (pinned image, no dev
-# bootstrap). See docs/content/docs/quickstart.mdx and self-hosting.mdx.
+# Local all-in-one Chimely for working on this checkout: builds the binary
+# from source, with Postgres and Redis. The quickstart uses the published
+# image instead (docs/content/docs/quickstart.mdx); production uses
+# deploy/docker-compose.yml (pinned image, no dev bootstrap).
+# Postgres and Redis publish no host ports so `docker compose up` cannot
+# collide with local services. Reach them via `docker compose exec`.
 services:
   postgres:
     image: postgres:16-alpine
     environment:
       POSTGRES_PASSWORD: chimely
-    ports:
-      - "5432:5432"
     volumes:
       - chimely-pg:/var/lib/postgresql/data
     healthcheck:
@@ -18,8 +19,6 @@ services:
 
   redis:
     image: redis:7-alpine
-    ports:
-      - "6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 2s

--- a/docs/content/docs/auth.mdx
+++ b/docs/content/docs/auth.mdx
@@ -19,8 +19,8 @@ session cookie; it is not used by application code.
 
 Keys are **per environment**. The environment is implied by the key, so
 requests carry no environment id. Create and revoke keys in the admin
-dashboard (developer or admin role); the plaintext is shown once at creation
-and stored only as a hash.
+dashboard (developer or admin role); the plaintext is shown once at creation.
+The server stores only its hash plus a short display prefix.
 
 ```bash
 curl -X POST https://chimely.example.com/v1/notifications \
@@ -34,7 +34,8 @@ Live keys are prefixed `chml_live_`. Keep them server-side.
 <Callout type="warn" title="No CHIMELY_API_KEY variable">
 The server reads no `CHIMELY_API_KEY`. Keys are minted in the admin dashboard
 and stored in **your** backend's secrets. The only key-related env var is
-`CHIMELY_DEV_API_KEY`, which seeds the dev quickstart environment.
+`CHIMELY_DEV_API_KEY`, which seeds a key into the dev quickstart environment
+(it does nothing unless `CHIMELY_DEV_ENVIRONMENT` is also set).
 </Callout>
 
 ## Subscriber HMAC hash
@@ -90,7 +91,7 @@ environment real users touch.
 Rotation is two-slot, zero-downtime. The old and new secrets are both accepted
 during the overlap:
 
-1. **Rotate** in the admin dashboard (or `POST /admin/api/environments/{env_id}/hmac/rotate`). A new secret is generated; the previous one stays valid.
+1. **Rotate** in the admin dashboard (admin role only; scripting it means `POST /admin/api/environments/{env_id}/hmac/rotate` with an admin session cookie and the `X-Chimely-Admin` CSRF header). A new secret is generated; the previous one stays valid.
 2. **Update your backend** to sign with the new secret.
 3. **Complete** the rotation (`…/hmac/rotate/complete`). The previous secret is dropped and only the new one is accepted.
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Fair-source, self-hostable in-app notification inbox infrastructure.
+description: Open-source, self-hostable in-app notification inbox infrastructure.
 ---
 
 import { Card, Cards } from 'fumadocs-ui/components/card';
@@ -50,7 +50,16 @@ These are deliberate. Chimely does the inbox and nothing else:
 
 ## License
 
-The server is [fair source](https://fair.io) (FSL-1.1-MIT): free to use,
-self-host, and modify, with each release converting to MIT two years after it
-ships. The SDKs and examples are MIT. Chimely is source-available, not OSI open
-source.
+The server is open source under
+[AGPL-3.0](https://github.com/dodopayments/chimely/blob/main/LICENSE), an
+OSI-approved license. You can use, self-host, modify, and redistribute it
+freely, at any scale, commercially or not. AGPL's one obligation is
+reciprocity: if you modify the server and offer it to others over a network,
+you must publish that modified source. Running it unmodified carries no such
+obligation.
+
+The SDKs (`@chimely/client`, `@chimely/react`) and the examples are MIT. Your
+application talks to Chimely over HTTP through the MIT SDKs, so the server's
+copyleft never reaches your code. The full
+[License FAQ](https://github.com/dodopayments/chimely#license-faq) covers the
+common questions.

--- a/docs/content/docs/operations.mdx
+++ b/docs/content/docs/operations.mdx
@@ -24,7 +24,7 @@ stalls.
 | `chimely_queue_due{environment,job_type}` | gauge, sampled | Jobs past `run_at` |
 | `chimely_job_wait_seconds{job_type}` | histogram | Due-to-claim latency (the fairness signal) |
 | `chimely_jobs_processed_total{environment}` | counter | Completed claims |
-| `chimely_jobs_failed_total{environment}` | counter | Failed claims (will retry) |
+| `chimely_jobs_failed_total{environment}` | counter | Failed job runs (retried or parked) |
 | `chimely_jobs_retried_total{job_type}` | counter | Backoff reschedules |
 | `chimely_jobs_parked_total{job_type}` | counter | Moves into `dead_letters` |
 | `chimely_dead_letters{job_type}` | gauge, sampled | Parked jobs awaiting replay |
@@ -100,7 +100,7 @@ applies per replica.
 
 | Knob | Default | Applies to |
 |---|---|---|
-| `CHIMELY_API_KEY_RATE_PER_SEC` / `_BURST` | 50 / 200 | per API key: `POST /v1/notifications`, `POST /v1/broadcasts` |
+| `CHIMELY_API_KEY_RATE_PER_SEC` / `_BURST` | 50 / 200 | per API key: `POST /v1/notifications`, `POST /v1/broadcasts`, `GET /v1/notifications/{id}/timeline` |
 | `CHIMELY_SUBSCRIBER_RATE_PER_SEC` / `_BURST` | 10 / 50 | per subscriber: `GET /v1/inbox/items` |
 
 A rate of `0` disables the limit.

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -25,16 +25,19 @@ docker run -d --name chimely-pg --network chimely \
   -e POSTGRES_PASSWORD=chimely postgres:16-alpine
 
 docker run -d --name chimely --network chimely -p 8080:8080 \
+  --restart unless-stopped \
   -e DATABASE_URL=postgres://postgres:chimely@chimely-pg:5432/postgres \
   -e CHIMELY_DEV_ENVIRONMENT=demo \
   -e CHIMELY_DEV_API_KEY=dev-secret-key \
   ghcr.io/dodopayments/chimely:0.2.0
 ```
 
-Migrations run on boot. The two `CHIMELY_DEV_*` variables seed environment
-`demo` (subscriber hashing off) and the API key `dev-secret-key`; without
-them the image boots with production defaults and an empty instance. Verify
-it is up:
+Migrations run on boot. The restart policy covers the first seconds while
+Postgres is still initializing: the server fails fast when its database is
+unreachable, and Docker brings it back up. The two `CHIMELY_DEV_*` variables
+seed environment `demo` (subscriber hashing off) and the API key
+`dev-secret-key`; without them the image boots with production defaults and
+an empty instance. Verify it is up:
 
 ```bash
 curl http://localhost:8080/healthz
@@ -87,7 +90,7 @@ No app handy? A throwaway one takes a minute:
 ```bash
 npm create vite@latest chimely-demo -- --template react-ts
 cd chimely-demo && npm install && npm install @chimely/react
-# put the <Inbox /> snippet in src/App.tsx
+# replace the App component in src/App.tsx so it returns the <Inbox /> above
 npm run dev
 ```
 

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -1,75 +1,48 @@
 ---
 title: Quickstart
-description: Run Chimely locally and render a live inbox in about ten minutes.
+description: Run Chimely from the published image and render a live inbox in five minutes. No cloning, no toolchain.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-Two ways to run Chimely locally. Both end with a live `<Inbox />` and a
-notification sent over `curl`. Subscriber HMAC hashing is off in the dev
-environment, so no backend signing is needed yet — see [Auth & HMAC](/docs/auth)
-before going to production.
+Nothing to clone and nothing to build: the server runs from the published
+Docker image, and the inbox component installs from npm into your own app.
+You need Docker and Node 20+.
 
-Prerequisites: Docker, Node 20+ with `pnpm`, and (for option A) a Rust toolchain.
+Subscriber HMAC hashing is off in the dev environment seeded below, so no
+backend signing is needed yet. See [Auth & HMAC](/docs/auth) before exposing
+an environment to real users.
 
-## Option A — local binary (Redis-less)
+## 1. Run the server
 
-Runs the server from source against a one-container Postgres, with no Redis.
-Hints ride Postgres `LISTEN/NOTIFY`.
-
-1. Start Postgres:
-
-   ```bash
-   docker run -d --name chimely-pg \
-     -e POSTGRES_PASSWORD=chimely -p 5432:5432 postgres:16-alpine
-   ```
-
-2. Start Chimely. The dev bootstrap seeds environment `demo`
-   (`require_subscriber_hash=false`) and the API key `dev-secret-key`:
-
-   ```bash
-   DATABASE_URL=postgres://postgres:chimely@localhost:5432/postgres \
-   CHIMELY_DEV_ENVIRONMENT=demo \
-   CHIMELY_DEV_API_KEY=dev-secret-key \
-   CHIMELY_LISTEN_ADDR=127.0.0.1:8080 \
-   cargo run --manifest-path server/Cargo.toml -- serve
-   ```
-
-   Migrations run on boot. The server listens on `127.0.0.1:8080`.
-
-3. Run the example app (new terminal):
-
-   ```bash
-   pnpm install
-   pnpm --filter "./packages/*" build
-   pnpm --filter chimely-example-nextjs dev
-   ```
-
-   Open [localhost:3000](http://localhost:3000).
-
-## Option B — docker-compose
-
-Builds the binary and runs it with Postgres and Redis. One command, no Rust
-toolchain:
+Two containers on a shared network: Postgres and Chimely. Redis is optional
+(hints fall back to Postgres `LISTEN/NOTIFY`), so the quickstart skips it.
 
 ```bash
-docker compose up --build
+docker network create chimely
+
+docker run -d --name chimely-pg --network chimely \
+  -e POSTGRES_PASSWORD=chimely postgres:16-alpine
+
+docker run -d --name chimely --network chimely -p 8080:8080 \
+  -e DATABASE_URL=postgres://postgres:chimely@chimely-pg:5432/postgres \
+  -e CHIMELY_DEV_ENVIRONMENT=demo \
+  -e CHIMELY_DEV_API_KEY=dev-secret-key \
+  ghcr.io/dodopayments/chimely:0.2.0
 ```
 
-This starts Chimely on `http://localhost:8080` with the same `demo`
-environment and `dev-secret-key`. Run the example app with the `pnpm` steps
-from Option A, step 3.
+Migrations run on boot. The two `CHIMELY_DEV_*` variables seed environment
+`demo` (subscriber hashing off) and the API key `dev-secret-key`; without
+them the image boots with production defaults and an empty instance. Verify
+it is up:
 
-<Callout type="info" title="npx chimely dev (planned)">
-A zero-config `npx chimely dev` (embedded Postgres, Redis-less) is the
-intended one-command on-ramp but is **not yet shipped**. Use Option A or B
-today.
-</Callout>
+```bash
+curl http://localhost:8080/healthz
+```
 
-## Send a notification
+## 2. Send a notification
 
-With either option running, POST one notification. The bearer token is the dev
-API key:
+POST one notification. The bearer token is the dev API key:
 
 ```bash
 curl -X POST http://localhost:8080/v1/notifications \
@@ -85,13 +58,13 @@ curl -X POST http://localhost:8080/v1/notifications \
   }'
 ```
 
-The bell badge increments without a refresh: the server publishes an SSE hint
-and the widget refetches conditionally (ETag, mostly `304`s). Opening the bell
-clears the badge; clicking the item marks it read and follows its `action_url`.
+## 3. Render the inbox
 
-## The `<Inbox />`
+In your React app:
 
-The example app is one component with three props (`examples/nextjs/app/page.tsx`):
+```bash
+npm install @chimely/react
+```
 
 ```tsx
 'use client';
@@ -104,10 +77,35 @@ import { Inbox } from '@chimely/react';
 />
 ```
 
-In production you add a fourth prop, `subscriberHash`, computed by your backend.
-See [Auth & HMAC](/docs/auth) and the [SDK reference](/docs/sdk-reference).
+The bell shows one unread. Send the curl again with the page open: the badge
+increments without a refresh, because the server publishes an SSE hint and
+the widget refetches conditionally (ETag, mostly `304`s). Opening the bell
+clears the badge; clicking an item marks it read and follows its `action_url`.
+
+No app handy? A throwaway one takes a minute:
+
+```bash
+npm create vite@latest chimely-demo -- --template react-ts
+cd chimely-demo && npm install && npm install @chimely/react
+# put the <Inbox /> snippet in src/App.tsx
+npm run dev
+```
+
+In production you add a fourth prop, `subscriberHash`, computed by your
+backend. See [Auth & HMAC](/docs/auth) and the [SDK reference](/docs/sdk-reference).
+
+## Clean up
+
+```bash
+docker rm -f chimely chimely-pg && docker network rm chimely
+```
+
+<Callout type="info" title="npx chimely dev (planned)">
+A zero-config `npx chimely dev` (embedded Postgres, no Docker) is the
+intended one-command on-ramp but is **not yet shipped**.
+</Callout>
 
 ## Next
 
-- [Self-hosting](/docs/self-hosting) — production compose, config, health, backups.
-- [Auth & HMAC](/docs/auth) — required before exposing an environment to real users.
+- [Self-hosting](/docs/self-hosting): production compose, config, health, backups.
+- [Auth & HMAC](/docs/auth): required before exposing an environment to real users.

--- a/docs/content/docs/sdk-reference.mdx
+++ b/docs/content/docs/sdk-reference.mdx
@@ -303,7 +303,7 @@ client.connect();
 | `archiveRead()` | `Promise<void>` | Server-side job; state converges via hint refetch |
 | `markAllRead()` | `Promise<void>` | Watermark move |
 | `markAllSeen()` | `Promise<void>` | Zeroes unseen; leaves read state |
-| `setFilter(f)` | `void` | `'default' \| 'unread' \| 'archived'`; resets pagination and refetches |
+| `setFilter(f)` | `Promise<void>` | `'default' \| 'unread' \| 'archived'`; resets pagination and refetches |
 | `getPreferences()` | `Promise<Preference[]>` | — |
 | `setPreferences(p)` | `Promise<Preference[]>` | — |
 

--- a/docs/content/docs/sdk-reference.mdx
+++ b/docs/content/docs/sdk-reference.mdx
@@ -70,8 +70,9 @@ properties (`colorPrimary`, `colorBackground`, `colorBadge`,
 `colorBadgeForeground`, `shadow`, `borderRadius`, `fontFamily`, …).
 `appearance.classNames` adds classes per slot and `appearance.styles` adds
 inline styles per slot: `root`, `bell`, `badge`, `popover`, `content`,
-`header`, `tabs`, `tab`, `tabActive`, `list`, `item`, `itemUnread`, `empty`,
-`footer`, `pill`, `preferences`. `appearance.icons` replaces the built-in
+`header`, `filter`, `tabs`, `tab`, `tabActive`, `list`, `item`, `itemUnread`,
+`empty`, `footer`, `pill`, `preferences`. `appearance.icons` replaces the
+built-in
 SVGs (`bell`, `gear`); `renderBell` wins over `icons.bell`.
 
 A dark preset ships with the package. Spread it and override freely:
@@ -109,15 +110,21 @@ better).
 <Inbox
   tabs={[
     { label: 'All' },
-    { label: 'Transactions', icon: <MoneyWavy />, filter: (item) => item.payload.tags?.includes('transactions') },
+    {
+      label: 'Transactions',
+      icon: <MoneyWavy />,
+      filter: (item) =>
+        Array.isArray(item.payload.tags) && item.payload.tags.includes('transactions'),
+    },
     { label: 'Business', filter: (item) => item.category.startsWith('business.') },
   ]}
 />
 ```
 
 `InboxTab.filter` is a client-side predicate over loaded items: it can match
-tag arrays, category prefixes, or anything else in the payload. A tab without
-a filter shows everything. When the active tab's filtered view runs short, the
+tag arrays, category prefixes, or anything else in the payload. Custom payload
+fields are typed `unknown`, so narrow them (as with `Array.isArray` above)
+before use. A tab without a filter shows everything. When the active tab's filtered view runs short, the
 list keeps fetching pages until the tab fills or the inbox is exhausted.
 
 Per-tab unread counts cover loaded pages only, so they are approximate for
@@ -176,6 +183,7 @@ accept `appearance` and `localization`.
 - **`<Preferences />`** is the per-category toggle list, for settings pages.
 
 ```tsx
+import { useEffect, useState } from 'react';
 import { Bell, InboxContent, useChimelyClient } from '@chimely/react';
 
 function CustomInbox() {
@@ -288,8 +296,14 @@ client.connect();
 | `refresh()` | `Promise<void>` | Conditional refetch (page 1) |
 | `fetchMore({ limit? })` | `Promise<void>` | Next page |
 | `markRead({ id, source })` | `Promise<void>` | Optimistic |
+| `markUnread({ id, source })` | `Promise<void>` | Optimistic |
+| `archive({ id, source })` | `Promise<void>` | Optimistic; drops the item from the default view |
+| `unarchive({ id, source })` | `Promise<void>` | Optimistic |
+| `archiveAll()` | `Promise<void>` | Watermark move |
+| `archiveRead()` | `Promise<void>` | Server-side job; state converges via hint refetch |
 | `markAllRead()` | `Promise<void>` | Watermark move |
 | `markAllSeen()` | `Promise<void>` | Zeroes unseen; leaves read state |
+| `setFilter(f)` | `void` | `'default' \| 'unread' \| 'archived'`; resets pagination and refetches |
 | `getPreferences()` | `Promise<Preference[]>` | — |
 | `setPreferences(p)` | `Promise<Preference[]>` | — |
 
@@ -308,6 +322,7 @@ interface InboxItem<TPayload = WellKnownPayload> {
   payload: TPayload;
   occurredAt: string;        // RFC 3339
   read: boolean;
+  archived?: boolean;
 }
 
 interface InboxCounts { unread: number; unseen: number }

--- a/docs/content/docs/self-hosting.mdx
+++ b/docs/content/docs/self-hosting.mdx
@@ -126,11 +126,12 @@ path. Postgres stays authoritative and no data is lost, but:
 - Hint debounce is per-replica, so multiple replicas can emit more hints than
   strictly needed (never fewer).
 
-<Callout type="warn" title="Transaction-mode PgBouncer breaks LISTEN">
-In Redis-less mode `DATABASE_URL` must point at Postgres directly or a
-**session-mode** pooler. Transaction-mode PgBouncer multiplexes connections
-and silently drops `LISTEN/NOTIFY`, so hints never arrive. With Redis, the
-pooler mode does not matter.
+<Callout type="warn" title="Transaction-mode PgBouncer is not supported">
+`DATABASE_URL` must point at Postgres directly or a **session-mode** pooler.
+Transaction-mode PgBouncer multiplexes server connections, which silently
+drops `LISTEN/NOTIFY` (hints never arrive in Redis-less mode) and breaks the
+session advisory locks used by boot migrations and partition maintenance.
+This applies with or without Redis.
 </Callout>
 
 ## Partitioning & retention


### PR DESCRIPTION
## Quickstart rewrite (clone-free only)

The quickstart no longer requires cloning or a toolchain: `docker run` from the published GHCR image (Redis-less, only 8080 published) + `npm install @chimely/react` in the reader's own app. Every documented command was executed and verified: image pull and boot, migrations, curl send, fresh Vite app with the registry packages, live SSE badge update in a browser.

The old Option A was broken on fresh clones anyway: `DATABASE_URL=... cargo run` points the sqlx compile-time checks at the still-empty database (migrations only run at boot). From-source instructions move to CONTRIBUTING (follow-up) with `SQLX_OFFLINE=true`.

## Audit fixes (3 agents, ~240 claims checked, 12 discrepancies)

- **index.mdx License section still said FSL / fair source / not-OSI** while the server is AGPL-3.0. Rewritten; also frontmatter + CLAUDE.md + a workflow comment.
- sdk-reference: tabs `filter` snippet did not typecheck (`payload.tags` is `unknown`); client Methods table missed `markUnread`/`archive`/`unarchive`/`archiveAll`/`archiveRead`/`setFilter`; `InboxItem` missed `archived`; slot list missed `filter`; composable snippet missed React imports.
- self-hosting: PgBouncer callout claimed pooler mode is irrelevant with Redis, but session advisory locks (migrations, partition maintenance) break under transaction pooling regardless.
- operations: `GET /v1/notifications/{id}/timeline` is also under the API-key limit; `jobs_failed_total` wording covered only the retry case.
- auth: key plaintext also stores a display prefix; `CHIMELY_DEV_API_KEY` is a no-op without `CHIMELY_DEV_ENVIRONMENT`; HMAC rotate is admin-role and needs session+CSRF when scripted.

## Compose

- Dev compose stops publishing Postgres/Redis host ports (collision with any local pg/redis made `docker compose up` fail; the app reaches them on the compose network).
- deploy compose default image tag 0.1.0 -> 0.2.0.

Docs typecheck + full static build pass; markdown twins regenerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)