### PR TITLE
docs: registry READMEs, CONTRIBUTING, crate metadata

### DIFF
--- a/.changeset/ship-package-readmes.md
+++ b/.changeset/ship-package-readmes.md
@@ -1,0 +1,6 @@
+---
+'@chimely/client': patch
+'@chimely/react': patch
+---
+
+Ship the package README on npm.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to Chimely
+
+Thanks for wanting to help. Two things to know before your first PR:
+
+- **CLA.** External code contributions require signing a Contributor License
+  Agreement, so the project keeps relicensing and commercial-licensing
+  flexibility. You will be asked on your first PR.
+- **Invariants.** `CLAUDE.md` at the repo root is the living record of the
+  design invariants (two-source inbox, watermark-only bulk operations,
+  transactional outbox, and friends). Violating one is a bug even if all
+  tests pass. Read it before touching the server.
+
+## Prerequisites
+
+- Rust (the toolchain is pinned by `rust-toolchain.toml`; rustup picks it up)
+- Node 20+ with pnpm (`corepack enable`)
+- Docker (server tests run against real Postgres and Redis via
+  testcontainers)
+
+## Server (`server/`, Rust)
+
+Builds are offline by default: the committed `.sqlx` cache carries the
+compile-time query metadata, so no database is needed to compile.
+
+```bash
+cd server
+SQLX_OFFLINE=true cargo fmt --check
+SQLX_OFFLINE=true cargo clippy --all-targets -- -D warnings
+SQLX_OFFLINE=true cargo nextest run        # needs Docker running
+```
+
+Run the server from source against a throwaway Postgres:
+
+```bash
+docker run -d --name chimely-dev-pg \
+  -e POSTGRES_PASSWORD=chimely -p 5432:5432 postgres:16-alpine
+
+SQLX_OFFLINE=true \
+DATABASE_URL=postgres://postgres:chimely@localhost:5432/postgres \
+CHIMELY_DEV_ENVIRONMENT=demo \
+CHIMELY_DEV_API_KEY=dev-secret-key \
+cargo run --manifest-path server/Cargo.toml -- serve
+```
+
+`SQLX_OFFLINE=true` matters: without it the sqlx macros check queries against
+the live `DATABASE_URL`, which is still empty on a first run (migrations only
+apply when the compiled binary boots).
+
+**Changing or adding SQL queries:** point `DATABASE_URL` at a Postgres that
+has the migrations applied (boot the server against it once), run
+`cargo sqlx prepare`, and commit the `.sqlx` changes. CI compiles offline and
+fails on a stale cache.
+
+The all-in-one stack (server + Postgres + Redis, built from your checkout) is
+`docker compose up --build` at the repo root.
+
+## TypeScript (`packages/`, `docs/`, `examples/`)
+
+```bash
+pnpm install
+pnpm lint                                # biome ci .
+pnpm --filter "./packages/*" build       # react typechecks against client's dist
+pnpm typecheck
+pnpm test
+```
+
+`@chimely/react` tests run against `@chimely/client`'s built `dist`, so
+rebuild the client after switching branches or its features will be missing.
+
+Package-visible changes need a changeset (`pnpm changeset`); pick `minor` for
+features and `patch` for fixes, pre-1.0.
+
+## Generated artifacts
+
+The OpenAPI document is code-first (utoipa). `docs/openapi/` and
+`packages/client/src/generated/` are derived from it:
+
+```bash
+pnpm generate    # regenerates both; commit the result
+```
+
+Never hand-edit generated files. CI fails if they are stale.
+
+## Commits and PRs
+
+Conventional Commits (`type(scope): summary`), subjects at or under about 50
+characters, and concise bodies. `feat`, `fix`, `refactor`, `docs`, `test`,
+`build`, `ci`, `chore` are the common types. PR descriptions state what
+changed and why in as few words as possible.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ Thanks for wanting to help. Two things to know before your first PR:
 ## Prerequisites
 
 - Rust (the toolchain is pinned by `rust-toolchain.toml`; rustup picks it up)
+- cargo-nextest, the test runner (`cargo install cargo-nextest`)
 - Node 20+ with pnpm (`corepack enable`)
 - Docker (server tests run against real Postgres and Redis via
   testcontainers)
