### PR TITLE
docs: server-side hash recipe and Novu divergence guide

### DIFF
--- a/docs/content/docs/auth.mdx
+++ b/docs/content/docs/auth.mdx
@@ -67,6 +67,36 @@ hash client-side leaks it and lets anyone read any inbox. Sign on the server
 and send only the per-user hash to the frontend.
 </Callout>
 
+<Callout type="error" title="Never sign a client-supplied id">
+Derive the subscriber id server-side from the authenticated session. An
+endpoint that signs whatever id the request carries makes the HMAC scheme
+theater: the secret never leaks, but any authenticated user can ask your
+backend to mint a valid hash for any inbox and read it.
+</Callout>
+
+### A secure hash endpoint
+
+Authenticate the caller, resolve **their** subscriber id from your own session
+or database, and sign that. The id never comes from query, body, or headers:
+
+```ts
+import { createHmac } from 'node:crypto';
+
+// Express, behind your auth middleware
+app.get('/api/inbox-auth', requireLogin, (req, res) => {
+  // From the session your backend established, never from request input
+  const subscriberId = req.session.userId;
+  const subscriberHash = createHmac('sha256', process.env.CHIMELY_HMAC_SECRET!)
+    .update(subscriberId)
+    .digest('hex');
+  res.json({ subscriberId, subscriberHash });
+});
+```
+
+The frontend fetches both values and passes them to
+`<Inbox subscriberId={...} subscriberHash={...} />`. It cannot influence which
+inbox it is allowed to read.
+
 The hash travels in request headers (or query parameters for the SSE stream,
 where `EventSource` cannot set headers):
 

