### PR TITLE
test(bench): sse concurrency harness

### DIFF
--- a/bench/sse/README.md
+++ b/bench/sse/README.md
@@ -52,15 +52,15 @@ sends no `X-Chimely-Subscriber-Hash`. Use a dev-bootstrapped environment
 
 Server-side prerequisites for a clean measurement:
 
-- `CHIMELY_SUBSCRIBER_RATE_PER_SEC=0` on the server, or the subscriber-plane
-  token bucket (default 10/s, burst 50) rejects the ramp itself.
-- The probe rate (default 0.5/s) sits far below the management-plane key
-  limit (default 50/s), so no server tuning is needed there.
+- No rate-limit tuning is needed. The stream endpoint is guarded by the
+  per-subscriber connection cap only, and the ramp respects it by
+  construction. The probe rate (default 0.5/s) sits far below the
+  management-plane key limit (default 50/s).
 
 ## What the numbers mean
 
 - `established` vs `N`: connections that got a 200 and stayed up. Failures
-  are broken down by cause (`http_429` = per-subscriber cap or rate limit,
+  are broken down by cause (`http_429` = the per-subscriber connection cap,
   `connect_*` = socket-level).
 - `hint_latency_ms`: end-to-end hint plumbing under load: management POST ->
   transactional outbox -> worker poll (`CHIMELY_WORKER_POLL_MS`, default

--- a/bench/sse/README.md
+++ b/bench/sse/README.md
@@ -1,0 +1,119 @@
+# SSE concurrency load harness
+
+Measures how many concurrent `GET /v1/inbox/stream` connections a Chimely
+server holds, and the hint fan-in latency under that load: the time from a
+`POST /v1/notifications` being accepted to the `hint` SSE event arriving on
+the target subscriber's open streams.
+
+Plain Node (no npm deps, raw `node:http`, one dedicated socket per stream).
+
+## Run
+
+Against any Chimely instance:
+
+```bash
+ulimit -n 16384   # see "File descriptors" below
+
+SERVER_PID=$(pgrep -f 'chimely serve' | head -1) \
+CHIMELY_URL=http://127.0.0.1:8299 \
+CHIMELY_ENV=demo \
+CHIMELY_API_KEY=dev-secret-key \
+N=2000 M=250 T=90 \
+node bench/sse/sse-load.mjs
+```
+
+| Var | Default | Meaning |
+| --- | --- | --- |
+| `CHIMELY_URL` | `http://127.0.0.1:8299` | Base URL of the server under test |
+| `CHIMELY_ENV` | `demo` | Environment slug (subscriber auth via `X-Chimely-Environment` header) |
+| `CHIMELY_API_KEY` | `dev-secret-key` | Management bearer key for the probe POSTs |
+| `N` | `500` | Total concurrent SSE connections |
+| `M` | `ceil(N/CAP)` | Distinct subscribers; connections round-robin across them |
+| `CAP` | `8` | Per-subscriber connection cap; must match the server's `CHIMELY_SSE_MAX_CONNS_PER_SUBSCRIBER`. The harness refuses to start if `N/M > CAP` |
+| `T` | `90` | Seconds to hold all connections after the ramp completes |
+| `PROBE_INTERVAL_MS` | `2000` | Probe cadence. Keep it above the server's `CHIMELY_HINT_DEBOUNCE_MS` (default 1000) or the debounce coalesces probes and the latency numbers lie |
+| `RAMP_CONCURRENCY` | `100` | Parallel connection-open attempts during the ramp |
+| `SERVER_PID` | unset | Local server pid; RSS is sampled via `ps` every 5 s. Unset skips RSS (e.g. remote target) |
+| `SUB_PREFIX` | `bench-sub` | Subscriber id prefix (`bench-sub-0` … `bench-sub-(M-1)`) |
+| `OUT_JSON` | unset | Also write the JSON summary to this path |
+
+Progress goes to stderr; the final JSON summary goes to stdout.
+
+The probe subscriber is always `<SUB_PREFIX>-0`, which holds `ceil(N/M)`
+connections, so each accepted probe should yield that many latency samples.
+Latency is measured from probe-POST response received to `hint` event
+observed, clamped at 0 (the outbox worker can publish between the server's
+transaction commit and the POST response flushing back).
+
+If the target environment requires subscriber hashes
+(`require_subscriber_hash = true`), this harness cannot authenticate: it
+sends no `X-Chimely-Subscriber-Hash`. Use a dev-bootstrapped environment
+(`CHIMELY_DEV_ENVIRONMENT`) or one with hashes disabled.
+
+Server-side prerequisites for a clean measurement:
+
+- `CHIMELY_SUBSCRIBER_RATE_PER_SEC=0` on the server, or the subscriber-plane
+  token bucket (default 10/s, burst 50) rejects the ramp itself.
+- The probe rate (default 0.5/s) sits far below the management-plane key
+  limit (default 50/s), so no server tuning is needed there.
+
+## What the numbers mean
+
+- `established` vs `N`: connections that got a 200 and stayed up. Failures
+  are broken down by cause (`http_429` = per-subscriber cap or rate limit,
+  `connect_*` = socket-level).
+- `hint_latency_ms`: end-to-end hint plumbing under load: management POST ->
+  transactional outbox -> worker poll (`CHIMELY_WORKER_POLL_MS`, default
+  250 ms) -> pub/sub (Redis, or Postgres LISTEN/NOTIFY in Redis-less mode)
+  -> broadcast fan-in -> SSE write. The worker poll interval is an expected
+  floor component: ~half the poll interval on average before load is even a
+  factor.
+- `server_rss_mb`: resident set of the server process, sampled every 5 s.
+- A run only counts as "held" if `open_at_end` equals `established` and
+  `dropped_mid_stream` is 0 for the whole window.
+
+## The laptop ceiling
+
+Numbers from a laptop bound what THIS laptop can demonstrate, not what the
+server can do. The honest ceilings you hit locally, roughly in the order
+they appear:
+
+1. **File descriptors.** Every SSE connection is one fd on the client AND
+   one on the server. macOS defaults are low (`ulimit -n` is often 256 or
+   10240); the hard per-process cap is `sysctl kern.maxfilesperproc`
+   (commonly 61440) and system-wide `kern.maxfiles`. Raise the soft limit in
+   BOTH shells (server and harness) before running:
+   `ulimit -n 16384` (or higher). Linux: also check
+   `/proc/sys/fs/file-max` and `nofile` in limits.conf/systemd.
+2. **Ephemeral ports.** Client and server share one loopback; each
+   connection consumes a local port from `net.inet.ip.portrange`
+   (~16k usable on macOS by default). Above ~15k connections from one
+   client IP to one server port, you exhaust source ports.
+3. **The harness itself.** One Node process parsing N streams competes with
+   the server for the same cores. Keep-alive pings (`CHIMELY_SSE_PING_SECS`,
+   default 30) mean N/30 frames/s of background parse work.
+4. **Memory.** Per-connection cost on the server is a broadcast receiver +
+   stream state. Watch `server_rss_mb` growth across ramp steps; it should
+   be roughly linear in open connections.
+
+Client and server co-located also means latency numbers exclude real network
+RTT, and a single loopback interface serializes what a real NIC + kernel
+would spread out.
+
+## What to expect in a real environment
+
+- A production deployment terminates TLS in front of the binary; TLS adds
+  per-connection memory (~tens of KB in the terminator) and handshake cost
+  on ramp, none of which this harness exercises.
+- Hint latency in production includes real network RTT and, with Redis
+  configured, Redis pub/sub instead of the LISTEN/NOTIFY fallback this
+  harness may have measured (see the run report). The dominant term stays
+  the worker poll interval unless the outbox backs up.
+- Multiple replicas divide connections; the per-subscriber cap is per
+  replica, so a load balancer changes effective per-subscriber limits.
+- Real clients are EventSource: they reconnect with `Last-Event-ID`,
+  triggering the resume-hint query per reconnect. This harness holds
+  steady-state connections and does not model reconnect storms (the server
+  jitters `retry:` on deploys precisely to spread those).
+- Fd limits on a server distro are a systemd `LimitNOFILE` setting, not a
+  shell ulimit.

--- a/bench/sse/sse-load.mjs
+++ b/bench/sse/sse-load.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 // SSE concurrency load harness for Chimely.
 //
 // Opens N concurrent SSE connections to GET /v1/inbox/stream spread across M
@@ -34,21 +35,21 @@
 // Exit code 0 even when connections fail: failures are data, not errors. The
 // summary is the product.
 
-import http from "node:http";
-import https from "node:https";
-import { execFileSync } from "node:child_process";
+import { execFileSync } from 'node:child_process';
+import http from 'node:http';
+import https from 'node:https';
 
 const cfg = {
-  url: new URL(process.env.CHIMELY_URL || "http://127.0.0.1:8299"),
-  env: process.env.CHIMELY_ENV || "demo",
-  apiKey: process.env.CHIMELY_API_KEY || "dev-secret-key",
-  n: parseInt(process.env.N || "500", 10),
-  cap: parseInt(process.env.CAP || "8", 10),
-  t: parseInt(process.env.T || "90", 10),
-  probeIntervalMs: parseInt(process.env.PROBE_INTERVAL_MS || "2000", 10),
-  rampConcurrency: parseInt(process.env.RAMP_CONCURRENCY || "100", 10),
+  url: new URL(process.env.CHIMELY_URL || 'http://127.0.0.1:8299'),
+  env: process.env.CHIMELY_ENV || 'demo',
+  apiKey: process.env.CHIMELY_API_KEY || 'dev-secret-key',
+  n: parseInt(process.env.N || '500', 10),
+  cap: parseInt(process.env.CAP || '8', 10),
+  t: parseInt(process.env.T || '90', 10),
+  probeIntervalMs: parseInt(process.env.PROBE_INTERVAL_MS || '2000', 10),
+  rampConcurrency: parseInt(process.env.RAMP_CONCURRENCY || '100', 10),
   serverPid: process.env.SERVER_PID ? parseInt(process.env.SERVER_PID, 10) : null,
-  subPrefix: process.env.SUB_PREFIX || "bench-sub",
+  subPrefix: process.env.SUB_PREFIX || 'bench-sub',
   outJson: process.env.OUT_JSON || null,
 };
 cfg.m = parseInt(process.env.M || String(Math.ceil(cfg.n / cfg.cap)), 10);
@@ -60,7 +61,7 @@ if (cfg.n / cfg.m > cfg.cap) {
   process.exit(2);
 }
 
-const transport = cfg.url.protocol === "https:" ? https : http;
+const transport = cfg.url.protocol === 'https:' ? https : http;
 
 // ---------------------------------------------------------------------------
 // State
@@ -109,22 +110,22 @@ function openSse(connIdx) {
     const req = transport.request(
       {
         host: cfg.url.hostname,
-        port: cfg.url.port || (cfg.url.protocol === "https:" ? 443 : 80),
-        path: "/v1/inbox/stream",
-        method: "GET",
+        port: cfg.url.port || (cfg.url.protocol === 'https:' ? 443 : 80),
+        path: '/v1/inbox/stream',
+        method: 'GET',
         agent: false, // dedicated socket per stream
         headers: {
-          accept: "text/event-stream",
-          "x-chimely-environment": cfg.env,
-          "x-chimely-subscriber": sub,
+          accept: 'text/event-stream',
+          'x-chimely-environment': cfg.env,
+          'x-chimely-subscriber': sub,
         },
       },
       (res) => {
         if (res.statusCode !== 200) {
           fail(`http_${res.statusCode}`);
           res.resume();
-          res.on("end", () => resolve(false));
-          res.on("error", () => resolve(false));
+          res.on('end', () => resolve(false));
+          res.on('error', () => resolve(false));
           return;
         }
         state.established += 1;
@@ -133,18 +134,18 @@ function openSse(connIdx) {
         state.connectLatenciesMs.push(performance.now() - started);
         resolve(true);
 
-        let buf = "";
-        res.setEncoding("utf8");
-        res.on("data", (chunk) => {
+        let buf = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => {
           buf += chunk;
           let idx;
-          while ((idx = buf.indexOf("\n\n")) !== -1) {
+          while ((idx = buf.indexOf('\n\n')) !== -1) {
             const frame = buf.slice(0, idx);
             buf = buf.slice(idx + 2);
             handleFrame(frame, connIdx, isProbeConn);
           }
           // Comment keep-alives (`: ping`) parse as frames too; harmless.
-          if (buf.length > 65536) buf = ""; // never happens per contract; guard anyway
+          if (buf.length > 65536) buf = ''; // never happens per contract; guard anyway
         });
         const gone = (cause) => () => {
           state.open -= 1;
@@ -153,11 +154,11 @@ function openSse(connIdx) {
             fail(cause);
           }
         };
-        res.on("end", gone("server_closed_stream"));
-        res.on("error", gone("stream_error"));
+        res.on('end', gone('server_closed_stream'));
+        res.on('error', gone('stream_error'));
       },
     );
-    req.on("error", (err) => {
+    req.on('error', (err) => {
       fail(`connect_${err.code || err.message}`);
       resolve(false);
     });
@@ -166,19 +167,17 @@ function openSse(connIdx) {
 }
 
 function handleFrame(frame, connIdx, isProbeConn) {
-  let event = "message";
-  for (const line of frame.split("\n")) {
-    if (line.startsWith("event:")) event = line.slice(6).trim();
+  let event = 'message';
+  for (const line of frame.split('\n')) {
+    if (line.startsWith('event:')) event = line.slice(6).trim();
   }
-  if (event === "hint") {
+  if (event === 'hint') {
     state.eventsSeen += 1;
     if (isProbeConn && currentProbe && !currentProbe.seenOn.has(connIdx)) {
       currentProbe.seenOn.add(connIdx);
       // Clamp at 0: the outbox worker can publish between the server's txn
       // commit and the POST response flushing back to us.
-      state.hintLatenciesMs.push(
-        Math.max(0, performance.now() - currentProbe.acceptedAt),
-      );
+      state.hintLatenciesMs.push(Math.max(0, performance.now() - currentProbe.acceptedAt));
     }
   }
 }
@@ -191,25 +190,25 @@ function postNotification() {
   return new Promise((resolve) => {
     const body = JSON.stringify({
       subscriber_id: PROBE_SUB,
-      category: "bench.probe",
+      category: 'bench.probe',
       payload: { sent_at_ms: Date.now() },
     });
     const req = transport.request(
       {
         host: cfg.url.hostname,
-        port: cfg.url.port || (cfg.url.protocol === "https:" ? 443 : 80),
-        path: "/v1/notifications",
-        method: "POST",
+        port: cfg.url.port || (cfg.url.protocol === 'https:' ? 443 : 80),
+        path: '/v1/notifications',
+        method: 'POST',
         agent: false,
         headers: {
           authorization: `Bearer ${cfg.apiKey}`,
-          "content-type": "application/json",
-          "content-length": Buffer.byteLength(body),
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(body),
         },
       },
       (res) => {
         res.resume();
-        res.on("end", () => {
+        res.on('end', () => {
           if (res.statusCode === 201 || res.statusCode === 200) {
             state.probesAccepted += 1;
             currentProbe = { acceptedAt: performance.now(), seenOn: new Set() };
@@ -221,9 +220,9 @@ function postNotification() {
         });
       },
     );
-    req.on("error", () => {
+    req.on('error', () => {
       state.probeErrors += 1;
-      fail("probe_connect_error");
+      fail('probe_connect_error');
       resolve();
     });
     req.end(body);
@@ -237,8 +236,8 @@ function postNotification() {
 function sampleRss() {
   if (!cfg.serverPid) return;
   try {
-    const out = execFileSync("ps", ["-o", "rss=", "-p", String(cfg.serverPid)], {
-      encoding: "utf8",
+    const out = execFileSync('ps', ['-o', 'rss=', '-p', String(cfg.serverPid)], {
+      encoding: 'utf8',
     });
     const kb = parseInt(out.trim(), 10);
     if (Number.isFinite(kb)) state.rssSamplesKb.push({ t: Date.now(), kb });
@@ -288,9 +287,7 @@ async function main() {
       await openSse(idx);
     }
   }
-  await Promise.all(
-    Array.from({ length: Math.min(cfg.rampConcurrency, cfg.n) }, opener),
-  );
+  await Promise.all(Array.from({ length: Math.min(cfg.rampConcurrency, cfg.n) }, opener));
   const rampSecs = (performance.now() - rampStart) / 1000;
   console.error(
     `ramp done in ${rampSecs.toFixed(1)}s: established=${state.established}/${cfg.n} open=${state.open}`,
@@ -307,7 +304,7 @@ async function main() {
   const statusTimer = setInterval(() => {
     const rss = state.rssSamplesKb.at(-1);
     console.error(
-      `t+${Math.round((Date.now() - holdStart) / 1000)}s open=${state.open} hints=${state.hintLatenciesMs.length} probes=${state.probesAccepted}/${state.probesSent} rss=${rss ? (rss.kb / 1024).toFixed(1) + "MB" : "n/a"}`,
+      `t+${Math.round((Date.now() - holdStart) / 1000)}s open=${state.open} hints=${state.hintLatenciesMs.length} probes=${state.probesAccepted}/${state.probesSent} rss=${rss ? `${(rss.kb / 1024).toFixed(1)}MB` : 'n/a'}`,
     );
   }, 10000);
 
@@ -358,8 +355,8 @@ async function main() {
 
   console.log(JSON.stringify(summary, null, 2));
   if (cfg.outJson) {
-    const { writeFileSync } = await import("node:fs");
-    writeFileSync(cfg.outJson, JSON.stringify(summary, null, 2) + "\n");
+    const { writeFileSync } = await import('node:fs');
+    writeFileSync(cfg.outJson, `${JSON.stringify(summary, null, 2)}\n`);
   }
   // Sockets are still open; exit hard rather than waiting for them to drain.
   process.exit(0);

--- a/bench/sse/sse-load.mjs
+++ b/bench/sse/sse-load.mjs
@@ -1,0 +1,371 @@
+#!/usr/bin/env node
+// SSE concurrency load harness for Chimely.
+//
+// Opens N concurrent SSE connections to GET /v1/inbox/stream spread across M
+// distinct subscribers (N/M must stay at or below the per-subscriber cap,
+// CHIMELY_SSE_MAX_CONNS_PER_SUBSCRIBER, default 8). Holds them for T seconds.
+// While holding, it periodically POSTs a notification to one probe subscriber
+// via the management API and measures hint fan-in latency: the time from the
+// POST response ("accepted") to the `hint` SSE event observed on each of that
+// subscriber's open connections.
+//
+// Plain Node, no dependencies. Raw `node:http` with `agent: false` so every
+// SSE stream owns a dedicated socket (one fd per connection, no pooling).
+//
+// Usage:
+//   node sse-load.mjs
+// Env vars (all optional):
+//   CHIMELY_URL        target base URL          (default http://127.0.0.1:8299)
+//   CHIMELY_ENV        environment slug         (default demo)
+//   CHIMELY_API_KEY    management bearer key    (default dev-secret-key)
+//   N                  total SSE connections    (default 500)
+//   M                  distinct subscribers     (default ceil(N / CAP))
+//   CAP                per-subscriber cap       (default 8, must match server)
+//   T                  hold seconds after ramp  (default 90)
+//   PROBE_INTERVAL_MS  probe cadence            (default 2000; keep it above
+//                      CHIMELY_HINT_DEBOUNCE_MS, default 1000, or the debounce
+//                      coalesces probes and latency numbers lie)
+//   RAMP_CONCURRENCY   parallel connection opens (default 100)
+//   SERVER_PID         pid to sample RSS from via `ps` (default: ask the
+//                      target's /metrics + lsof is NOT attempted; unset = skip)
+//   SUB_PREFIX         subscriber id prefix     (default bench-sub)
+//   OUT_JSON           path to write the JSON summary (default: stdout only)
+//
+// Exit code 0 even when connections fail: failures are data, not errors. The
+// summary is the product.
+
+import http from "node:http";
+import https from "node:https";
+import { execFileSync } from "node:child_process";
+
+const cfg = {
+  url: new URL(process.env.CHIMELY_URL || "http://127.0.0.1:8299"),
+  env: process.env.CHIMELY_ENV || "demo",
+  apiKey: process.env.CHIMELY_API_KEY || "dev-secret-key",
+  n: parseInt(process.env.N || "500", 10),
+  cap: parseInt(process.env.CAP || "8", 10),
+  t: parseInt(process.env.T || "90", 10),
+  probeIntervalMs: parseInt(process.env.PROBE_INTERVAL_MS || "2000", 10),
+  rampConcurrency: parseInt(process.env.RAMP_CONCURRENCY || "100", 10),
+  serverPid: process.env.SERVER_PID ? parseInt(process.env.SERVER_PID, 10) : null,
+  subPrefix: process.env.SUB_PREFIX || "bench-sub",
+  outJson: process.env.OUT_JSON || null,
+};
+cfg.m = parseInt(process.env.M || String(Math.ceil(cfg.n / cfg.cap)), 10);
+
+if (cfg.n / cfg.m > cfg.cap) {
+  console.error(
+    `N/M = ${(cfg.n / cfg.m).toFixed(2)} exceeds per-subscriber cap ${cfg.cap}; raise M`,
+  );
+  process.exit(2);
+}
+
+const transport = cfg.url.protocol === "https:" ? https : http;
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+const state = {
+  established: 0,
+  peakEstablished: 0,
+  open: 0,
+  failures: new Map(), // cause -> count
+  hintLatenciesMs: [], // one sample per (probe, connection) observation
+  probesSent: 0,
+  probesAccepted: 0,
+  probeErrors: 0,
+  rssSamplesKb: [], // {t, kb}
+  connectLatenciesMs: [], // time to 200 + headers per connection
+  eventsSeen: 0,
+  droppedMidStream: 0,
+};
+
+function fail(cause) {
+  state.failures.set(cause, (state.failures.get(cause) || 0) + 1);
+}
+
+// Outstanding probe the next hint on a probe-subscriber connection attributes
+// to. Probes are spaced above the server's debounce window so exactly one
+// hint per connection per probe is expected.
+let currentProbe = null; // {acceptedAt, seenOn: Set<connId>}
+
+// ---------------------------------------------------------------------------
+// SSE connection
+// ---------------------------------------------------------------------------
+
+function subscriberFor(connIdx) {
+  // Round-robin so each subscriber holds at most ceil(N/M) <= CAP streams.
+  return `${cfg.subPrefix}-${connIdx % cfg.m}`;
+}
+
+const PROBE_SUB = `${cfg.subPrefix}-0`;
+
+function openSse(connIdx) {
+  return new Promise((resolve) => {
+    const sub = subscriberFor(connIdx);
+    const isProbeConn = sub === PROBE_SUB;
+    const started = performance.now();
+    const req = transport.request(
+      {
+        host: cfg.url.hostname,
+        port: cfg.url.port || (cfg.url.protocol === "https:" ? 443 : 80),
+        path: "/v1/inbox/stream",
+        method: "GET",
+        agent: false, // dedicated socket per stream
+        headers: {
+          accept: "text/event-stream",
+          "x-chimely-environment": cfg.env,
+          "x-chimely-subscriber": sub,
+        },
+      },
+      (res) => {
+        if (res.statusCode !== 200) {
+          fail(`http_${res.statusCode}`);
+          res.resume();
+          res.on("end", () => resolve(false));
+          res.on("error", () => resolve(false));
+          return;
+        }
+        state.established += 1;
+        state.open += 1;
+        state.peakEstablished = Math.max(state.peakEstablished, state.open);
+        state.connectLatenciesMs.push(performance.now() - started);
+        resolve(true);
+
+        let buf = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          buf += chunk;
+          let idx;
+          while ((idx = buf.indexOf("\n\n")) !== -1) {
+            const frame = buf.slice(0, idx);
+            buf = buf.slice(idx + 2);
+            handleFrame(frame, connIdx, isProbeConn);
+          }
+          // Comment keep-alives (`: ping`) parse as frames too; harmless.
+          if (buf.length > 65536) buf = ""; // never happens per contract; guard anyway
+        });
+        const gone = (cause) => () => {
+          state.open -= 1;
+          if (!shuttingDown) {
+            state.droppedMidStream += 1;
+            fail(cause);
+          }
+        };
+        res.on("end", gone("server_closed_stream"));
+        res.on("error", gone("stream_error"));
+      },
+    );
+    req.on("error", (err) => {
+      fail(`connect_${err.code || err.message}`);
+      resolve(false);
+    });
+    req.end();
+  });
+}
+
+function handleFrame(frame, connIdx, isProbeConn) {
+  let event = "message";
+  for (const line of frame.split("\n")) {
+    if (line.startsWith("event:")) event = line.slice(6).trim();
+  }
+  if (event === "hint") {
+    state.eventsSeen += 1;
+    if (isProbeConn && currentProbe && !currentProbe.seenOn.has(connIdx)) {
+      currentProbe.seenOn.add(connIdx);
+      // Clamp at 0: the outbox worker can publish between the server's txn
+      // commit and the POST response flushing back to us.
+      state.hintLatenciesMs.push(
+        Math.max(0, performance.now() - currentProbe.acceptedAt),
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Probe: POST /v1/notifications to the probe subscriber
+// ---------------------------------------------------------------------------
+
+function postNotification() {
+  return new Promise((resolve) => {
+    const body = JSON.stringify({
+      subscriber_id: PROBE_SUB,
+      category: "bench.probe",
+      payload: { sent_at_ms: Date.now() },
+    });
+    const req = transport.request(
+      {
+        host: cfg.url.hostname,
+        port: cfg.url.port || (cfg.url.protocol === "https:" ? 443 : 80),
+        path: "/v1/notifications",
+        method: "POST",
+        agent: false,
+        headers: {
+          authorization: `Bearer ${cfg.apiKey}`,
+          "content-type": "application/json",
+          "content-length": Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        res.resume();
+        res.on("end", () => {
+          if (res.statusCode === 201 || res.statusCode === 200) {
+            state.probesAccepted += 1;
+            currentProbe = { acceptedAt: performance.now(), seenOn: new Set() };
+          } else {
+            state.probeErrors += 1;
+            fail(`probe_http_${res.statusCode}`);
+          }
+          resolve();
+        });
+      },
+    );
+    req.on("error", () => {
+      state.probeErrors += 1;
+      fail("probe_connect_error");
+      resolve();
+    });
+    req.end(body);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// RSS sampling
+// ---------------------------------------------------------------------------
+
+function sampleRss() {
+  if (!cfg.serverPid) return;
+  try {
+    const out = execFileSync("ps", ["-o", "rss=", "-p", String(cfg.serverPid)], {
+      encoding: "utf8",
+    });
+    const kb = parseInt(out.trim(), 10);
+    if (Number.isFinite(kb)) state.rssSamplesKb.push({ t: Date.now(), kb });
+  } catch {
+    // server gone; the hold loop will notice via dropped streams
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Percentiles
+// ---------------------------------------------------------------------------
+
+function pct(sorted, p) {
+  if (sorted.length === 0) return null;
+  const i = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, i)];
+}
+
+function summarize(arr) {
+  const s = [...arr].sort((a, b) => a - b);
+  return {
+    count: s.length,
+    p50: pct(s, 50),
+    p95: pct(s, 95),
+    p99: pct(s, 99),
+    max: s.length ? s[s.length - 1] : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+let shuttingDown = false;
+
+async function main() {
+  console.error(
+    `target=${cfg.url.origin} env=${cfg.env} N=${cfg.n} M=${cfg.m} cap=${cfg.cap} hold=${cfg.t}s probe_every=${cfg.probeIntervalMs}ms`,
+  );
+
+  // Ramp: open N connections with bounded parallelism.
+  const rampStart = performance.now();
+  let next = 0;
+  async function opener() {
+    while (next < cfg.n) {
+      const idx = next++;
+      await openSse(idx);
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(cfg.rampConcurrency, cfg.n) }, opener),
+  );
+  const rampSecs = (performance.now() - rampStart) / 1000;
+  console.error(
+    `ramp done in ${rampSecs.toFixed(1)}s: established=${state.established}/${cfg.n} open=${state.open}`,
+  );
+
+  // Hold + probe.
+  sampleRss();
+  const holdStart = Date.now();
+  const probeTimer = setInterval(() => {
+    state.probesSent += 1;
+    postNotification();
+  }, cfg.probeIntervalMs);
+  const rssTimer = setInterval(sampleRss, 5000);
+  const statusTimer = setInterval(() => {
+    const rss = state.rssSamplesKb.at(-1);
+    console.error(
+      `t+${Math.round((Date.now() - holdStart) / 1000)}s open=${state.open} hints=${state.hintLatenciesMs.length} probes=${state.probesAccepted}/${state.probesSent} rss=${rss ? (rss.kb / 1024).toFixed(1) + "MB" : "n/a"}`,
+    );
+  }, 10000);
+
+  await new Promise((r) => setTimeout(r, cfg.t * 1000));
+
+  clearInterval(probeTimer);
+  clearInterval(rssTimer);
+  clearInterval(statusTimer);
+  // Let the last probe's hints land.
+  await new Promise((r) => setTimeout(r, 1500));
+  sampleRss();
+
+  shuttingDown = true;
+  const openAtEnd = state.open;
+
+  const rssKb = state.rssSamplesKb.map((s) => s.kb);
+  const summary = {
+    config: {
+      target: cfg.url.origin,
+      environment: cfg.env,
+      n: cfg.n,
+      m: cfg.m,
+      cap: cfg.cap,
+      hold_secs: cfg.t,
+      probe_interval_ms: cfg.probeIntervalMs,
+    },
+    ramp_secs: Number(rampSecs.toFixed(1)),
+    established: state.established,
+    open_at_end: openAtEnd,
+    dropped_mid_stream: state.droppedMidStream,
+    failures: Object.fromEntries(state.failures),
+    connect_ms: summarize(state.connectLatenciesMs),
+    probes: {
+      sent: state.probesSent,
+      accepted: state.probesAccepted,
+      errors: state.probeErrors,
+    },
+    hint_latency_ms: summarize(state.hintLatenciesMs),
+    hint_events_total: state.eventsSeen,
+    server_rss_mb: rssKb.length
+      ? {
+          start: Number((rssKb[0] / 1024).toFixed(1)),
+          max: Number((Math.max(...rssKb) / 1024).toFixed(1)),
+          end: Number((rssKb.at(-1) / 1024).toFixed(1)),
+        }
+      : null,
+  };
+
+  console.log(JSON.stringify(summary, null, 2));
+  if (cfg.outJson) {
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(cfg.outJson, JSON.stringify(summary, null, 2) + "\n");
+  }
+  // Sockets are still open; exit hard rather than waiting for them to drain.
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/bench/sse/sse-load.mjs
+++ b/bench/sse/sse-load.mjs
@@ -23,12 +23,11 @@
 //   M                  distinct subscribers     (default ceil(N / CAP))
 //   CAP                per-subscriber cap       (default 8, must match server)
 //   T                  hold seconds after ramp  (default 90)
-//   PROBE_INTERVAL_MS  probe cadence            (default 2000; keep it above
+//   PROBE_INTERVAL_MS  probe cadence            (default 2000, keep it above
 //                      CHIMELY_HINT_DEBOUNCE_MS, default 1000, or the debounce
 //                      coalesces probes and latency numbers lie)
 //   RAMP_CONCURRENCY   parallel connection opens (default 100)
-//   SERVER_PID         pid to sample RSS from via `ps` (default: ask the
-//                      target's /metrics + lsof is NOT attempted; unset = skip)
+//   SERVER_PID         pid to sample RSS from via `ps` (unset skips sampling)
 //   SUB_PREFIX         subscriber id prefix     (default bench-sub)
 //   OUT_JSON           path to write the JSON summary (default: stdout only)
 //
@@ -86,10 +85,20 @@ function fail(cause) {
   state.failures.set(cause, (state.failures.get(cause) || 0) + 1);
 }
 
-// Outstanding probe the next hint on a probe-subscriber connection attributes
-// to. Probes are spaced above the server's debounce window so exactly one
-// hint per connection per probe is expected.
-let currentProbe = null; // {acceptedAt, seenOn: Set<connId>}
+// In-flight probes in accepted order. Hint events carry no notification id,
+// so a hint on a probe-subscriber connection is attributed to the oldest
+// unexpired probe that connection has not been counted against. Probes are
+// spaced above the server's debounce window, so one hint per connection per
+// probe is expected. Entries expire after two probe intervals. Past that a
+// hint is ambiguous and is not counted.
+const inflightProbes = []; // {acceptedAt, seenOn: Set<connId>}
+
+function expireProbes(now) {
+  const cutoff = now - cfg.probeIntervalMs * 2;
+  while (inflightProbes.length > 0 && inflightProbes[0].acceptedAt < cutoff) {
+    inflightProbes.shift();
+  }
+}
 
 // ---------------------------------------------------------------------------
 // SSE connection
@@ -145,8 +154,8 @@ function openSse(connIdx) {
             handleFrame(frame, connIdx, isProbeConn);
             idx = buf.indexOf('\n\n');
           }
-          // Comment keep-alives (`: ping`) parse as frames too; harmless.
-          if (buf.length > 65536) buf = ''; // never happens per contract; guard anyway
+          // Comment keep-alives (`: ping`) parse as frames too. Harmless.
+          if (buf.length > 65536) buf = ''; // never happens per contract, guard anyway
         });
         const gone = (cause) => () => {
           state.open -= 1;
@@ -174,11 +183,16 @@ function handleFrame(frame, connIdx, isProbeConn) {
   }
   if (event === 'hint') {
     state.eventsSeen += 1;
-    if (isProbeConn && currentProbe && !currentProbe.seenOn.has(connIdx)) {
-      currentProbe.seenOn.add(connIdx);
-      // Clamp at 0: the outbox worker can publish between the server's txn
-      // commit and the POST response flushing back to us.
-      state.hintLatenciesMs.push(Math.max(0, performance.now() - currentProbe.acceptedAt));
+    if (isProbeConn) {
+      const now = performance.now();
+      expireProbes(now);
+      const probe = inflightProbes.find((p) => !p.seenOn.has(connIdx));
+      if (probe) {
+        probe.seenOn.add(connIdx);
+        // Clamp at 0: the outbox worker can publish between the server's txn
+        // commit and the POST response flushing back to us.
+        state.hintLatenciesMs.push(Math.max(0, now - probe.acceptedAt));
+      }
     }
   }
 }
@@ -217,7 +231,9 @@ function postNotification() {
         res.on('end', () => {
           if (res.statusCode === 201 || res.statusCode === 200) {
             state.probesAccepted += 1;
-            currentProbe = { acceptedAt: performance.now(), seenOn: new Set() };
+            const now = performance.now();
+            expireProbes(now);
+            inflightProbes.push({ acceptedAt: now, seenOn: new Set() });
           } else {
             state.probeErrors += 1;
             fail(`probe_http_${res.statusCode}`);
@@ -248,7 +264,7 @@ function sampleRss() {
     const kb = parseInt(out.trim(), 10);
     if (Number.isFinite(kb)) state.rssSamplesKb.push({ t: Date.now(), kb });
   } catch {
-    // server gone; the hold loop will notice via dropped streams
+    // Server gone. The hold loop notices via dropped streams.
   }
 }
 
@@ -339,6 +355,7 @@ async function main() {
     },
     ramp_secs: Number(rampSecs.toFixed(1)),
     established: state.established,
+    peak_established: state.peakEstablished,
     open_at_end: openAtEnd,
     dropped_mid_stream: state.droppedMidStream,
     failures: Object.fromEntries(state.failures),
@@ -364,7 +381,7 @@ async function main() {
     const { writeFileSync } = await import('node:fs');
     writeFileSync(cfg.outJson, `${JSON.stringify(summary, null, 2)}\n`);
   }
-  // Sockets are still open; exit hard rather than waiting for them to drain.
+  // Sockets are still open. Exit hard rather than waiting for them to drain.
   process.exit(0);
 }
 

--- a/bench/sse/sse-load.mjs
+++ b/bench/sse/sse-load.mjs
@@ -178,11 +178,16 @@ function openSse(connIdx) {
 
 function handleFrame(frame, connIdx, isProbeConn) {
   let event = 'message';
+  let data = '';
   for (const line of frame.split('\n')) {
     if (line.startsWith('event:')) event = line.slice(6).trim();
+    if (line.startsWith('data:')) data = line.slice(5).trim();
   }
   if (event === 'hint') {
     state.eventsSeen += 1;
+    // Lagged hints signal broadcast fan-in overflow, not a probe delivery.
+    // Binding one to an in-flight probe would inject a bogus sample.
+    if (data.includes('"lagged"')) return;
     if (isProbeConn) {
       const now = performance.now();
       expireProbes(now);

--- a/bench/sse/sse-load.mjs
+++ b/bench/sse/sse-load.mjs
@@ -209,6 +209,11 @@ function postNotification() {
       },
       (res) => {
         res.resume();
+        res.on('error', () => {
+          state.probeErrors += 1;
+          fail('probe_stream_error');
+          resolve();
+        });
         res.on('end', () => {
           if (res.statusCode === 201 || res.statusCode === 200) {
             state.probesAccepted += 1;

--- a/bench/sse/sse-load.mjs
+++ b/bench/sse/sse-load.mjs
@@ -138,11 +138,12 @@ function openSse(connIdx) {
         res.setEncoding('utf8');
         res.on('data', (chunk) => {
           buf += chunk;
-          let idx;
-          while ((idx = buf.indexOf('\n\n')) !== -1) {
+          let idx = buf.indexOf('\n\n');
+          while (idx !== -1) {
             const frame = buf.slice(0, idx);
             buf = buf.slice(idx + 2);
             handleFrame(frame, connIdx, isProbeConn);
+            idx = buf.indexOf('\n\n');
           }
           // Comment keep-alives (`: ping`) parse as frames too; harmless.
           if (buf.length > 65536) buf = ''; // never happens per contract; guard anyway


### PR DESCRIPTION
Rerunnable SSE concurrency load harness under `bench/sse/` (plain Node, zero deps; target/N/M/T via env vars) plus a README covering ulimit/fd notes, what the laptop ceiling means, and production expectations.

Run once on this machine (release binary, Redis-less, Dockerized PG, per-subscriber cap 8, rate limit off, 75 s holds):

| Target | Established | Held | RSS steady | Hint p50 | Hint p95 |
|---|---|---|---|---|---|
| 500 | 500 | clean | ~15 MB | 161 ms | 385 ms |
| 2000 | 2000 | clean | ~20 MB | 191 ms | 386 ms |
| 5000 | 5000 | clean | ~35 MB | 121 ms | 252 ms |
| 8000 | 8000 | **clean, last honest step** | ~44 MB | 138 ms | 250 ms |
| 12000 | 12000 | held, ramp poisoned by host swap | n/a | 162 ms | 267 ms |

The ceiling was host memory pressure (37 GB swap in use; macOS killed the Docker VM once mid-suite), not the server: hint latency stays flat 500 -> 12k, RSS grows ~4 KB/connection, zero mid-stream drops, zero 429s, fd and port limits never reached. Notably, when the database VM died under a 5k-connection hold, the server and all 5000 streams survived and recovered. 10k+ was NOT verified stable on this hardware; the harness is written to rerun in a real environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)