@@ -29,7 +30,8 @@ SQLX_OFFLINE=true cargo clippy --all-targets -- -D warnings
 SQLX_OFFLINE=true cargo nextest run        # needs Docker running
 ```
 
-Run the server from source against a throwaway Postgres:
+Run the server from source against a throwaway Postgres (from the repo
+root):
 
 ```bash
 docker run -d --name chimely-dev-pg \
@@ -79,7 +81,9 @@ The OpenAPI document is code-first (utoipa). `docs/openapi/` and
 pnpm generate    # regenerates both; commit the result
 ```
 
-Never hand-edit generated files. CI fails if they are stale.
+Never hand-edit generated files. A stale artifact shows up as an uncommitted
+diff after `pnpm generate`; regenerate and commit it with the change that
+moved the spec.
 
 ## Commits and PRs
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,102 @@
 # Chimely
 
+[![CI](https://github.com/dodopayments/chimely/actions/workflows/ci.yml/badge.svg)](https://github.com/dodopayments/chimely/actions/workflows/ci.yml)
+[![@chimely/react](https://img.shields.io/npm/v/%40chimely%2Freact?label=%40chimely%2Freact)](https://www.npmjs.com/package/@chimely/react)
+[![@chimely/client](https://img.shields.io/npm/v/%40chimely%2Fclient?label=%40chimely%2Fclient)](https://www.npmjs.com/package/@chimely/client)
+[![License](https://img.shields.io/badge/license-AGPL--3.0%20server%20%7C%20MIT%20SDKs-blue)](https://github.com/dodopayments/chimely#license-faq)
+
 Open-source, self-hostable **in-app notification inbox infrastructure**.
 One Rust binary + Postgres + Redis, a deliberately small HTTP API, and a
-drop-in `<Inbox />` React component. No workflow engine — the inbox is the
+drop-in `<Inbox />` React component. No workflow engine: the inbox is the
 primitive.
+
+Your backend sends one POST:
+
+```bash
+curl -X POST https://chimely.example.com/v1/notifications \
+  -H 'Authorization: Bearer <api-key>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "subscriber_id": "usr_123",
+    "category": "billing.invoice",
+    "payload": { "title": "Invoice ready", "body": "March invoice is ready." }
+  }'
+```
+
+Your frontend renders one component:
+
+```tsx
+import { Inbox } from '@chimely/react';
+
+<Inbox
+  serverUrl="https://chimely.example.com"
+  environment="production"
+  subscriberId="usr_123"
+  subscriberHash={subscriberHash}
+/>
+```
+
+That is a live bell with unread counts, read state, tabs, archive, infinite
+scroll, per-category preferences, and SSE live updates. Nothing else to build.
+
+## Quickstart
+
+Nothing to clone: the server runs from the published image and the component
+installs from npm.
+
+```bash
+docker network create chimely
+
+docker run -d --name chimely-pg --network chimely \
+  -e POSTGRES_PASSWORD=chimely postgres:16-alpine
+
+docker run -d --name chimely --network chimely -p 8080:8080 \
+  -e DATABASE_URL=postgres://postgres:chimely@chimely-pg:5432/postgres \
+  -e CHIMELY_DEV_ENVIRONMENT=demo \
+  -e CHIMELY_DEV_API_KEY=dev-secret-key \
+  ghcr.io/dodopayments/chimely:0.2.0
+```
+
+Then follow the [quickstart](https://chimely.dev/docs/quickstart): send a
+notification with curl and mount `<Inbox />` in your app, about five minutes
+end to end.
+
+## How it works
+
+```
+ your backend ── POST /v1/notifications ──▶ ┌─────────────┐ ◀──▶ Postgres  (source of truth)
+                                            │   chimely   │
+ your frontend ◀── SSE hints + REST/ETag ──▶│  one binary │ ◀──▶ Redis  (hints; optional)
+    <Inbox />                               └─────────────┘
+```
+
+- **Postgres is authoritative.** Redis only carries real-time hints and
+  recomputable caches; losing it delays updates but never loses data.
+- **SSE is a hint, not a transport.** Every hint triggers a conditional
+  refetch (ETag, mostly `304`s), so missed hints are harmless by
+  construction.
+- **Single-org, multi-environment.** Environments are the isolation unit;
+  multi-tenancy is "run another instance".
+- The server embeds its migrations (run on boot under an advisory lock), an
+  operator dashboard, Prometheus metrics, and OpenAPI docs at `/docs`.
+
+## What Chimely is not
+
+These are deliberate. Chimely does the inbox and nothing else:
+
+- No workflows, steps, or conditional routing.
+- No email, SMS, or push channels. In-app inbox only.
+- No server-side templating. Your payload is stored and shown as-is.
+- No digests or batching.
 
 ## Repository layout
 
 ```
