### PR TITLE
fix(server): static 400s and identifier scrub

### DIFF
--- a/docs/content/docs/self-hosting.mdx
+++ b/docs/content/docs/self-hosting.mdx
@@ -90,6 +90,7 @@ Every knob is an environment variable with a production default. Only
 | `CHIMELY_ADMIN_TLS_TERMINATED` | `false` | Set `true` when TLS terminates upstream |
 | `CHIMELY_SHUTDOWN_GRACE_MS` | `5000` | `/readyz` 503 window before the listener closes |
 | `CHIMELY_SHUTDOWN_DRAIN_DEADLINE_MS` | `30000` | In-flight job drain budget |
+| `CHIMELY_LOG_SCRUB_IDENTIFIERS` | `false` | Redact subscriber/environment identifiers from access logs and traces (`subscriber_hash` is always redacted) |
 
 <Callout type="warn" title="Dev-only">
 `CHIMELY_DEV_ENVIRONMENT` and `CHIMELY_DEV_API_KEY` seed a quickstart

--- a/server/src/api/preferences.rs
+++ b/server/src/api/preferences.rs
@@ -229,10 +229,9 @@ pub async fn write(
             return Err(ApiError::bad_request("category must be 1–255 characters"));
         }
         if !ALLOWED_CHANNELS.contains(&p.channel.as_str()) {
-            return Err(ApiError::bad_request(format!(
-                "unknown channel: {}",
-                p.channel
-            )));
+            // Static message. Echoing the caller's channel value would
+            // reflect unvalidated input into the response body.
+            return Err(ApiError::bad_request("channel must be one of: in_app"));
         }
     }
 

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -78,6 +78,12 @@ pub struct Config {
     /// In-flight job drain budget after claiming stops. Past it the worker
     /// is aborted. At-least-once semantics make the rollback safe.
     pub shutdown_drain_deadline: Duration,
+    /// Redacts subscriber and environment identifiers from the access log
+    /// and the http.request span. subscriber_hash is a credential and is
+    /// always scrubbed regardless. This flag additionally covers the
+    /// subscriber_id and environment query params and the subscriber path
+    /// segment, for operators whose logs leave their control.
+    pub log_scrub_identifiers: bool,
 }
 
 /// Manual impl so credentials can never reach logs through `{:?}`.
@@ -130,6 +136,7 @@ impl std::fmt::Debug for Config {
             .field("subscriber_rate_burst", &self.subscriber_rate_burst)
             .field("shutdown_readiness_grace", &self.shutdown_readiness_grace)
             .field("shutdown_drain_deadline", &self.shutdown_drain_deadline)
+            .field("log_scrub_identifiers", &self.log_scrub_identifiers)
             .finish()
     }
 }
@@ -197,6 +204,7 @@ impl Config {
                 "CHIMELY_SHUTDOWN_DRAIN_DEADLINE_MS",
                 30_000,
             )?),
+            log_scrub_identifiers: parse_var("CHIMELY_LOG_SCRUB_IDENTIFIERS", false)?,
         })
     }
 }
