### PR TITLE
feat(react): first-class notification severity

### DIFF
--- a/.changeset/notification-severity.md
+++ b/.changeset/notification-severity.md
@@ -1,0 +1,6 @@
+---
+"@chimely/client": minor
+"@chimely/react": minor
+---
+
+First-class notification severity (frontend slice). `WellKnownPayload` gains an optional `severity: 'high' | 'medium' | 'low'`, and the default item renders a left accent tinted by the new `colorSeverityHigh` / `colorSeverityMedium` / `colorSeverityLow` appearance variables. Any other value renders no accent. Tabs can already filter on `severity` via their `filter` predicate.

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -30,6 +30,12 @@ export interface WellKnownPayload {
   action_url?: string;
   /** Leading icon/avatar in the default rendering. */
   icon_url?: string;
+  /**
+   * Relative importance. The default item shows a matching severity accent
+   * tinted by the `colorSeverity*` appearance variables. Any other value
+   * renders no accent.
+   */
+  severity?: 'high' | 'medium' | 'low';
   [custom: string]: unknown;
 }
 

--- a/packages/react/src/appearance.ts
+++ b/packages/react/src/appearance.ts
@@ -43,6 +43,12 @@ export interface InboxAppearance {
     colorBadgeForeground?: string;
     /** Popover and pill box-shadow. Default 0 8px 24px rgba(0, 0, 0, 0.12). */
     shadow?: string;
+    /** Accent on `severity: 'high'` items. Default #dc2626. */
+    colorSeverityHigh?: string;
+    /** Accent on `severity: 'medium'` items. Default #d97706. */
+    colorSeverityMedium?: string;
+    /** Accent on `severity: 'low'` items. Default #2563eb. */
+    colorSeverityLow?: string;
     /** Extension point: forwarded as `--chimely-<key>` verbatim. */
     [customProperty: string]: string | undefined;
   };

--- a/packages/react/src/components/DefaultItem.tsx
+++ b/packages/react/src/components/DefaultItem.tsx
@@ -25,8 +25,19 @@ export function DefaultItem<TPayload>(
 ): ReactNode {
   const { item, className, style, formatTimestamp, onClick } = props;
   const payload = item.payload as Partial<WellKnownPayload>;
+  // Payloads pass through verbatim, so guard against values outside the union.
+  const severity =
+    payload.severity === 'high' || payload.severity === 'medium' || payload.severity === 'low'
+      ? payload.severity
+      : undefined;
   return (
     <button type="button" className={className} style={style} onClick={onClick}>
+      {severity && (
+        <span
+          className={`chimely-item-severity chimely-item-severity-${severity}`}
+          aria-hidden="true"
+        />
+      )}
       {props.renderAvatar
         ? props.renderAvatar({ item })
         : typeof payload.icon_url === 'string' &&

--- a/packages/react/src/inbox.test.tsx
+++ b/packages/react/src/inbox.test.tsx
@@ -848,3 +848,36 @@ describe('standalone mode', () => {
     expect(stub.stream().closed).toBe(true);
   });
 });
+
+describe('severity accent', () => {
+  test('renders a tinted accent for a known severity', async () => {
+    const stub = createStubServer();
+    stub.addNotification({ payload: { title: 'urgent', severity: 'high' } });
+    await renderInbox(stub);
+    fireEvent.click(bell());
+
+    const accent = document.querySelector('.chimely-item-severity');
+    expect(accent).not.toBeNull();
+    expect(accent?.classList.contains('chimely-item-severity-high')).toBe(true);
+    // Decorative only: the count already rides the item text.
+    expect(accent?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  test('renders no accent without a severity', async () => {
+    const stub = createStubServer();
+    stub.addNotification({ payload: { title: 'routine' } });
+    await renderInbox(stub);
+    fireEvent.click(bell());
+
+    expect(document.querySelector('.chimely-item-severity')).toBeNull();
+  });
+
+  test('ignores a severity outside the known set', async () => {
+    const stub = createStubServer();
+    stub.addNotification({ payload: { title: 'weird', severity: 'critical' } });
+    await renderInbox(stub);
+    fireEvent.click(bell());
+
+    expect(document.querySelector('.chimely-item-severity')).toBeNull();
+  });
+});

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -253,6 +253,7 @@ export const INBOX_CSS = `
   background: var(--chimely-colorMuted, #f3f4f6);
 }
 .chimely-item {
+  position: relative;
   display: flex;
   align-items: flex-start;
   gap: 10px;
@@ -303,6 +304,22 @@ export const INBOX_CSS = `
   border-radius: 50%;
   background: var(--chimely-colorPrimary, #1264FF);
   flex: none;
+}
+.chimely-item-severity {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 3px;
+}
+.chimely-item-severity-high {
+  background: var(--chimely-colorSeverityHigh, #dc2626);
+}
+.chimely-item-severity-medium {
+  background: var(--chimely-colorSeverityMedium, #d97706);
+}
+.chimely-item-severity-low {
+  background: var(--chimely-colorSeverityLow, #2563eb);
 }
 .chimely-empty {
   padding: 32px 16px;


### PR DESCRIPTION
Closes #36.

Frontend slice of first-class notification severity.

### What
- **`@chimely/client`**: `WellKnownPayload` gains an optional `severity: 'high' | 'medium' | 'low'` -- additive, in keeping with its "only ever gains optional fields" contract.
- **`@chimely/react`**: the default item renders a left accent bar tinted by three new appearance variables -- `colorSeverityHigh` (`#dc2626`), `colorSeverityMedium` (`#d97706`), `colorSeverityLow` (`#2563eb`). The accent is decorative (`aria-hidden`); the value already rides the item text.
- Payloads pass through Chimely verbatim, so any value outside the union renders no accent.
- Tabs can already filter on `severity` via their `filter` predicate, per the issue.

### Deferred (as the issue frames it)
- **Bell tinting by highest unread severity** and **severity-filterable server counts** need the server-side counts work first (#39), so they are out of this slice.
- No server change -- payloads pass through verbatim.

### Verification
`biome`, `pnpm --filter "./packages/*" build`, typecheck, and vitest are all green: **`@chimely/client` 54 tests and `@chimely/react` 108 tests**, including 3 new ones (known-severity accent, no accent without severity, and an out-of-set value rendering nothing). A minor changeset covers both packages.