-server/            Rust binary: API, SSE, workers          (AGPL-3.0)
-packages/client/   @chimely/client — headless TS core       (MIT)
-packages/react/    @chimely/react  — hooks + <Inbox />      (MIT)
-examples/          quickstarts and integration examples    (MIT)
-docs/              Fumadocs site                           (MIT)
+server/            Rust binary: API, SSE, workers           (AGPL-3.0)
+packages/client/   @chimely/client, headless TS core        (MIT)
+packages/react/    @chimely/react, hooks + <Inbox />        (MIT)
+examples/          quickstarts and integration examples     (MIT)
+docs/              Fumadocs site                            (MIT)
 ```
 
 ## Admin dashboard
@@ -20,25 +104,26 @@ docs/              Fumadocs site                           (MIT)
 The server embeds an operator dashboard at `/admin` (status/timeline browser,
 broadcast composer, subscriber lookup, DLQ replay, environment + API key
 management, HMAC rotation, and admin-user management). It ships inside the
-binary — `docker run chimely` serves it with no extra artifact.
+binary: `docker run chimely` serves it with no extra artifact.
 
 **Built-in users with roles.** The dashboard has its own login (email +
 password, Argon2id-hashed) backed by a server-side session cookie. Four fixed
-roles gate what each operator can do (still single-org — no organizations, no
+roles gate what each operator can do (still single-org, no organizations, no
 per-environment user scoping):
 
-- **viewer** — read-only (inbox, timelines, subscriber lookup, DLQ list).
-- **operator** — viewer, plus DLQ replay and composing broadcasts.
-- **developer** — viewer, plus create/revoke API keys and read an
-  environment's subscriber HMAC secret.
-- **admin** — everything, including creating environments, rotating HMAC
-  secrets, and managing users.
+- **viewer** reads everything (inbox, timelines, subscriber lookup, DLQ list).
+- **operator** adds DLQ replay and composing broadcasts.
+- **developer** adds create/revoke API keys and reading an environment's
+  subscriber HMAC secret.
+- **admin** adds creating environments, rotating HMAC secrets, and managing
+  users.
 
 **Bootstrap (root) admin.** On boot, if `CHIMELY_ADMIN_EMAIL` and
 `CHIMELY_ADMIN_PASSWORD` are set, Chimely ensures an `admin` account with that
-email — creating it, or resetting its password to the env value if it drifted.
-This is the lockout-recovery path: restart with the env vars to restore admin
-access. Everyone else gets their own account from the Users page.
+email exists, creating it or resetting its password to the env value if it
+drifted. This is the lockout-recovery path: restart with the env vars to
+restore admin access. Everyone else gets their own account from the Users
+page.
 
 ```bash
 CHIMELY_ADMIN_EMAIL=ops@example.com \
@@ -53,16 +138,28 @@ The binary serves plain HTTP, so terminate TLS at a proxy and set that flag;
 without it Chimely logs a boot-time warning and the cookie omits `Secure`.
 Passwords and session ids are never logged.
 
