### PR TITLE
fix(react): use client banner, a11y count, CSP escape

### DIFF
--- a/.changeset/frontend-hardening.md
+++ b/.changeset/frontend-hardening.md
@@ -1,0 +1,9 @@
+---
+'@chimely/react': patch
+---
+
+Hostile-host hardening: the bundle now carries its own `'use client'`
+directive (imports cleanly from React Server Component module graphs), the
+bell's accessible name includes the unseen count (previously invisible to
+assistive tech), and `INBOX_CSS` is exported so nonce-CSP hosts can serve the
+stylesheet from their own pipeline.

--- a/docs/content/docs/sdk-reference.mdx
+++ b/docs/content/docs/sdk-reference.mdx
@@ -25,6 +25,12 @@ version bumps until 1.0.0. Pin your versions.
 npm i @chimely/react react react-dom
 ```
 
+The components are **client-only** and the bundle carries its own
+`'use client'` directive, so importing from a React Server Component module
+graph is safe without a wrapper. Server rendering is supported and emits the
+bell with an empty, disconnected inbox; data loads and the SSE stream opens
+in effects after hydration.
+
 ## `<Inbox />`
 
 A bell + popover. Use it standalone (pass connection props; it owns a client)
@@ -135,7 +141,7 @@ omitted keys keep the `en-US` defaults.
 | `markAllRead` | `Mark all as read` | |
 | `preferencesTitle` | `Notification preferences` | Preferences header and gear label |
 | `inboxTitle` | `Notifications` | List-view header title and dialog label |
-| `bellLabel` | `Notifications` | Bell button aria-label |
+| `bellLabel` | `Notifications` | Bell button aria-label; the unseen count is appended, e.g. `Notifications (3)` |
 | `backLabel` | `Back` | Preferences back button aria-label |
 | `categoryLabels` | `{}` | Display names for category keys in the preferences panel |
 | `filterLabel` | `View` | View select aria-label |
@@ -156,6 +162,34 @@ The default timestamp rendering is relative (`5 minutes ago`, via
 `Intl.RelativeTimeFormat`), falling back to the locale date past seven days.
 The absolute time stays on the `<time>` element's `dateTime` and `title`
 attributes.
+
+### Popover behavior in hostile layouts
+
+The default popover renders next to the bell in the DOM, so it clips under
+`overflow: hidden` ancestors and misplaces inside CSS-transformed ones; set
+`portal` to escape both. With `portal`, the popover lives under
+`document.body`, so Tab order walks the page between the bell and the dialog;
+focus stays on the bell when the popover opens, and Escape closes it from
+anywhere and returns focus to the bell. The popover ships with `z-index:
+1000`; override per-slot via `appearance.styles.popover` when your stacking
+contexts demand it.
+
+### Content Security Policy
+
+The widget injects one `<style data-chimely>` tag. Under a strict CSP a host
+needs:
+
+```
+style-src 'self' 'unsafe-inline';                  # the injected style tag
+connect-src 'self' https://your-chimely-server;    # REST + the SSE stream
+```
+
+Without `'unsafe-inline'` (or a hash) the widget stays fully functional but
+unstyled. Nonce-based hosts can skip the injection entirely: the full
+stylesheet is exported as `INBOX_CSS`, so serve it from your own pipeline
+(the blocked injected tag is then harmless). There is no `eval`, no inline
+event handler, and no `script-src` implication. `action_url` navigation is
+restricted to `http(s)` schemes.
 
 ## Composable components
 

--- a/docs/content/docs/sdk-reference.mdx
+++ b/docs/content/docs/sdk-reference.mdx
@@ -176,20 +176,20 @@ contexts demand it.
 
 ### Content Security Policy
 
-The widget injects one `<style data-chimely>` tag. Under a strict CSP a host
-needs:
+The widget injects one `<style data-chimely>` tag, which needs
+`'unsafe-inline'` (or a hash) in `style-src`, and it talks to the server via
+fetch and `EventSource`, which need the server's origin in `connect-src`:
 
 ```