@@ -249,6 +257,7 @@ mod tests {
             subscriber_rate_burst: 0.0,
             shutdown_readiness_grace: Duration::from_millis(1),
             shutdown_drain_deadline: Duration::from_millis(1),
+            log_scrub_identifiers: false,
         };
         let out = format!("{cfg:?}");
         assert!(

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -101,6 +101,11 @@ impl IntoResponse for ApiError {
 
 /// Internal failures (database, serialization) become opaque 500s. The detail
 /// goes to tracing, never to the client.
+///
+/// The logged error can embed Postgres DETAIL values on a unique violation
+/// (`Key (...)=(<values>)`). Any new plain INSERT on a secret-keyed or
+/// PII-keyed table must intercept the conflict before its error reaches this
+/// path or any `tracing::error!(error = ?err)` site.
 impl<E> From<E> for ApiError
 where
     E: Into<anyhow::Error>,

--- a/server/src/extract.rs
+++ b/server/src/extract.rs
@@ -4,12 +4,28 @@
 //! plain-text 400/415/422 bodies. The contract allows exactly one error
 //! shape (`{"error": {"code", "message"}}`) and no 415/422, so every handler
 //! extracts through these wrappers instead.
+//!
+//! Rejection messages are static. axum/serde rejection prose quotes
+//! caller-supplied scalars on a type mismatch, so it never reaches the
+//! response body.
 
+use axum::extract::rejection::JsonRejection;
 use axum::extract::{FromRequest, FromRequestParts, OptionalFromRequest, Request};
 use axum::http::request::Parts;
 use serde::de::DeserializeOwned;
 
 use crate::error::ApiError;
+
+/// `body_text()` embeds the serde error, which quotes a caller-supplied
+/// scalar on a type mismatch. Each rejection class maps to a fixed message.
+fn json_rejection_message(rejection: &JsonRejection) -> &'static str {
+    match rejection {
+        JsonRejection::JsonSyntaxError(_) => "request body is not valid JSON",
+        JsonRejection::JsonDataError(_) => "request body does not match the expected schema",
+        JsonRejection::MissingJsonContentType(_) => "expected content-type: application/json",
+        _ => "invalid request body",
+    }
+}
 
 pub struct ApiJson<T>(pub T);
 
@@ -23,7 +39,7 @@ where
     async fn from_request(req: Request, state: &S) -> Result<Self, ApiError> {
         match <axum::Json<T> as FromRequest<S>>::from_request(req, state).await {
             Ok(axum::Json(value)) => Ok(Self(value)),
-            Err(rejection) => Err(ApiError::bad_request(rejection.body_text())),
+            Err(rejection) => Err(ApiError::bad_request(json_rejection_message(&rejection))),
         }
     }
 }
@@ -39,7 +55,7 @@ where
         match <axum::Json<T> as OptionalFromRequest<S>>::from_request(req, state).await {
             Ok(Some(axum::Json(value))) => Ok(Some(Self(value))),
             Ok(None) => Ok(None),
-            Err(rejection) => Err(ApiError::bad_request(rejection.body_text())),
+            Err(rejection) => Err(ApiError::bad_request(json_rejection_message(&rejection))),
         }
     }
 }
@@ -56,7 +72,9 @@ where
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, ApiError> {
         match axum::extract::Query::<T>::from_request_parts(parts, state).await {
             Ok(axum::extract::Query(value)) => Ok(Self(value)),
-            Err(rejection) => Err(ApiError::bad_request(rejection.body_text())),
+            Err(_) => Err(ApiError::bad_request(
+                "query string does not match the expected parameters",
+            )),
         }
     }
 }

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -120,7 +120,10 @@ pub fn router(state: AppState) -> Router {
             get(move || std::future::ready(prometheus.render())),
         )
         .merge(utoipa_scalar::Scalar::with_url("/docs", openapi::api_doc()))
-        .layer(middleware::from_fn(access_log))
+        .layer(middleware::from_fn({
+            let scrub_identifiers = state.cfg.log_scrub_identifiers;
+            move |req, next| access_log(scrub_identifiers, req, next)
+        }))
         .with_state(state)
 }
 
