### PR TITLE
feat(react): announce arrivals, document client sharing

### DIFF
--- a/.changeset/arrival-announcements.md
+++ b/.changeset/arrival-announcements.md
@@ -1,0 +1,5 @@
+---
+"@chimely/react": patch
+---
+
+New arrivals held behind the pill now announce through a visually hidden polite status region, so screen-reader users perceive the count change without moving focus. Docs gain a "one client per page" section: share one `ChimelyProvider` client across multiple inbox surfaces so each does not open its own SSE connection into the HTTP/1.1 per-origin cap.

--- a/docs/content/docs/sdk-reference.mdx
+++ b/docs/content/docs/sdk-reference.mdx
@@ -296,6 +296,29 @@ import { ChimelyProvider } from '@chimely/react';
 
 `useChimelyClient()` returns the client; it throws outside a provider.
 
+### One client per page
+
+Every standalone `<Inbox />` (connection props passed directly) owns its own
+client and therefore its own SSE connection. Browsers cap concurrent
+connections per origin on HTTP/1.1 at around six, so a page rendering several
+standalone inboxes (a bell in the header, another in a drawer, a full-page
+inbox) can starve the host app's own requests.
+
+Render one `ChimelyProvider` near the root instead and let every `<Inbox />`,
+`<Bell />`, and hook inside it share the provider's client — one SSE
+connection, one snapshot, no cap pressure:
+
+```tsx
+<ChimelyProvider config={{ serverUrl, environment, subscriberId, subscriberHash }}>
+  <Header>
+    <Inbox />       {/* no connection props: reads the shared client */}
+  </Header>
+  <Drawer>
+    <InboxContent />
+  </Drawer>
+</ChimelyProvider>
+```
+
 ## `@chimely/client`
 
 ```ts

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -40,6 +40,12 @@ For custom UIs, skip the popover and compose:
   `renderBell`, `renderFooter`) to replace one fragment while keeping the
   rest
 
+Pages rendering more than one inbox surface should share one client through
+a single `ChimelyProvider` near the root: each standalone `<Inbox />` opens
+its own SSE connection, and HTTP/1.1 browsers cap concurrent connections per
+origin at about six. See
+[One client per page](https://chimely.dev/docs/sdk-reference#one-client-per-page).
+
 ## Theming
 
 Plain CSS with custom properties. `appearance.variables` sets tokens

--- a/packages/react/src/components/NotificationList.tsx
+++ b/packages/react/src/components/NotificationList.tsx
@@ -184,6 +184,12 @@ export function NotificationList<TPayload>(props: NotificationListProps<TPayload
 
   return (
     <div className="chimely-list-container">
+      {/* Screen-reader announcement for arrivals held behind the pill. The
+          pill is a visual affordance only; a polite status region announces
+          the same text so the count change is perceivable without focus. */}
+      <span className="chimely-sr-only" role="status">
+        {pendingCount > 0 ? strings.newNotifications(pendingCount) : ''}
+      </span>
       {pendingCount > 0 && (
         <button
           type="button"

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -193,6 +193,17 @@ export const INBOX_CSS = `
   flex: 1;
   min-height: 0;
 }
+.chimely-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
 .chimely-pill {
   position: absolute;
   top: 8px;

--- a/packages/react/src/theming.test.tsx
+++ b/packages/react/src/theming.test.tsx
@@ -160,6 +160,33 @@ describe('new-notification pill', () => {
     expect(document.querySelector('.chimely-pill')).toBeNull();
   });
 
+  test('arrivals behind the pill announce via a polite status region', async () => {
+    const stub = createStubServer();
+    for (let i = 0; i < 6; i += 1) {
+      stub.addNotification();
+    }
+    await renderInbox(stub);
+    fireEvent.click(bell());
+
+    const status = screen.getByRole('status');
+    expect(status.classList.contains('chimely-sr-only')).toBe(true);
+    expect(status.textContent).toBe('');
+
+    const list = document.querySelector('.chimely-list') as HTMLElement;
+    list.scrollTop = 200;
+    stub.addNotification({ payload: { title: 'late arrival' } });
+    stub.emitHint();
+    await waitFor(() => {
+      expect(status.textContent).toBe('1 new notification');
+    });
+
+    // Dismissing the pill empties the region without a further announcement.
+    fireEvent.click(screen.getByRole('button', { name: '1 new notification' }));
+    await waitFor(() => {
+      expect(status.textContent).toBe('');
+    });
+  });
+
   test('prunes ids evicted by a non-contiguous reset', async () => {
     const stub = createStubServer();
     for (let i = 0; i < 3; i += 1) {


### PR DESCRIPTION
Completes the last two deferred items from #61 (follow-up to #72, which covers the other four):

- **aria-live for the new-arrival pill**: a visually hidden `role=status` region carries the same localized text as the pill, so screen-reader users perceive arrivals held behind it without moving focus. Emptied on dismiss. Deliberately scoped to the pill: always-on badge announcements would read every unseen tick during bursts, while the badge count already rides the bell's accessible name (announced on focus, per the audit note).
- **One client per page docs**: sdk-reference gains a section (plus a react README pointer) on sharing one `ChimelyProvider` client across multiple inbox surfaces, since each standalone `<Inbox />` opens its own SSE connection into the browser's ~6-per-origin HTTP/1.1 cap.

### Verification
biome, build, typecheck, vitest all green: **106 react tests**, including a new one pinning the status region (announces on arrival behind the pill, empties on dismiss). Patch changeset included.