### PR TITLE
feat(react): group, sort, and filter preference rows

### DIFF
--- a/.changeset/preferences-grouping.md
+++ b/.changeset/preferences-grouping.md
@@ -1,0 +1,5 @@
+---
+"@chimely/react": minor
+---
+
+Preferences panel grouping, sorting, and filtering (frontend-only). `<Preferences>` and `<Inbox>` gain `preferencesFilter` (show a subset of categories), `preferencesSort` (order the rows, default alphabetical), and `preferenceGroups` (render rows under labeled headings, with ungrouped categories following in sorted order). The `PreferenceGroup` type is exported. Default rendering is unchanged.

--- a/packages/react/src/Inbox.tsx
+++ b/packages/react/src/Inbox.tsx
@@ -213,6 +213,9 @@ function InboxView<TPayload>(props: InboxProps<TPayload>): ReactNode {
         localization={props.localization}
         titleId={titleId}
         preferencesPanel={props.preferencesPanel}
+        preferencesFilter={props.preferencesFilter}
+        preferencesSort={props.preferencesSort}
+        preferenceGroups={props.preferenceGroups}
         onItemClick={props.onItemClick}
         routerPush={props.routerPush}
         renderItem={props.renderItem}

--- a/packages/react/src/components/InboxContent.tsx
+++ b/packages/react/src/components/InboxContent.tsx
@@ -11,7 +11,7 @@ import { ensureStyles } from '../styles';
 import type { ItemRenderProps } from './DefaultItem';
 import { GearIcon } from './icons';
 import { NotificationList } from './NotificationList';
-import { Preferences } from './Preferences';
+import { type PreferenceGroup, Preferences } from './Preferences';
 
 /**
  * One tab of the inbox list. The filter runs client-side over loaded items.
@@ -56,6 +56,12 @@ export interface InboxContentProps<TPayload = WellKnownPayload> extends ItemRend
   renderItem?: (ctx: { item: InboxItem<TPayload>; markRead: () => Promise<void> }) => ReactNode;
   renderEmpty?: () => ReactNode;
   renderFooter?: () => ReactNode;
+  /** Show only preference categories for which this returns true. */
+  preferencesFilter?: (category: string) => boolean;
+  /** Order the preference category rows. Default: alphabetical. */
+  preferencesSort?: (a: string, b: string) => number;
+  /** Group preference category rows under labeled headings. */
+  preferenceGroups?: ReadonlyArray<PreferenceGroup>;
 }
 
 export function InboxContent<TPayload = WellKnownPayload>(
@@ -334,7 +340,13 @@ export function InboxContent<TPayload = WellKnownPayload>(
         </div>
       )}
       {showPreferences ? (
-        <Preferences appearance={props.appearance} localization={props.localization} />
+        <Preferences
+          appearance={props.appearance}
+          localization={props.localization}
+          preferencesFilter={props.preferencesFilter}
+          preferencesSort={props.preferencesSort}
+          preferenceGroups={props.preferenceGroups}
+        />
       ) : (
         <NotificationList
           // Remount on tab switch: resets scroll and the sentinel fill loop.

--- a/packages/react/src/components/Preferences.tsx
+++ b/packages/react/src/components/Preferences.tsx
@@ -7,6 +7,14 @@ import type { InboxLocalization } from '../localization';
 import { mergeLocalization } from '../localization';
 import { ensureStyles } from '../styles';
 
+/** A labeled group of preference category rows. */
+export interface PreferenceGroup {
+  /** Heading shown above the group's rows. */
+  label: string;
+  /** Category keys in this group, in display order. */
+  categories: ReadonlyArray<string>;
+}
+
 /**
  * Standalone per-category in_app preference toggles, for settings pages and
  * custom popovers. Reads the client from the enclosing ChimelyProvider.
@@ -15,12 +23,22 @@ import { ensureStyles } from '../styles';
 export interface PreferencesProps {
   appearance?: InboxAppearance;
   localization?: Partial<InboxLocalization>;
+  /** Show only categories for which this returns true. Default: all shown. */
+  preferencesFilter?: (category: string) => boolean;
+  /** Order the category rows. Default: alphabetical by category key. */
+  preferencesSort?: (a: string, b: string) => number;
+  /**
+   * Group category rows under labeled headings, in the given order. Categories
+   * absent from every group render after the groups in the sorted order.
+   */
+  preferenceGroups?: ReadonlyArray<PreferenceGroup>;
 }
 
 export function Preferences(props: PreferencesProps): ReactNode {
   const { items } = useNotifications();
   const preferences = usePreferences();
   const strings = mergeLocalization(props.localization);
+  const { preferencesFilter, preferencesSort, preferenceGroups } = props;
 
   useEffect(() => {
     ensureStyles();
@@ -37,30 +55,55 @@ export function Preferences(props: PreferencesProps): ReactNode {
     return [...set].sort();
   }, [items, preferences.preferences]);
 
+  // Filter then sort. Default order is the alphabetical `categories` above.
+  const visible = useMemo(() => {
+    const filtered = preferencesFilter ? categories.filter(preferencesFilter) : categories;
+    return preferencesSort ? [...filtered].sort(preferencesSort) : filtered;
+  }, [categories, preferencesFilter, preferencesSort]);
+
   const isEnabled = (category: string): boolean =>
     !preferences.preferences.some(
       (row) => row.category === category && row.channel === 'in_app' && !row.enabled,
     );
+
+  const renderRow = (category: string): ReactNode => (
+    <label key={category} className="chimely-preference">
+      <span>{strings.categoryLabels[category] ?? category}</span>
+      <input
+        type="checkbox"
+        checked={isEnabled(category)}
+        onChange={(event) => {
+          void preferences.setPreferences([
+            { category, channel: 'in_app', enabled: event.target.checked },
+          ]);
+        }}
+      />
+    </label>
+  );
+
+  const visibleSet = new Set(visible);
+  const groups = preferenceGroups ?? [];
+  const grouped = new Set(groups.flatMap((group) => group.categories));
+  const ungrouped = visible.filter((category) => !grouped.has(category));
 
   return (
     <div
       className={slotClass(props.appearance?.classNames, 'preferences')}
       style={variablesToStyle(props.appearance?.variables)}
     >
-      {categories.map((category) => (
-        <label key={category} className="chimely-preference">
-          <span>{strings.categoryLabels[category] ?? category}</span>
-          <input
-            type="checkbox"
-            checked={isEnabled(category)}
-            onChange={(event) => {
-              void preferences.setPreferences([
-                { category, channel: 'in_app', enabled: event.target.checked },
-              ]);
-            }}
-          />
-        </label>
-      ))}
+      {groups.map((group) => {
+        const rows = group.categories.filter((category) => visibleSet.has(category));
+        if (rows.length === 0) {
+          return null;
+        }
+        return (
+          <div key={group.label} className="chimely-preference-group">
+            <div className="chimely-preference-group-label">{group.label}</div>
+            {rows.map(renderRow)}
+          </div>
+        );
+      })}
+      {ungrouped.map(renderRow)}
     </div>
   );
 }

--- a/packages/react/src/components/Preferences.tsx
+++ b/packages/react/src/components/Preferences.tsx
@@ -86,13 +86,23 @@ export function Preferences(props: PreferencesProps): ReactNode {
   const grouped = new Set(groups.flatMap((group) => group.categories));
   const ungrouped = visible.filter((category) => !grouped.has(category));
 
+  // A category renders at most once. The first group that lists it wins, so
+  // overlapping groups cannot produce two checkboxes writing one preference.
+  const claimed = new Set<string>();
+
   return (
     <div
       className={slotClass(props.appearance?.classNames, 'preferences')}
       style={variablesToStyle(props.appearance?.variables)}
     >
       {groups.map((group) => {
-        const rows = group.categories.filter((category) => visibleSet.has(category));
+        const rows = group.categories.filter((category) => {
+          if (!visibleSet.has(category) || claimed.has(category)) {
+            return false;
+          }
+          claimed.add(category);
+          return true;
+        });
         if (rows.length === 0) {
           return null;
         }

--- a/packages/react/src/composition.test.tsx
+++ b/packages/react/src/composition.test.tsx
@@ -154,6 +154,23 @@ describe('preferences grouping', () => {
     expect(rowLabels()).toEqual(['billing.invoice', 'security.alert', 'social.mention']);
   });
 
+  test('a category listed in two groups renders once, first group wins', async () => {
+    const stub = createStubServer();
+    stub.addNotification({ category: 'billing.invoice' });
+    await provided(stub, () => (
+      <Preferences
+        preferenceGroups={[
+          { label: 'Money', categories: ['billing.invoice'] },
+          { label: 'Everything', categories: ['billing.invoice'] },
+        ]}
+      />
+    ));
+    expect(screen.getByText('Money')).toBeDefined();
+    expect(screen.queryByText('Everything')).toBeNull();
+    expect(rowLabels()).toEqual(['billing.invoice']);
+    expect(screen.getAllByRole('checkbox')).toHaveLength(1);
+  });
+
   test('a group with no visible category renders no heading', async () => {
     const stub = createStubServer();
     stub.addNotification({ category: 'social.mention' });

--- a/packages/react/src/composition.test.tsx
+++ b/packages/react/src/composition.test.tsx
@@ -119,6 +119,62 @@ describe('standalone Preferences', () => {
   });
 });
 
+describe('preferences grouping', () => {
+  const rowLabels = (): Array<string | null> =>
+    [...document.querySelectorAll('.chimely-preference span')].map((el) => el.textContent);
+
+  test('preferencesFilter limits the shown categories', async () => {
+    const stub = createStubServer();
+    stub.addNotification({ category: 'billing.invoice' });
+    stub.addNotification({ category: 'security.alert' });
+    await provided(stub, () => (
+      <Preferences preferencesFilter={(category) => category.startsWith('billing')} />
+    ));
+    expect(rowLabels()).toEqual(['billing.invoice']);
+  });
+
+  test('preferencesSort orders the category rows', async () => {
+    const stub = createStubServer();
+    stub.addNotification({ category: 'a.one' });
+    stub.addNotification({ category: 'b.two' });
+    await provided(stub, () => <Preferences preferencesSort={(a, b) => b.localeCompare(a)} />);
+    expect(rowLabels()).toEqual(['b.two', 'a.one']);
+  });
+
+  test('preferenceGroups renders labeled groups with an ungrouped tail', async () => {
+    const stub = createStubServer();
+    stub.addNotification({ category: 'billing.invoice' });
+    stub.addNotification({ category: 'security.alert' });
+    stub.addNotification({ category: 'social.mention' });
+    await provided(stub, () => (
+      <Preferences preferenceGroups={[{ label: 'Money', categories: ['billing.invoice'] }]} />
+    ));
+    expect(screen.getByText('Money')).toBeDefined();
+    // Grouped first (group order), then the ungrouped tail (sorted).
+    expect(rowLabels()).toEqual(['billing.invoice', 'security.alert', 'social.mention']);
+  });
+
+  test('a group with no visible category renders no heading', async () => {
+    const stub = createStubServer();
+    stub.addNotification({ category: 'social.mention' });
+    await provided(stub, () => (
+      <Preferences preferenceGroups={[{ label: 'Money', categories: ['billing.invoice'] }]} />
+    ));
+    expect(screen.queryByText('Money')).toBeNull();
+    expect(rowLabels()).toEqual(['social.mention']);
+  });
+
+  test('the props thread through <Inbox> to the panel', async () => {
+    const stub = createStubServer();
+    stub.addNotification({ category: 'billing.invoice' });
+    await renderInbox(stub, {
+      preferenceGroups: [{ label: 'Money', categories: ['billing.invoice'] }],
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Notification preferences' }));
+    expect(screen.getByText('Money')).toBeDefined();
+  });
+});
+
 describe('granular render props', () => {
   test('renderSubject replaces only the subject', async () => {
     const assign = vi.spyOn(navigation, 'assign').mockImplementation(() => {});

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -14,7 +14,7 @@ export type { BellProps } from './components/Bell';
 export { Bell } from './components/Bell';
 export type { InboxContentProps, InboxTab } from './components/InboxContent';
 export { InboxContent } from './components/InboxContent';
-export type { PreferencesProps } from './components/Preferences';
+export type { PreferenceGroup, PreferencesProps } from './components/Preferences';
 export { Preferences } from './components/Preferences';
 export type { ChimelyProviderProps } from './context';
 export { ChimelyProvider, useChimelyClient } from './context';

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -339,6 +339,14 @@ export const INBOX_CSS = `
 .chimely-preference input {
   accent-color: var(--chimely-colorPrimary, #1264FF);
 }
+.chimely-preference-group-label {
+  padding: 12px 14px 4px;
+  font-size: 0.8em;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.55;
+}
 `;
 
 let injected = false;


### PR DESCRIPTION
Frontend-only slice of #38 -- the grouping / sorting / filtering the issue calls out as shippable against current data. The other three items (critical categories, global per-channel toggle, categories endpoint) are the server half, so this intentionally does **not** close #38.

### What
`<Preferences>` and `<Inbox>` gain three optional props:
- `preferencesFilter?: (category: string) => boolean` -- show only a subset of categories.
- `preferencesSort?: (a: string, b: string) => number` -- order the rows (default: alphabetical, unchanged).
- `preferenceGroups?: PreferenceGroup[]` -- render rows under labeled headings; categories in no group follow in sorted order, and an empty group renders no heading.

`PreferenceGroup` (`{ label, categories }`) is exported. It works against the panel's existing category source (loaded items + explicit preference rows), so there is no server change. Default rendering with no props is unchanged.

### Verification
`biome`, `pnpm --filter "./packages/*" build`, typecheck, and vitest are all green -- **110 react tests**, including 5 new ones: filter, sort, groups + ungrouped tail, empty-group heading suppression, and the props threading through `<Inbox>` to the panel. A minor changeset covers `@chimely/react`.

I kept this to the frontend-only slice deliberately. Happy to add a `Closes #38` (or open follow-up issues for the server items) if you'd prefer -- your call on how to track the remainder.