@@ -244,18 +247,28 @@ async fn readyz(
 /// credential on the SSE endpoint (EventSource cannot set headers) and must
 /// never reach log lines. This is a tested invariant.
 ///
+/// With `scrub_identifiers` set, subscriber and environment identifiers are
+/// redacted too, from the query string and from the subscriber path segment.
+/// The scrubbed path also names the `http.request` span, so identifiers stay
+/// out of exported traces.
+///
 /// The handler runs inside an `http.request` span: jobs enqueued by the
 /// handler carry this span's context through the outbox, so the whole
 /// ingest -> outbox -> worker -> hint flow lands in one trace.
 async fn access_log(
+    scrub_identifiers: bool,
     req: axum::extract::Request,
     next: middleware::Next,
 ) -> axum::response::Response {
     use tracing::Instrument as _;
 
     let method = req.method().clone();
-    let path = req.uri().path().to_owned();
-    let query = req.uri().query().map(scrub_query);
+    let path = if scrub_identifiers {
+        scrub_path(req.uri().path())
+    } else {
+        req.uri().path().to_owned()
+    };
+    let query = req.uri().query().map(|q| scrub_query(q, scrub_identifiers));
     let started = std::time::Instant::now();
     let span = tracing::info_span!("http.request", %method, %path);
     let response = next.run(req).instrument(span).await;
@@ -276,10 +289,18 @@ async fn access_log(
 /// valid credential and must scrub the same way) and the output is
 /// re-encoded, so a credential value can never smuggle raw bytes into a log
 /// line.
-pub fn scrub_query(query: &str) -> String {
+///
+/// `scrub_identifiers` additionally redacts `subscriber_id` and
+/// `environment`. Those are identifiers, not credentials. The opt-in exists
+/// for operators whose logs leave their control.
+pub fn scrub_query(query: &str, scrub_identifiers: bool) -> String {
     form_urlencoded::parse(query.as_bytes())
         .map(|(name, value)| {
-            let value = if name.eq_ignore_ascii_case("subscriber_hash") {
+            let credential = name.eq_ignore_ascii_case("subscriber_hash");
+            let identifier = scrub_identifiers
+                && (name.eq_ignore_ascii_case("subscriber_id")
+                    || name.eq_ignore_ascii_case("environment"));
+            let value = if credential || identifier {
                 std::borrow::Cow::Borrowed("redacted")
             } else {
                 value
@@ -294,6 +315,25 @@ pub fn scrub_query(query: &str) -> String {
         .join("&")
 }
 
+/// Replaces the path segment after a `subscribers` segment with a fixed
+/// marker. The external subscriber id is customer-chosen and can be an email
+/// or an internal user id. Covers the management routes
+/// `/v1/subscribers/{id}` and `/v1/subscribers/{id}/preferences` and the
+/// admin subscriber lookup.
+fn scrub_path(path: &str) -> String {
+    let mut redact_next = false;
+    path.split('/')
+        .map(|segment| {
+            if std::mem::replace(&mut redact_next, segment == "subscribers") {
+                "redacted"
+            } else {
+                segment
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -301,24 +341,65 @@ mod tests {
     #[test]
     fn scrubs_subscriber_hash_wherever_it_appears() {
         assert_eq!(
-            scrub_query("environment=acme&subscriber_id=u1&subscriber_hash=deadbeef"),
+            scrub_query(
+                "environment=acme&subscriber_id=u1&subscriber_hash=deadbeef",
+                false
+            ),
             "environment=acme&subscriber_id=u1&subscriber_hash=redacted"
         );
-        assert_eq!(scrub_query("subscriber_hash=x"), "subscriber_hash=redacted");
         assert_eq!(
-            scrub_query("SUBSCRIBER_HASH=x&a=b"),
+            scrub_query("subscriber_hash=x", false),
+            "subscriber_hash=redacted"
+        );
+        assert_eq!(
+            scrub_query("SUBSCRIBER_HASH=x&a=b", false),
             "SUBSCRIBER_HASH=redacted&a=b"
         );
         // Percent-encoded names decode before matching: auth accepts
         // `subscriber%5Fhash`, so the scrub must catch it too.
         assert_eq!(
-            scrub_query("subscriber%5Fhash=deadbeef"),
+            scrub_query("subscriber%5Fhash=deadbeef", false),
             "subscriber_hash=redacted"
         );
         assert_eq!(
-            scrub_query("%73ubscriber_hash=deadbeef&a=b"),
+            scrub_query("%73ubscriber_hash=deadbeef&a=b", false),
             "subscriber_hash=redacted&a=b"
         );
-        assert_eq!(scrub_query("a=b"), "a=b");
+        assert_eq!(scrub_query("a=b", false), "a=b");
+    }
+
+    #[test]
+    fn identifier_scrubbing_is_opt_in() {
+        assert_eq!(
+            scrub_query("environment=acme&subscriber_id=u1&subscriber_hash=x", true),
+            "environment=redacted&subscriber_id=redacted&subscriber_hash=redacted"
+        );
+        assert_eq!(
+            scrub_query("SUBSCRIBER_ID=u1&Environment=acme", true),
+            "SUBSCRIBER_ID=redacted&Environment=redacted"
+        );
+        assert_eq!(
+            scrub_query("subscriber%5Fid=u1", true),
+            "subscriber_id=redacted"
+        );
+        assert_eq!(scrub_query("a=b", true), "a=b");
+    }
+
+    #[test]
+    fn scrub_path_redacts_the_subscriber_segment() {
+        assert_eq!(
+            scrub_path("/v1/subscribers/user-42"),
+            "/v1/subscribers/redacted"
+        );
+        assert_eq!(
+            scrub_path("/v1/subscribers/user-42/preferences"),
+            "/v1/subscribers/redacted/preferences"
+        );
+        assert_eq!(
+            scrub_path("/admin/api/environments/0197abcd/subscribers/user-42"),
+            "/admin/api/environments/0197abcd/subscribers/redacted"
+        );
+        assert_eq!(scrub_path("/v1/inbox/items"), "/v1/inbox/items");
+        assert_eq!(scrub_path("/v1/subscribers"), "/v1/subscribers");
     }
 }

--- a/server/tests/chaos.rs
+++ b/server/tests/chaos.rs
@@ -527,6 +527,7 @@ async fn sustained_jobs_churn_stays_bounded_under_autovacuum() {
         subscriber_rate_burst: 0.0,
         shutdown_readiness_grace: Duration::from_millis(100),
         shutdown_drain_deadline: Duration::from_secs(5),
+        log_scrub_identifiers: false,
     };
     let cfg = std::sync::Arc::new(cfg);
     let pubsub = chimely::pubsub::build(None, &pool).await.unwrap();

--- a/server/tests/management.rs
+++ b/server/tests/management.rs
@@ -273,6 +273,72 @@ async fn malformed_bodies_get_the_error_envelope() {
     assert_eq!(body["error"]["code"], "invalid_request");
 }
 
+/// Rejection messages are static. serde rejection prose quotes a
+/// caller-supplied scalar on a type mismatch, so a canary token in the bad
+/// value must never surface in the 400 body.
+#[tokio::test]
+async fn rejection_messages_never_echo_caller_input() {
+    let app = support::spawn().await;
+
+    // Type mismatch inside the JSON body: subscriber_id expects a string.
+    let res = app
+        .mgmt_post(
+            "/v1/notifications",
+            json!({ "subscriber_id": ["CANARY-9f2"], "category": "x" }),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
+    let body: serde_json::Value = res.json().await.expect("envelope body");
+    let message = body["error"]["message"].as_str().unwrap();
+    assert!(
+        !message.contains("CANARY-9f2"),
+        "caller input echoed into the 400 body: {message}"
+    );
+    assert_eq!(message, "request body does not match the expected schema");
+
+    // Type mismatch in the query string.
+    let res = app
+        .client
+        .get(format!("{}/v1/inbox/items?limit=CANARY-9f2", app.base))
+        .headers(app.subscriber_headers("usr_canary"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
+    let body: serde_json::Value = res.json().await.expect("envelope body");
+    let message = body["error"]["message"].as_str().unwrap();
+    assert!(
+        !message.contains("CANARY-9f2"),
+        "caller input echoed into the 400 body: {message}"
+    );
+    assert_eq!(
+        message,
+        "query string does not match the expected parameters"
+    );
+
+    // Unknown preference channel: the value must not reflect back.
+    let res = app
+        .client
+        .put(format!("{}/v1/inbox/preferences", app.base))
+        .headers(app.subscriber_headers("usr_canary"))
+        .json(&json!({ "preferences": [
+            { "category": "billing", "channel": "CANARY-9f2", "enabled": false }
+        ] }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
+    let body: serde_json::Value = res.json().await.expect("envelope body");
+    let message = body["error"]["message"].as_str().unwrap();
+    assert!(
+        !message.contains("CANARY-9f2"),
+        "caller input echoed into the 400 body: {message}"
+    );
+    assert_eq!(message, "channel must be one of: in_app");
+}
+
 #[tokio::test]
 async fn management_plane_requires_a_valid_bearer_key() {
     let app = support::spawn().await;

--- a/server/tests/support/mod.rs
+++ b/server/tests/support/mod.rs
@@ -149,6 +149,9 @@ async fn spawn_inner(
         subscriber_rate_burst: 0.0,
         shutdown_readiness_grace: Duration::from_millis(150),
         shutdown_drain_deadline: Duration::from_secs(5),
+        // Off matches the production default. Tests that need the scrub
+        // opt in via spawn_configured.
+        log_scrub_identifiers: false,
     };
     configure(&mut cfg);
     let cfg = Arc::new(cfg);


### PR DESCRIPTION
Closes #58.

The three hardenable items from the launch log-hygiene audit.

### H4 -- 400 bodies no longer echo caller input
- `extract.rs`: the three rejection arms passed axum's `body_text()` into the envelope, and that prose quotes caller-supplied scalars on a type mismatch (serde `invalid type: string "..."`, unknown-variant/field names via serde_path_to_error). Rejections now map to static per-class messages: JSON syntax vs schema mismatch vs content-type vs query string, so callers keep enough signal to debug without any caller bytes reflecting back. The failing field name is deliberately not included -- axum only exposes composed prose, and the serde path segments can themselves be caller input (keys of the free-form `payload` object).
- `preferences.rs`: `unknown channel: {}` echoed the caller's channel value; now static (`channel must be one of: in_app`).
- New regression test `rejection_messages_never_echo_caller_input`: a `CANARY-9f2` token in a mismatched body field, a query param, and a channel value must never surface in the 400 body, and each arm's static message is pinned exactly. No existing test asserts the old prose (audited every message assertion in the suite -- the only message-text assertion anywhere is the admin login one, untouched).

### H3 -- opt-in identifier scrubbing for the access log
`CHIMELY_LOG_SCRUB_IDENTIFIERS` (default `false`, so default behavior is byte-identical). When set, `scrub_query` additionally redacts `subscriber_id` and `environment` values (same machinery as the hash scrub: case-insensitive, percent-decoded names, re-encoded output), and a new `scrub_path` redacts the segment after any `subscribers` segment, covering `/v1/subscribers/{id}`, `/v1/subscribers/{id}/preferences`, and the admin subscriber lookup. The scrubbed path is computed before the `http.request` span is created, so the redaction reaches exported traces too -- the issue names the span as a leak surface. `subscriber_hash` stays unconditionally scrubbed (the sse.rs invariant test keeps pinning it). The flag reaches the stateless middleware as a captured bool in `middleware::from_fn`; documented in the self-hosting env table.

Scope note: the `{env_id}` path segment on admin routes is not scrubbed -- it is an internal UUID, not the operator-facing slug the `environment=` query param carries.

### H2 -- rule recorded
The plain-INSERT conflict-interception rule is recorded as a doc comment at the generic `From<E> for ApiError` logging site, where a new violation would land.

### Verification
`cargo fmt --check` passes. Unit tests added for the query scrub (opt-in on/off, case-insensitivity, percent-decoded names) and the path scrub (all three route shapes plus edges). My environment cannot run clippy/nextest locally (no MSVC toolchain); flagging so a maintainer CI approval gets the full suite. No OpenAPI annotation changed, so no generated-artifact churn.