--- a/docs/content/docs/auth.mdx
+++ b/docs/content/docs/auth.mdx
@@ -82,9 +82,9 @@ or database, and sign that. The id never comes from query, body, or headers:
 ```ts
 import { createHmac } from 'node:crypto';
 
-// Express, behind your auth middleware
+// Express, behind auth middleware
 app.get('/api/inbox-auth', requireLogin, (req, res) => {
-  // From the session your backend established, never from request input
+  // Session-derived id, never request input
   const subscriberId = req.session.userId;
   const subscriberHash = createHmac('sha256', process.env.CHIMELY_HMAC_SECRET!)
     .update(subscriberId)

--- a/docs/content/docs/coming-from-novu.mdx
+++ b/docs/content/docs/coming-from-novu.mdx
@@ -1,6 +1,6 @@
 ---
 title: Coming from Novu
-description: What Chimely's <Inbox /> covers, and where it deliberately diverges.
+description: What Chimely's Inbox component covers, and where it deliberately diverges from Novu.
 ---
 
 Chimely's `<Inbox />` covers the component surface a Novu inbox integration

--- a/docs/content/docs/coming-from-novu.mdx
+++ b/docs/content/docs/coming-from-novu.mdx
@@ -49,8 +49,13 @@ them:
   for a keyless mode to skip: keys are minted in your own admin dashboard.
   The try-it-before-wiring-a-backend role is filled by the
   [quickstart](/docs/quickstart)'s `CHIMELY_DEV_*` variables, which seed a
-  dev environment with subscriber hashing off. Nothing is plan-gated: the
-  only limits are the [rate limits](/docs/operations#rate-limits) you
-  configure yourself, and a rate of `0` disables one. Workflow-editor
-  concepts have no equivalent at any tier; the payload your backend POSTs
-  is what the inbox shows.
+  dev environment with subscriber hashing off. Nothing is plan-gated: there
+  is no plan, quota, or tier mechanism. The limits that exist are
+  operational, not commercial: the
+  [rate limits](/docs/operations#rate-limits) you configure yourself (a rate
+  of `0` disables one), the per-subscriber
+  [SSE connection cap](/docs/self-hosting#real-time-sse), and fixed
+  per-request caps (payloads up to 16 KiB serialized, at most 100 recipients
+  per call; use a broadcast for more). Workflow-editor concepts have no
+  equivalent at any tier; the payload your backend POSTs is what the inbox
+  shows.

--- a/docs/content/docs/coming-from-novu.mdx
+++ b/docs/content/docs/coming-from-novu.mdx
@@ -16,7 +16,7 @@ them:
 
 | Novu feature | Why Chimely diverges |
 |---|---|
-| `context` / `contextHash` multi-tenancy scoping | Single-org is a design invariant. Environments are the isolation unit; multi-tenancy is another environment or another instance |
+| `context` / `contextHash` multi-tenancy scoping | Single-org is a design invariant. Environments isolate data, not tenants; admin users and roles are instance-wide, so multi-tenancy is "run another instance" |
 | WebSocket transport (`socketUrl`, `socketOptions`) | SSE-as-hint plus conditional REST refetch is the architecture; there is no socket to configure |
 | HTML in notifications (opt-in unsanitized rendering) | The default renderer is plain text by construction; a custom `renderItem` can already render anything it trusts |
 | Schedule / quiet hours | Novu's schedule gates email, SMS, and push, and always delivers in-app; with in-app as the only channel there is nothing to gate. Revisit when push lands |
@@ -24,14 +24,18 @@ them:
 
 ## What this means in practice
 
-- **Tenant scoping.** Where Novu scopes an inbox with `context` +
-  `contextHash`, Chimely scopes with the environment: point each tenant
-  surface at its own environment (or instance) and sign the subscriber hash
-  with that environment's secret. See [Auth & HMAC](/docs/auth).
+- **Tenant scoping.** There is no `context` / `contextHash` equivalent
+  inside one instance. Admin users and roles span every environment, so an
+  environment is not a tenant boundary: serving multiple tenants means
+  running one instance per tenant. Environments within an instance separate
+  stages (development, staging, production), each with its own HMAC secret.
+  See [Auth & HMAC](/docs/auth).
 - **Realtime.** There is no `socketUrl` equivalent. The client opens one SSE
   stream per client instance and treats events as hints to refetch over REST,
-  so a dropped or missed event is harmless. Nothing to configure beyond
-  `backoff`.
-- **Rich content.** Payloads are stored and rendered as plain text by
-  default. To render markup you trust, override `renderItem` (or
-  `renderSubject` / `renderBody`) and sanitize in your own code.
+  so a dropped or missed event is harmless. `<Inbox />` exposes `backoff`;
+  outside the browser, the headless client also takes a `createEventSource`
+  factory (polyfills, React Native, testing).
+- **Rich content.** Payload JSON is stored and passed through verbatim; the
+  default renderer treats the `title` and `body` strings as plain text. To
+  render markup you trust, override `renderItem` (or `renderSubject` /
+  `renderBody`) and sanitize in your own code.

--- a/docs/content/docs/coming-from-novu.mdx
+++ b/docs/content/docs/coming-from-novu.mdx
@@ -1,0 +1,37 @@
+---
+title: Coming from Novu
+description: What Chimely's <Inbox /> covers, and where it deliberately diverges.
+---
+
+Chimely's `<Inbox />` covers the component surface a Novu inbox integration
+relies on: tabs with per-tab counts, composable sub-components (`Bell`,
+`InboxContent`, `Preferences`), granular render props, portal positioning,
+controlled open, `routerPush`, appearance theming with a dark preset,
+localization, mark-as-unread, and archive. The [SDK
+reference](/docs/sdk-reference) documents the full prop surface.
+
+Some Novu features are missing **on purpose**. They are design decisions, not
+roadmap gaps, so plan your migration around them rather than waiting for
+them:
+
+| Novu feature | Why Chimely diverges |
+|---|---|
+| `context` / `contextHash` multi-tenancy scoping | Single-org is a design invariant. Environments are the isolation unit; multi-tenancy is another environment or another instance |
+| WebSocket transport (`socketUrl`, `socketOptions`) | SSE-as-hint plus conditional REST refetch is the architecture; there is no socket to configure |
+| HTML in notifications (opt-in unsanitized rendering) | The default renderer is plain text by construction; a custom `renderItem` can already render anything it trusts |
+| Schedule / quiet hours | Novu's schedule gates email, SMS, and push, and always delivers in-app; with in-app as the only channel there is nothing to gate. Revisit when push lands |
+| Keyless mode, plan-gated limits, workflow-editor concepts | Cloud-product features, not component features |
+
+## What this means in practice
+
+- **Tenant scoping.** Where Novu scopes an inbox with `context` +
+  `contextHash`, Chimely scopes with the environment: point each tenant
+  surface at its own environment (or instance) and sign the subscriber hash
+  with that environment's secret. See [Auth & HMAC](/docs/auth).
+- **Realtime.** There is no `socketUrl` equivalent. The client opens one SSE
+  stream per client instance and treats events as hints to refetch over REST,
+  so a dropped or missed event is harmless. Nothing to configure beyond
+  `backoff`.
+- **Rich content.** Payloads are stored and rendered as plain text by
+  default. To render markup you trust, override `renderItem` (or
+  `renderSubject` / `renderBody`) and sanitize in your own code.

--- a/docs/content/docs/coming-from-novu.mdx
+++ b/docs/content/docs/coming-from-novu.mdx
@@ -39,3 +39,18 @@ them:
   default renderer treats the `title` and `body` strings as plain text. To
   render markup you trust, override `renderItem` (or `renderSubject` /
   `renderBody`) and sanitize in your own code.
+- **Quiet hours.** There is no schedule to recreate. Novu's schedule gates
+  email, SMS, and push and always delivers in-app; in-app is Chimely's only
+  channel, so that always-deliver behavior is already the whole system. The
+  per-subscriber mute that does exist is per-category
+  [preferences](/docs/sdk-reference); preferences already carry a `channel`
+  field, so a future push channel gains gating without a contract break.
+- **Keyless mode.** There is no cloud signup to defer, so there is nothing
+  for a keyless mode to skip: keys are minted in your own admin dashboard.
+  The try-it-before-wiring-a-backend role is filled by the
+  [quickstart](/docs/quickstart)'s `CHIMELY_DEV_*` variables, which seed a
+  dev environment with subscriber hashing off. Nothing is plan-gated: the
+  only limits are the [rate limits](/docs/operations#rate-limits) you
+  configure yourself, and a rate of `0` disables one. Workflow-editor
+  concepts have no equivalent at any tier; the payload your backend POSTs
+  is what the inbox shows.

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -1,3 +1,11 @@
 {
-  "pages": ["index", "quickstart", "auth", "self-hosting", "operations", "sdk-reference"]
+  "pages": [
+    "index",
+    "quickstart",
+    "auth",
+    "self-hosting",
+    "operations",
+    "sdk-reference",
+    "coming-from-novu"
+  ]
 }


### PR DESCRIPTION
This PR closes the two remaining documentation gaps from the #34 parity audit. The HMAC auth docs showed how to compute the subscriber hash but never warned against signing a client-supplied id, so a naive endpoint turns the scheme into a confused deputy: the secret never leaks, yet any authenticated user can ask the backend to mint a valid hash for any inbox. Separately, the deliberate Novu divergences from Part 3 of the audit were undocumented, leaving migrators to mistake design decisions for roadmap gaps.

What changed:

- `docs/content/docs/auth.mdx`: a "Never sign a client-supplied id" callout plus a secure hash endpoint recipe. The example authenticates the caller, resolves the subscriber id from the server-side session, and signs that; the id never comes from query, body, or headers.
- `docs/content/docs/coming-from-novu.mdx` (new page, registered in `meta.json`): the Part-3 divergence table (context/contextHash multi-tenancy, WebSocket transport, HTML rendering, schedule/quiet hours, keyless/plan gating) with the reasoning for each, plus a section on what each divergence means for a migration. Every claim is backed by code on main.

Ordering notes for two open PRs that touch neighboring docs:

- #79 moves the HMAC formula in `auth.mdx` to the env-bound form. This PR documents the formula as it exists on main, so whichever merges second needs a one-line follow-up: the recipe's `.update(subscriberId)` line becomes the env-bound form after #79.
- #78 adds the one-client-per-page sharing section to `sdk-reference.mdx`; this PR intentionally does not duplicate it. A cross-link from the new page's realtime bullet can follow once #78 lands.

Addresses the remaining documentation gap from #34. That issue is an RFC meta-issue that also tracks child issues #35-#39, so closing it is the maintainers' call, not this PR's.