+## Versioning
+
+Chimely is pre-1.0 (currently 0.2.x). The HTTP API and the SDK surface may
+change on minor version bumps until 1.0.0. Pin your versions: the Docker tag
+and the npm versions.
+
+## Contributing
+
+See [CONTRIBUTING.md](https://github.com/dodopayments/chimely/blob/main/CONTRIBUTING.md)
+for the dev setup and workflow. External code contributions require a CLA so
+the project keeps relicensing and commercial-licensing flexibility.
+
 ## License FAQ
 
 **What is licensed how?** The server (`server/`) is
-[AGPL-3.0](./LICENSE) — the GNU Affero General Public License v3. The SDKs
-(`packages/client`, `packages/react`) and everything in `examples/` are
-MIT — they embed in your frontend, and they carry their own `LICENSE`
-files.
+[AGPL-3.0](https://github.com/dodopayments/chimely/blob/main/LICENSE), the GNU
+Affero General Public License v3. The SDKs (`packages/client`,
+`packages/react`) and everything in `examples/` are MIT; they embed in your
+frontend, and they carry their own `LICENSE` files.
 
 **What does AGPL mean for me?** You can use, self-host, modify, and
-redistribute Chimely freely — internally, in production, commercially, at
+redistribute Chimely freely: internally, in production, commercially, at
 any scale, for free, forever. AGPL's one obligation is reciprocity: if you
 modify Chimely and offer it to others over a network, you must give those
 users that modified server's source (AGPL §13). Running it
@@ -71,7 +168,7 @@ unmodified carries no such obligation.
 **Does the server license affect my application?** No. You run the Chimely
 binary as a standalone network service and integrate over HTTP through the
 MIT-licensed SDKs. Your application is a separate program that talks to
-Chimely over the API — AGPL covers Chimely's own source, not the client
+Chimely over the API. AGPL covers Chimely's own source, not the client
 code that calls it, and calling the HTTP API creates no obligations.
 
 **Is this open source?** Yes. AGPL-3.0 is an OSI-approved open source
@@ -83,8 +180,5 @@ the documentation content are MIT, so third-party clients, bindings, and
 integrations are unambiguous.
 
 **The name and logo?** Not licensed. "Chimely" and the logo remain with the
-project regardless of code license — that, not the code license, is the
+project regardless of code license; that, not the code license, is the
 protection against confusing forks.
-
-**Contributing:** external code contributions require a CLA (so the project
-can continue to relicense or offer commercial licenses if needed).

--- a/README.md
+++ b/README.md
@@ -51,13 +51,16 @@ docker run -d --name chimely-pg --network chimely \
   -e POSTGRES_PASSWORD=chimely postgres:16-alpine
 
 docker run -d --name chimely --network chimely -p 8080:8080 \
+  --restart unless-stopped \
   -e DATABASE_URL=postgres://postgres:chimely@chimely-pg:5432/postgres \
   -e CHIMELY_DEV_ENVIRONMENT=demo \
   -e CHIMELY_DEV_API_KEY=dev-secret-key \
   ghcr.io/dodopayments/chimely:0.2.0
 ```
 
-Then follow the [quickstart](https://chimely.dev/docs/quickstart): send a
+The restart policy covers the first seconds while Postgres is still
+initializing (the server fails fast when its database is unreachable). Then
+follow the [quickstart](https://chimely.dev/docs/quickstart): send a
 notification with curl and mount `<Inbox />` in your app, about five minutes
 end to end.
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,0 +1,66 @@
+# @chimely/client
+
+Headless, framework-agnostic core for [Chimely](https://github.com/dodopayments/chimely),
+the open-source, self-hostable in-app notification inbox. Zero runtime
+dependencies. If you use React, you probably want
+[`@chimely/react`](https://www.npmjs.com/package/@chimely/react), which wraps
+this client in hooks and a drop-in `<Inbox />`.
+
+```bash
+npm install @chimely/client
+```
+
+## Usage
+
+```ts
+import { ChimelyClient } from '@chimely/client';
+
+const client = new ChimelyClient({
+  serverUrl: 'https://chimely.example.com',
+  environment: 'production',
+  subscriberId: 'usr_123',
+  // Computed by YOUR backend: hex(HMAC-SHA256(environment_secret, subscriberId)).
+  // Never compute it in the browser.
+  subscriberHash,
+});
+
+const unsubscribe = client.subscribe(() => {
+  const { items, counts } = client.getSnapshot();
+  render(items, counts.unread);
+});
+
+client.connect();
+```
+
+The snapshot is immutable with a new identity per change, so it plugs straight
+into `useSyncExternalStore` or any equality-based renderer. Mutations
+(`markRead`, `markUnread`, `archive`, `markAllRead`, ...) apply optimistically
+and roll back on failure.
+
+Live updates arrive over Server-Sent Events, but SSE is a hint, not a
+transport: every hint triggers a conditional REST refetch (ETag, mostly
+`304`s), so a missed hint is harmless and reconnects are cheap.
+
+## Types are generated
+
+The wire types are generated from the Chimely server's exported OpenAPI
+document and shipped with the package. They are never hand-edited, so the
+types you compile against are exactly what the server serves.
+
+## Versioning
+
+Pre-1.0: the HTTP API and this package's surface may change on minor bumps.
+Pin your versions.
+
+## Links
+
+- [Documentation](https://chimely.dev/docs)
+- [SDK reference](https://chimely.dev/docs/sdk-reference)
+- [Auth and the subscriber hash](https://chimely.dev/docs/auth)
+- [GitHub](https://github.com/dodopayments/chimely)
+
+## License
+
+MIT. The Chimely server is AGPL-3.0, which does not affect applications that
+talk to it over HTTP through this SDK. See the
+[License FAQ](https://github.com/dodopayments/chimely#license-faq).

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,74 @@
+# @chimely/react
+
+Drop-in `<Inbox />`, hooks, and composable components for
+[Chimely](https://github.com/dodopayments/chimely), the open-source,
+self-hostable in-app notification inbox.
+
+```bash
+npm install @chimely/react
+```
+
+Requires `react` and `react-dom` 18 or 19 as peer dependencies.
+
+## The `<Inbox />`
+
+```tsx
+import { Inbox } from '@chimely/react';
+
+<Inbox
+  serverUrl="https://chimely.example.com"
+  environment="production"
+  subscriberId="usr_123"
+  subscriberHash={subscriberHash}
+/>
+```
+
+That is a live bell with an unseen badge, a popover inbox with unread state,
+tabs, filters, archive, infinite scroll, per-category preferences, and SSE
+live updates. `subscriberHash` is `hex(HMAC-SHA256(environment_secret,
+subscriberId))`, computed by **your backend**, never in the browser. See
+[Auth and the subscriber hash](https://chimely.dev/docs/auth).
+
+## Hooks and composables
+
+For custom UIs, skip the popover and compose:
+
+- `ChimelyProvider` plus `useNotifications`, `useUnreadCount`,
+  `useUnseenCount`, `usePreferences`
+- `<Bell />`, `<InboxContent />`, `<Preferences />` as standalone components
+- Render props (`renderItem`, `renderSubject`, `renderBody`, `renderAvatar`,
+  `renderBell`, `renderFooter`) to replace one fragment while keeping the
+  rest
+
+## Theming
+
+Plain CSS with custom properties. `appearance.variables` sets tokens
+(`colorPrimary`, `colorBackground`, `shadow`, ...), `appearance.classNames`
+and `appearance.styles` target each named slot, and a `darkTheme` preset
+ships with the package:
+
+```tsx
+import { darkTheme } from '@chimely/react';
+
+<Inbox appearance={{ variables: { ...darkTheme, colorPrimary: '#8b5cf6' } }} />
+```
+
+The full prop, slot, and localization tables are in the
+[SDK reference](https://chimely.dev/docs/sdk-reference).
+
+## Versioning
+
+Pre-1.0: the component and hook surface may change on minor bumps. Pin your
+versions.
+
+## Links
+
+- [Quickstart](https://chimely.dev/docs/quickstart) (five minutes, nothing to clone)
+- [Documentation](https://chimely.dev/docs)
+- [GitHub](https://github.com/dodopayments/chimely)
+
+## License
+
+MIT. The Chimely server is AGPL-3.0, which does not affect applications that
+talk to it over HTTP through this SDK. See the
+[License FAQ](https://github.com/dodopayments/chimely#license-faq).

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "chimely"
-version = "0.1.2"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "argon2",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "chimely"
-version = "0.1.2"
+version = "0.2.1"
 edition = "2024"
+# Distributed as a Docker image (GHCR), not on crates.io.
+publish = false
 license = "AGPL-3.0-only"
 description = "In-app notification inbox infrastructure: one binary + Postgres + Redis."
 repository = "https://github.com/dodopayments/chimely"

--- a/server/README.md
+++ b/server/README.md
@@ -18,10 +18,13 @@ docker run -d --name chimely-pg --network chimely \
   -e POSTGRES_PASSWORD=chimely postgres:16-alpine
 
 docker run -d --name chimely --network chimely -p 8080:8080 \
+  --restart unless-stopped \
   -e DATABASE_URL=postgres://postgres:chimely@chimely-pg:5432/postgres \
   ghcr.io/dodopayments/chimely:0.2.0
 ```
 
+The restart policy covers the first seconds while Postgres is still
+initializing (the server fails fast when its database is unreachable).
 Migrations run on boot under an advisory lock. `DATABASE_URL` is the only
 required setting; every other knob is an environment variable with a
 production default. The image is production-ready as started above: dev

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,52 @@
+# Chimely server
+
+The [Chimely](https://github.com/dodopayments/chimely) server: open-source,
+self-hostable in-app notification inbox infrastructure in one binary. Postgres
+is the source of truth; Redis is an optional real-time hint plane. The image
+bundles the operator dashboard at `/admin`.
+
+Published image: `ghcr.io/dodopayments/chimely`
+
+## Run it
+
+Two containers, no Redis (hints fall back to Postgres `LISTEN/NOTIFY`):
+
+```bash
+docker network create chimely
+
+docker run -d --name chimely-pg --network chimely \
+  -e POSTGRES_PASSWORD=chimely postgres:16-alpine
+
+docker run -d --name chimely --network chimely -p 8080:8080 \
+  -e DATABASE_URL=postgres://postgres:chimely@chimely-pg:5432/postgres \
+  ghcr.io/dodopayments/chimely:0.2.0
+```
+
+Migrations run on boot under an advisory lock. `DATABASE_URL` is the only
+required setting; every other knob is an environment variable with a
+production default. The image is production-ready as started above: dev
+bootstrap (`CHIMELY_DEV_*`) and the recovery admin (`CHIMELY_ADMIN_*`) are
+strictly opt-in, the process runs as a non-root user, and logs are JSON.
+
+- Full configuration reference: https://chimely.dev/docs/self-hosting
+- Metrics, alerts, dead letters, shutdown: https://chimely.dev/docs/operations
+- Probes: `GET /healthz` (liveness), `GET /readyz` (readiness; Redis down is
+  not readiness-fatal)
+- Production compose with a pinned image:
+  [`deploy/docker-compose.yml`](https://github.com/dodopayments/chimely/blob/main/deploy/docker-compose.yml)
+
+Terminate TLS at a reverse proxy in front of the binary; it serves plain HTTP.
+
+## Requirements
+
+- Postgres 15 or newer (the durable state; back this up)
+- Redis 7 (optional; holds only recomputable hints and cached counters)
+
+## License
+
+AGPL-3.0. Free to use, self-host, modify, and redistribute at any scale.
+Applications integrate over HTTP through the MIT-licensed SDKs
+([`@chimely/client`](https://www.npmjs.com/package/@chimely/client),
+[`@chimely/react`](https://www.npmjs.com/package/@chimely/react)), so the
+server's copyleft never reaches your code. See the
+[License FAQ](https://github.com/dodopayments/chimely#license-faq).


### PR DESCRIPTION
## Why

`@chimely/client` and `@chimely/react` shipped 0.2.0 with **no README**: their npmjs.com pages are blank. Registry READMEs are baked into the tarball at publish time, so these ride the 0.2.1 patch (changeset included; `npm pack --dry-run` verified both tarballs now carry README + LICENSE).

## What

- `packages/client/README.md`, `packages/react/README.md`: install, verified usage snippets, HMAC-is-server-side note, pre-1.0 pin note, license boundary. Absolute URLs only (relative links 404 on npm).
- `server/README.md`: GHCR-facing. Verified `docker run` pair, production-defaults statement, probes, config links, AGPL + FAQ link.
- Root `README.md`: badges, the two-snippet proof (curl + `<Inbox />`), clone-free quickstart, architecture sketch, non-goals, versioning, CONTRIBUTING link. Admin and License FAQ sections kept.
- `CONTRIBUTING.md`: CLA requirement, offline-sqlx workflow (`SQLX_OFFLINE=true`; fresh-clone builds fail without it since the sqlx macros hit the empty dev DB), testcontainers note, changesets, commit style.
- `server/Cargo.toml`: `publish = false` (server ships as a Docker image, not on crates.io) and version 0.1.2 -> 0.2.1 so `/healthz` stops reporting 0.1.2 from a 0.2.x-tagged image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)