### PR TITLE
build(release): attach npm provenance on publish

### DIFF
--- a/.changeset/attach-npm-provenance.md
+++ b/.changeset/attach-npm-provenance.md
@@ -1,0 +1,6 @@
+---
+"@chimely/client": patch
+"@chimely/react": patch
+---
+
+Attach npm provenance via `publishConfig.provenance`. The `NPM_CONFIG_PROVENANCE` env did not survive the changesets -> `pnpm publish` chain, so 0.2.1 shipped without `dist.attestations`. Setting it per package is tool-agnostic; the release workflow env stays as belt and braces.

--- a/.changeset/attach-npm-provenance.md
+++ b/.changeset/attach-npm-provenance.md
@@ -1,6 +1,0 @@
----
-"@chimely/client": patch
-"@chimely/react": patch
----
-
-Attach npm provenance via `publishConfig.provenance`. The `NPM_CONFIG_PROVENANCE` env did not survive the changesets -> `pnpm publish` chain, so 0.2.1 shipped without `dist.attestations`. Setting it per package is tool-agnostic; the release workflow env stays as belt and braces.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -42,7 +42,8 @@
     "vitest": "^4.1.8"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -57,7 +57,8 @@
     "vitest": "^4.1.8"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #65.

`NPM_CONFIG_PROVENANCE: true` ran on the 0.2.1 publish with `id-token: write` on a public repo, but the tarballs carried no `dist.attestations` -- the env var did not survive the `changesets -> pnpm publish` chain.

This applies the durable fix from the issue: set `"publishConfig": { "provenance": true }` in both SDK packages. It is tool-agnostic (no env plumbing), so provenance attaches on the next publish regardless of how `pnpm publish` is invoked. The release workflow's visibility-gated `NPM_CONFIG_PROVENANCE` is left in place as belt and braces.

### Changes
- `packages/client/package.json`, `packages/react/package.json`: add `provenance: true` to the existing `publishConfig`.
- Changeset: patch-bumps both packages so the fix reaches npm on the next release (verify `dist.attestations` exists afterward).

### Verification
- `pnpm install --frozen-lockfile`, `pnpm lint` (biome), `pnpm --filter "./packages/*" build`, and typecheck + vitest for `@chimely/client` + `@chimely/react` all pass (159 tests).
- No code, API surface, or generated artifacts touched; the Rust, license, and docker CI jobs are unaffected.