-style-src 'self' 'unsafe-inline';                  # the injected style tag
-connect-src 'self' https://your-chimely-server;    # REST + the SSE stream
+style-src 'self' 'unsafe-inline'; connect-src 'self' https://your-chimely-server
 ```
 
 Without `'unsafe-inline'` (or a hash) the widget stays fully functional but
-unstyled. Nonce-based hosts can skip the injection entirely: the full
-stylesheet is exported as `INBOX_CSS`, so serve it from your own pipeline
-(the blocked injected tag is then harmless). There is no `eval`, no inline
-event handler, and no `script-src` implication. `action_url` navigation is
-restricted to `http(s)` schemes.
+unstyled, and each page load logs one CSP violation for the blocked tag.
+Nonce-based hosts have a supported path: the full stylesheet is exported as
+`INBOX_CSS`, so serve it from your own pipeline and ignore the blocked
+injection. There is no `eval`, no inline event handler, and no `script-src`
+implication. `action_url` navigation is restricted to `http(s)` schemes.
 
 ## Composable components
 

--- a/packages/react/src/archive-ui.test.tsx
+++ b/packages/react/src/archive-ui.test.tsx
@@ -14,7 +14,7 @@ async function renderInbox(stub: StubServer, props: InboxProps = {}): Promise<vo
       <Inbox {...props} />
     </ChimelyProvider>,
   );
-  fireEvent.click(screen.getByRole('button', { name: 'Notifications' }));
+  fireEvent.click(screen.getByRole('button', { name: /^Notifications/ }));
 }
 
 afterEach(() => {

--- a/packages/react/src/components/Bell.tsx
+++ b/packages/react/src/components/Bell.tsx
@@ -29,6 +29,13 @@ export const Bell = forwardRef<HTMLButtonElement, BellProps>(function Bell(props
   const { count: unseenCount } = useUnseenCount();
   const strings = mergeLocalization(props.localization);
   const open = props.open === true;
+  // The aria-label overrides the button's text content in accessible-name
+  // computation, so the visual badge alone leaves the count imperceptible
+  // to assistive tech. The count rides the name instead.
+  const label =
+    unseenCount > 0
+      ? `${strings.bellLabel} (${unseenCount > 99 ? '99+' : unseenCount})`
+      : strings.bellLabel;
   // Bell re-renders on every unseen tick, a fresh style object per render
   // would defeat React's shallow style comparison.
   const style = useMemo(
@@ -46,7 +53,7 @@ export const Bell = forwardRef<HTMLButtonElement, BellProps>(function Bell(props
       type="button"
       className={slotClass(props.appearance?.classNames, 'bell')}
       style={style}
-      aria-label={strings.bellLabel}
+      aria-label={label}
       aria-expanded={props.open === undefined ? undefined : open}
       aria-haspopup={props.popupId === undefined ? undefined : 'dialog'}
       aria-controls={props.popupId !== undefined && open ? props.popupId : undefined}

--- a/packages/react/src/composition.test.tsx
+++ b/packages/react/src/composition.test.tsx
@@ -25,7 +25,7 @@ async function provided(
 
 async function renderInbox(stub: StubServer, props: InboxProps = {}): Promise<void> {
   await provided(stub, () => <Inbox {...props} />);
-  fireEvent.click(screen.getByRole('button', { name: 'Notifications' }));
+  fireEvent.click(screen.getByRole('button', { name: /^Notifications/ }));
 }
 
 afterEach(() => {
@@ -79,7 +79,7 @@ describe('standalone Bell', () => {
     const ref = createRef<HTMLButtonElement>();
     await provided(stub, () => <Bell ref={ref} onClick={onClick} />);
 
-    const button = screen.getByRole('button', { name: 'Notifications' });
+    const button = screen.getByRole('button', { name: /^Notifications/ });
     expect(ref.current).toBe(button);
     expect(screen.getByText('2')).toBeDefined();
 

--- a/packages/react/src/filter-actions.test.tsx
+++ b/packages/react/src/filter-actions.test.tsx
@@ -14,7 +14,7 @@ async function renderInbox(stub: StubServer, props: InboxProps = {}): Promise<vo
       <Inbox {...props} />
     </ChimelyProvider>,
   );
-  fireEvent.click(screen.getByRole('button', { name: 'Notifications' }));
+  fireEvent.click(screen.getByRole('button', { name: /^Notifications/ }));
 }
 
 afterEach(() => {

--- a/packages/react/src/inbox.test.tsx
+++ b/packages/react/src/inbox.test.tsx
@@ -46,7 +46,7 @@ async function renderInbox(
 }
 
 function bell(): HTMLElement {
-  return screen.getByRole('button', { name: 'Notifications' });
+  return screen.getByRole('button', { name: /^Notifications/ });
 }
 
 afterEach(() => {
@@ -73,6 +73,20 @@ describe('bell and badge', () => {
     stub.addNotification({ seen: true });
     await renderInbox(stub);
     expect(document.querySelector('.chimely-badge')).toBeNull();
+  });
+
+  test('the unseen count rides the accessible name', async () => {
+    const stub = createStubServer();
+    stub.addNotification();
+    stub.addNotification();
+    await renderInbox(stub);
+
+    expect(screen.getByRole('button', { name: 'Notifications (2)' })).toBeDefined();
+
+    fireEvent.click(bell());
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Notifications' })).toBeDefined();
+    });
   });
 
   test('renderBell fully replaces the bell contents', async () => {
@@ -450,7 +464,7 @@ describe('header title and footer', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Notification preferences' }));
     expect(screen.getByRole('dialog', { name: 'Notification preferences' })).toBeDefined();
     fireEvent.click(screen.getByRole('button', { name: 'Back' }));
-    expect(screen.getByRole('dialog', { name: 'Notifications' })).toBeDefined();
+    expect(screen.getByRole('dialog', { name: /^Notifications/ })).toBeDefined();
   });
 });
 
@@ -461,7 +475,7 @@ describe('localized labels', () => {
     await renderInbox(stub, {
       localization: { bellLabel: 'Meine Glocke', backLabel: 'Zurueck' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Meine Glocke' }));
+    fireEvent.click(screen.getByRole('button', { name: /^Meine Glocke/ }));
     fireEvent.click(screen.getByRole('button', { name: 'Notification preferences' }));
     expect(screen.getByRole('button', { name: 'Zurueck' })).toBeDefined();
   });

--- a/packages/react/src/inbox.test.tsx
+++ b/packages/react/src/inbox.test.tsx
@@ -89,6 +89,15 @@ describe('bell and badge', () => {
     });
   });
 
+  test('the accessible name caps at 99+', async () => {
+    const stub = createStubServer();
+    for (let i = 0; i < 105; i += 1) {
+      stub.addNotification();
+    }
+    await renderInbox(stub);
+    expect(screen.getByRole('button', { name: 'Notifications (99+)' })).toBeDefined();
+  });
+
   test('renderBell fully replaces the bell contents', async () => {
     const stub = createStubServer();
     stub.addNotification();

--- a/packages/react/src/index.test.ts
+++ b/packages/react/src/index.test.ts
@@ -3,6 +3,7 @@ import {
   Bell,
   ChimelyProvider,
   DEFAULT_LOCALIZATION,
+  INBOX_CSS,
   Inbox,
   InboxContent,
   Preferences,
@@ -28,4 +29,5 @@ test('public surface exports', () => {
   // forwardRef components are objects with a render function.
   expect(Bell).toBeDefined();
   expect(DEFAULT_LOCALIZATION.markAllRead.length).toBeGreaterThan(0);
+  expect(INBOX_CSS).toContain('.chimely-popover');
 });

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -36,3 +36,7 @@ export type { InboxProps } from './Inbox';
 export { Inbox } from './Inbox';
 export type { InboxLocalization } from './localization';
 export { DEFAULT_LOCALIZATION } from './localization';
+// The stylesheet as a string, for hosts whose CSP blocks the injected
+// style tag (nonce-based style-src). Served from the host's own pipeline,
+// the blocked injection is harmless and styling still works.
+export { INBOX_CSS } from './styles';

--- a/packages/react/src/theming.test.tsx
+++ b/packages/react/src/theming.test.tsx
@@ -24,7 +24,7 @@ async function renderInbox(
 }
 
 function bell(): HTMLElement {
-  return screen.getByRole('button', { name: 'Notifications' });
+  return screen.getByRole('button', { name: /^Notifications/ });
 }
 
 afterEach(() => {

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -7,4 +7,8 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   external: ['react', 'react-dom'],
+  // The components are client-only (createContext at module scope). The
+  // banner keeps the package importable from a React Server Component
+  // module graph without every consumer wrapping it.
+  banner: { js: "'use client';" },
 });


### PR DESCRIPTION
Fixes the three real defects from the hostile-frontend review (run against SSR, hydration, CSP, portal, multi-instance, and a11y surfaces; 104/104 tests pass):

- **`'use client'` banner in the bundle** (tsup `banner`): importing `@chimely/react` from a React Server Component module graph previously failed at module evaluation (`createContext` at module scope). Verified present in both ESM and CJS dist outputs.
- **Unseen count in the bell's accessible name**: `aria-label` overrides text content in accessible-name computation, so the visual badge was imperceptible to screen readers. The name is now `Notifications (3)` (localized label + count, `99+` capped), reverting to the bare label at zero. New test asserts the name flips after open marks all seen; existing exact-name queries switched to prefix matchers.
- **`INBOX_CSS` export**: nonce-based strict-CSP hosts cannot authorize the injected style tag; they can now serve the exported stylesheet from their own pipeline (the blocked injection is harmless).

Docs (sdk-reference): client-only/SSR note, popover clipping/portal-tab-order/z-index paragraph, and a CSP section with the minimum directives.

Review findings deliberately deferred (filing separately): portal focus-on-open, menu-role arrow keys, narrow-viewport width, head-replacing-nav style loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)