### PR TITLE
docs: bump version references to 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ docker run -d --name chimely --network chimely -p 8080:8080 \
   -e DATABASE_URL=postgres://postgres:chimely@chimely-pg:5432/postgres \
   -e CHIMELY_DEV_ENVIRONMENT=demo \
   -e CHIMELY_DEV_API_KEY=dev-secret-key \
-  ghcr.io/dodopayments/chimely:0.2.0
+  ghcr.io/dodopayments/chimely:0.2.1
 ```
 
 The restart policy covers the first seconds while Postgres is still

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     restart: unless-stopped
 
   chimely:
-    image: ghcr.io/dodopayments/chimely:${CHIMELY_VERSION:-0.2.0}
+    image: ghcr.io/dodopayments/chimely:${CHIMELY_VERSION:-0.2.1}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/app/(home)/_components/hero.tsx
+++ b/docs/app/(home)/_components/hero.tsx
@@ -12,7 +12,7 @@ function Kicker() {
   return (
     <span className="inline-flex w-fit items-center gap-2.5 rounded-full border border-fd-border bg-fd-muted/50 px-3.5 py-1.5 font-mono text-[12.5px] font-medium tracking-wide text-fd-muted-foreground dark:border-white/[0.14] dark:bg-white/[0.04] dark:text-white/70">
       <span className="size-[7px] rounded-full bg-[#00D87D] shadow-[0_0_0_3px_rgba(0,216,125,0.18)] motion-safe:animate-pulse" />
-      Open source · Self-hostable · v0.2.0
+      Open source · Self-hostable · v0.2.1
     </span>
   );
 }

--- a/docs/app/(home)/_components/site-footer.tsx
+++ b/docs/app/(home)/_components/site-footer.tsx
@@ -70,7 +70,7 @@ export function SiteFooter() {
       {/* Pre-1.0 disclaimer, kept visually quiet */}
       <div className="mx-auto mt-7 max-w-[1200px] border-t border-fd-border pt-5">
         <p className="max-w-[80ch] font-mono text-[12.5px] leading-relaxed text-fd-muted-foreground/70">
-          Chimely is at v0.2.0. The HTTP API and SDK surface may still change on minor releases
+          Chimely is at v0.2.1. The HTTP API and SDK surface may still change on minor releases
           until 1.0. Pin your versions.
         </p>
       </div>

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -16,7 +16,7 @@ drop-in `<Inbox />` renders them.
 A live bell, unread counts, read state, and preferences, with nothing to build.
 
 <Callout type="warn" title="Pre-1.0">
-Chimely is at **0.2.0**. The HTTP API and the SDK surface may change on minor
+Chimely is at **0.2.1**. The HTTP API and the SDK surface may change on minor
 version bumps until 1.0.0. Pin your versions.
 </Callout>
 

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -29,7 +29,7 @@ docker run -d --name chimely --network chimely -p 8080:8080 \
   -e DATABASE_URL=postgres://postgres:chimely@chimely-pg:5432/postgres \
   -e CHIMELY_DEV_ENVIRONMENT=demo \
   -e CHIMELY_DEV_API_KEY=dev-secret-key \
-  ghcr.io/dodopayments/chimely:0.2.0
+  ghcr.io/dodopayments/chimely:0.2.1
 ```
 
 Migrations run on boot. The restart policy covers the first seconds while

--- a/docs/content/docs/sdk-reference.mdx
+++ b/docs/content/docs/sdk-reference.mdx
@@ -17,7 +17,7 @@ Wire types in `@chimely/client` are generated from the OpenAPI spec with
 `openapi-typescript` (`packages/client/src/generated/`) and never hand-edited.
 
 <Callout type="info" title="Pre-1.0">
-Both packages are at `0.2.0` on npm. The SDK surface may change on minor
+Both packages are at `0.2.1` on npm. The SDK surface may change on minor
 version bumps until 1.0.0. Pin your versions.
 </Callout>
 

--- a/server/README.md
+++ b/server/README.md
@@ -20,7 +20,7 @@ docker run -d --name chimely-pg --network chimely \
 docker run -d --name chimely --network chimely -p 8080:8080 \
   --restart unless-stopped \
   -e DATABASE_URL=postgres://postgres:chimely@chimely-pg:5432/postgres \
-  ghcr.io/dodopayments/chimely:0.2.0
+  ghcr.io/dodopayments/chimely:0.2.1
 ```
 
 The restart policy covers the first seconds while Postgres is still


### PR DESCRIPTION
Post-release reference bump: quickstart and README image pins, deploy compose default, docs and homepage version strings, all 0.2.0 -> 0.2.1. Same shape as #51 for 0.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)